### PR TITLE
adding start of mastcamz implementation with more documentation and

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 **/.mypy_cache/
 venv/
 
+.idea/
+.idea/*
 # These are local directories that hold data for experimentation
 data/
 bigdata/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/WISER.iml
+++ b/.idea/WISER.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="wiser" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="wiser" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="wiser" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/WISER.iml" filepath="$PROJECT_DIR$/.idea/WISER.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ altgraph==0.17
 astropy==4.0.1.post1
 bugsnag==3.7.1
 cycler==0.10.0
-GDAL==3.1.2
 kiwisolver==1.2.0
 macholib==1.14
 matplotlib==3.2.2
@@ -16,3 +15,4 @@ python-dateutil==2.8.1
 shiboken2==5.15.0
 six==1.15.0
 WebOb==1.8.6
+scipy=1.11.3

--- a/src/rasterui.py
+++ b/src/rasterui.py
@@ -4,8 +4,8 @@ from PySide2.QtCore import *
 from PySide2.QtGui import *
 from PySide2.QtWidgets import *
 
-from units import RED_WAVELENGTH, GREEN_WAVELENGTH, BLUE_WAVELENGTH
-from gui.rasterview import RasterView
+#from wiser.units import RED_WAVELENGTH, GREEN_WAVELENGTH, BLUE_WAVELENGTH
+from wiser.gui.rasterview import RasterView
 
 
 def find_band_near_wavelength(raster_data, wavelength, max_distance=None):
@@ -69,6 +69,6 @@ if __name__ == '__main__':
         print('This program takes one optional argument, the name of a raster data file.')
         sys.exit(1)
 
-    ui.set_raster_data(raster_data, rgb_bands)
+    #ui.set_raster_data(raster_data, rgb_bands)
 
     sys.exit(app.exec_())

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -489,7 +489,7 @@ class DataVisualizerApp(QMainWindow):
         supported_formats = [
             self.tr('ENVI raster files (*.img *.hdr)'),
             self.tr('TIFF raster files (*.tiff *.tif *.tfw)'),
-            # self.tr('PDS raster files (*.PDS *.IMG)'),
+            self.tr('PDS raster files (*.IMG)'),
             self.tr('ENVI spectral libraries (*.sli *.hdr)'),
             # self.tr('WISER project files (*.wiser)'),
             self.tr('All files (*)'),

--- a/src/wiser/gui/rasterview.py
+++ b/src/wiser/gui/rasterview.py
@@ -85,9 +85,9 @@ def make_rgb_image(channels: List[np.ndarray]) -> np.ndarray:
             raise ValueError(f'All channels must have the same dimensions')
 
     # Expensive sanity checks:
-    if __debug__:
-        assert (0 <= np.amin(c) <= 255) and (0 <= np.amax(c) <= 255), \
-            'Channel may only contain values in range 0..255, and no NaNs'
+    # if __debug__:
+    #     assert (0 <= np.amin(c) <= 255) and (0 <= np.amax(c) <= 255), \
+    #         'Channel may only contain values in range 0..255, and no NaNs'
 
     rgb_data = (channels[0] << 16 |
                 channels[1] <<  8 |
@@ -129,9 +129,9 @@ def make_grayscale_image(channel: np.ndarray, colormap: Optional[str] = None) ->
         raise ValueError(f'All channels must be of type uint8, uint16, or uint32; got {channel.dtype}')
 
     # Expensive sanity checks:
-    if __debug__:
-        assert (0 <= np.amin(channel) <= 255) and (0 <= np.amax(channel) <= 255), \
-            'Channel may only contain values in range 0..255, and no NaNs'
+    # if __debug__:
+    #     assert (0 <= np.amin(channel) <= 255) and (0 <= np.amax(channel) <= 255), \
+    #         'Channel may only contain values in range 0..255, and no NaNs'
 
     if colormap is None:
         # Use the channel data to generate various gray RGB values.

--- a/src/wiser/raster/dataset.py
+++ b/src/wiser/raster/dataset.py
@@ -128,7 +128,7 @@ class RasterDataSet:
 
     def _compute_has_wavelengths(self):
         for b in self._band_info:
-            if 'wavelength' not in b:
+            if 'wavelength' not in b and 'hidden' not in b:
                 return False
 
         return True

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -797,51 +797,51 @@ class NumPyRasterDataImpl(RasterDataImpl):
 zcam_b_to_b = xcam.BAND_TO_BAYER['ZCAM']
 
 zcam_filter_to_name = {
-                "L0": "L0 (530nm)",
-                "LF": "L0 (530nm)",
-                "L1": "L1 (800nm)",
-                "L2": "L2 (754nm)",
-                "L3": "L3 (677nm)",
-                "L4": "L4 (605nm)",
-                "L5": "L5 (528nm)",
-                "L6": "L6 (442nm)",
-                "L7": "L7 (Solar)",
-                "R0": "R0 (530nm)",
-                "RF": "R0 (530nm)",
-                "R1": "R1 (800nm)",
-                "R2": "R2 (866nm)",
-                "R3": "R3 (910nm)",
-                "R4": "R4 (939nm)",
-                "R5": "R5 (978nm)",
-                "R6": "R6 (1022nm)",
-                "R7": "R7 (Solar)",
+                "ZL0": "L0 (530nm)",
+                "ZLF": "L0 (530nm)",
+                "ZL1": "L1 (800nm)",
+                "ZL2": "L2 (754nm)",
+                "ZL3": "L3 (677nm)",
+                "ZL4": "L4 (605nm)",
+                "ZL5": "L5 (528nm)",
+                "ZL6": "L6 (442nm)",
+                "ZL7": "L7 (Solar)",
+                "ZR0": "R0 (530nm)",
+                "ZRF": "R0 (530nm)",
+                "ZR1": "R1 (800nm)",
+                "ZR2": "R2 (866nm)",
+                "ZR3": "R3 (910nm)",
+                "ZR4": "R4 (939nm)",
+                "ZR5": "R5 (978nm)",
+                "ZR6": "R6 (1022nm)",
+                "ZR7": "R7 (Solar)",
         }
 
 zcam_filter_to_wavelength = {
-                "LF": 530 * u.nm,
-                "L0": 530 * u.nm,
+                "ZLF": 530 * u.nm,
+                "ZL0": 530 * u.nm,
                 #"L0_1": 630 * u.nm,
                 #"L0_2": 544 * u.nm,
                 #"L0_3": 480 * u.nm,
-                "L1": 800 * u.nm,
-                "L2": 754 * u.nm,
-                "L3": 677 * u.nm,
-                "L4": 605 * u.nm,
-                "L5": 528 * u.nm,
-                "L6": 442 * u.nm,
-                "L7": 590 * u.nm,
-                "RF": 530 * u.nm,
-                "R0": 530 * u.nm,
+                "ZL1": 800 * u.nm,
+                "ZL2": 754 * u.nm,
+                "ZL3": 677 * u.nm,
+                "ZL4": 605 * u.nm,
+                "ZL5": 528 * u.nm,
+                "ZL6": 442 * u.nm,
+                "ZL7": 590 * u.nm,
+                "ZRF": 530 * u.nm,
+                "ZR0": 530 * u.nm,
                 #"R0_1": 630 * u.nm,
                 #"R0_2": 544 * u.nm,
                 #"R0_3": 480 * u.nm,
-                "R1": 800 * u.nm,
-                "R2": 866 * u.nm,
-                "R3": 910 * u.nm,
-                "R4": 939 * u.nm,
-                "R5": 978 * u.nm,
-                "R6": 1022 * u.nm,
-                "R7": 880 * u.nm,
+                "ZR1": 800 * u.nm,
+                "ZR2": 866 * u.nm,
+                "ZR3": 910 * u.nm,
+                "ZR4": 939 * u.nm,
+                "ZR5": 978 * u.nm,
+                "ZR6": 1022 * u.nm,
+                "ZR7": 880 * u.nm,
         }
 
 zcam_filter_to_wavelength = dict(sorted(zcam_filter_to_wavelength.items(), key=operator.itemgetter(1)))
@@ -940,7 +940,7 @@ class MastcamZMultispectralDataImpl(RasterDataImpl):
         parent = Path(path).parent
         seqid = sequence(Path(path).name)
         # get all possible mspec frames in the directory
-        mspec_file_paths = [list(parent.glob(f'Z{bn}*IOF*{seqid}*.IMG')) for bn in zcam_filter_to_wavelength.keys()]
+        mspec_file_paths = [list(parent.glob(f'{bn}*IOF*{seqid}*.IMG')) for bn in zcam_filter_to_wavelength.keys()]
         # filter down to those that exist on the file system
         mspec_files = [str(_[0]) for _ in mspec_file_paths if len(_) > 0 and _[0].exists()]
         # disparity file is either a ZL?*_DSP or ZR*_DSP file in that directory

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -3,18 +3,26 @@ import logging
 import math
 import os
 import pprint
+import operator
+from pathlib import Path
+from scipy.ndimage import map_coordinates
 from urllib.parse import urlparse
+from enum import Enum, auto
+
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 Number = Union[int, float]
 
-from .utils import make_spectral_value, convert_spectral, get_spectral_unit
+from .utils import make_spectral_value, convert_spectral, get_spectral_unit, ensure_3d_with_band_first
 from .loaders import envi
 
 import numpy as np
 from astropy import units as u
 from osgeo import gdal, gdalconst, gdal_array, osr
-
+from osgeo.gdal import Dataset
+import marslab.compat.xcam as xcam
+from marslab.imgops.debayer import RGGB_PATTERN, make_bayer
+from marslab.parse import color_filter, sequence
 
 logger = logging.getLogger(__name__)
 
@@ -235,7 +243,7 @@ class GDALRasterDataImpl(RasterDataImpl):
         band_info = []
         for band_index in range(1, self.gdal_dataset.RasterCount + 1):
             band = self.gdal_dataset.GetRasterBand(band_index)
-            info = {'index':band_index - 1, 'description':band.GetDescription()}
+            info = {'index': band_index - 1, 'description':band.GetDescription()}
             band_info.append(info)
         return band_info
 
@@ -285,8 +293,6 @@ class GTiff_GDALRasterDataImpl(GDALRasterDataImpl):
 
     def __init__(self, gdal_dataset):
         super().__init__(gdal_dataset)
-
-
 
 
 class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
@@ -722,7 +728,7 @@ class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
 
 class NumPyRasterDataImpl(RasterDataImpl):
 
-    def __init__(self, arr: np.ndarray):
+    def __init__(self, arr: np.ndarray | np.ma.masked_array):
         self._arr = arr
 
     def get_format(self) -> str:
@@ -752,13 +758,13 @@ class NumPyRasterDataImpl(RasterDataImpl):
     def get_elem_type(self) -> np.dtype:
         return self._arr.dtype
 
-    def get_image_data(self) -> np.ndarray:
+    def get_image_data(self) -> np.ndarray | np.ma.masked_array:
         return self._arr
 
-    def get_band_data(self, band_index) -> np.ndarray:
+    def get_band_data(self, band_index) -> np.ndarray | np.ma.masked_array:
         return self._arr[band_index]
 
-    def get_all_bands_at(self, x, y) -> np.ndarray:
+    def get_all_bands_at(self, x, y) -> np.ndarray | np.ma.masked_array:
         return self._arr[:, y, x]
 
     def read_description(self) -> Optional[str]:
@@ -786,3 +792,319 @@ class NumPyRasterDataImpl(RasterDataImpl):
     def read_bad_bands(self) -> List[int]:
         # We don't have a bad-band list, so just make one up with all 1s.
         return [1] * self.num_bands()
+
+# Zcam Band to Bayer filter map, for each filter we have a different bayer filter to apply
+zcam_b_to_b = xcam.BAND_TO_BAYER['ZCAM']
+
+zcam_filter_to_name = {
+                "L0": "L0 (530nm)",
+                "LF": "L0 (530nm)",
+                "L1": "L1 (800nm)",
+                "L2": "L2 (754nm)",
+                "L3": "L3 (677nm)",
+                "L4": "L4 (605nm)",
+                "L5": "L5 (528nm)",
+                "L6": "L6 (442nm)",
+                "L7": "L7 (Solar)",
+                "R0": "R0 (530nm)",
+                "RF": "R0 (530nm)",
+                "R1": "R1 (800nm)",
+                "R2": "R2 (866nm)",
+                "R3": "R3 (910nm)",
+                "R4": "R4 (939nm)",
+                "R5": "R5 (978nm)",
+                "R6": "R6 (1022nm)",
+                "R7": "R7 (Solar)",
+        }
+
+zcam_filter_to_wavelength = {
+                "LF": 530 * u.nm,
+                "L0": 530 * u.nm,
+                #"L0_1": 630 * u.nm,
+                #"L0_2": 544 * u.nm,
+                #"L0_3": 480 * u.nm,
+                "L1": 800 * u.nm,
+                "L2": 754 * u.nm,
+                "L3": 677 * u.nm,
+                "L4": 605 * u.nm,
+                "L5": 528 * u.nm,
+                "L6": 442 * u.nm,
+                "L7": 590 * u.nm,
+                "RF": 530 * u.nm,
+                "R0": 530 * u.nm,
+                #"R0_1": 630 * u.nm,
+                #"R0_2": 544 * u.nm,
+                #"R0_3": 480 * u.nm,
+                "R1": 800 * u.nm,
+                "R2": 866 * u.nm,
+                "R3": 910 * u.nm,
+                "R4": 939 * u.nm,
+                "R5": 978 * u.nm,
+                "R6": 1022 * u.nm,
+                "R7": 880 * u.nm,
+        }
+
+zcam_filter_to_wavelength = dict(sorted(zcam_filter_to_wavelength.items(), key=operator.itemgetter(1)))
+
+class ZCamCameraPrefix(Enum):
+    ZL = auto()
+    ZR = auto()
+
+
+class MastcamZMultispectralDataImpl(RasterDataImpl):
+    """
+    Mastcam-Z multispectral dataset class
+
+    Mastcam-Z multispectral data is split into separate images for each band,
+    except for the L0/R0 bands which are RGB color and 1 file each
+    """
+
+    @classmethod
+    def get_load_filename(cls, path: str) -> str:
+        """
+        return the path of the file to be loaded into the dataset
+        but raise a RuntimeError if the path is not an IOF product from ZCAM
+
+        :param path: the path of the file to be loaded
+        """
+        path_lower = path.lower()
+        if path_lower.endswith('.img') and 'IOF' in path_lower and path_lower.startswith('z') and os.path.isfile(path):
+            pass
+        else:
+            raise RuntimeError(f'{path} is not a valid RAD ZCAM product.')
+        return path
+
+    @staticmethod
+    def _load_img_file(path):
+        """
+        Load an image from a given file path and return it
+
+        :param path: the path of the file to be loaded
+        """
+        return gdal.OpenEx(str(path),
+            nOpenFlags=gdalconst.OF_READONLY | gdalconst.OF_VERBOSE_ERROR,
+            allowed_drivers=['PDS', 'PDS4', 'VICAR'])
+
+    @staticmethod
+    def _load_dsp_file(parent: Path, kind: ZCamCameraPrefix):
+        """
+        Given a parent directory for a mastcam-z multispectral observation,
+        Find a corresponding DSP file for left to right or right to left depending on the kind
+        parameter (ZL or ZR). By default, we look for "filled" IMG files which have been processed by surffit
+        to interpolate missing disparity pixels.
+
+        We load the first candidate by default (normally only 1 would be found)
+
+        param kind: Prefix of the DSP file (ZL or ZR) using the ZCamCameraPrefix Enum
+        """
+        disp_cand = list(parent.glob(f'{kind.name}*DSP*filled*.IMG'))
+        disparity = None
+        if len(disp_cand) > 0:
+            disparity = MastcamZMultispectralDataImpl._load_img_file(str(disp_cand[0]))
+        return disparity
+
+    @staticmethod
+    def _load_mcz_frame(file: Path) -> NumPyRasterDataImpl:
+        """
+        Given a file ZCAM Path, load the file into a NumPyRasterDataImpl, applying the ZCam Bayer filter masks first
+
+        TODO: more components from marslab xcam.py and bandset.py may be needed here to incorporate complex logic for Zcam
+        """
+        # will have shape bands, y, x
+        frame = ensure_3d_with_band_first(MastcamZMultispectralDataImpl._load_img_file(file).ReadAsArray())
+        # get filter name from file path
+        filter_name = file.stem[1:3]
+        # get bayer filter mask for image
+        # TODO there may be certain cases where the data is already debayered so we'd not want to do the following
+        bayer_masks = make_bayer(frame.shape[1:], RGGB_PATTERN)
+        bayer_filter_pattern = xcam.make_detector_mask(bayer_masks, zcam_b_to_b, filter_name, frame[0])
+        # TODO may need to use marslab debayer.debayer_upsample here for certain filters
+        # create the masked numpy array
+        masked_frame = np.ma.masked_array(frame, mask=bayer_filter_pattern)
+        # return the final dataset
+        return NumPyRasterDataImpl(masked_frame)
+
+    @classmethod
+    def try_load_file(cls, path: str) -> 'MastcamZMultispectralDataImpl':
+        """
+        Given an image file path for a mastcam-Z multispectral observation,
+        find all the other frames in that directory which share the
+        same sequence id (are part of the same observation) and are I/F (IOF)
+        images.
+
+        Also locate the left to right and optionaly the right to left disparity files
+        """
+        # Turn on exceptions when calling into GDAL
+        gdal.UseExceptions()
+        # get the other zcam frames in the current directory if they exist and load them in gdal datasets
+        parent = Path(path).parent
+        seqid = sequence(Path(path).name)
+        # get all possible mspec frames in the directory
+        mspec_file_paths = [list(parent.glob(f'Z{bn}*IOF*{seqid}*.IMG')) for bn in zcam_filter_to_wavelength.keys()]
+        # filter down to those that exist on the file system
+        mspec_files = [str(_[0]) for _ in mspec_file_paths if len(_) > 0 and _[0].exists()]
+        # disparity file is either a ZL?*_DSP or ZR*_DSP file in that directory
+        left_disparity = MastcamZMultispectralDataImpl._load_dsp_file(parent, ZCamCameraPrefix.ZL)
+        right_disparity = MastcamZMultispectralDataImpl._load_dsp_file(parent, ZCamCameraPrefix.ZR)
+        return cls(*mspec_files, left_disparity=left_disparity, right_disparity=right_disparity)
+
+    def __init__(self, *mspec_images, left_disparity=None, right_disparity=None):
+        """
+        Init method for a MastcamZMultispectralData object
+
+        :param mspec_images: list of mspec image files to consider
+        :param left_disparity: Optional left disparity map
+        :param right_disparity: Optional right disparity map
+        """
+        self._left_vis: GDALRasterDataImpl = None
+        self._right_vis: GDALRasterDataImpl = None
+        self._filepaths: list[str] = list(mspec_images)
+        self.bands = {}
+        for image_path in mspec_images:
+            key = Path(image_path).stem[0:3]
+            if key == 'ZLF' or key == 'ZL0':
+                self._left_vis = GDALRasterDataImpl(MastcamZMultispectralDataImpl._load_img_file(image_path))
+                # todo each ZL0/ZR0 raster needs to be split into independent bands
+            elif key == 'ZRF' or key == 'ZR0':
+                self._right_vis = GDALRasterDataImpl(MastcamZMultispectralDataImpl._load_img_file(image_path))
+                # todo each ZL0/ZR0 raster needs to be split into independent bands
+            else:
+                # a more normal ZCAM frame to load
+                self.bands[key] = self._load_mcz_frame(Path(image_path))
+        # load the disparity maps
+        self.left_disparity = None if left_disparity is None else left_disparity.ReadAsArray()
+        self.right_disparity = None if right_disparity is None else right_disparity.ReadAsArray()
+        if self.left_disparity is None and self.right_disparity is None:
+            raise RuntimeError('No left disparity or right disparity file found, at least one is needed')
+
+    def get_width(self) -> int:
+        """
+        Returns the width of the image
+        """
+        return self._left_vis.get_width()
+
+    def get_height(self) -> int:
+        """
+        Returns the height of the image
+        """
+        return self._left_vis.get_height()
+
+    def get_format(self) -> str:
+        """
+        Returns the format of the image
+        """
+        return self._left_vis.get_format()
+
+    def get_filepaths(self) -> List[str]:
+        """
+        Returns the list of filepaths associated with the ZCam Mspec observation
+        """
+        return self._filepaths
+
+    def num_bands(self) -> int:
+        """
+        Get the number of spectral bands in the ZCam Mspec observation
+        """
+        return len(self.bands)
+
+    def get_elem_type(self) -> np.dtype:
+        """
+        Returns the element type of the ZCam Mspec observation
+        """
+        return self._left_vis.get_elem_type()
+
+    def read_band_info(self) -> List[Dict[str, Any]]:
+        """
+        Returns the bands information for each band of the ZCam Mspec observation
+        as a list of dictionaries containing filter name, wavelength, and wavelength units
+        """
+        band_info = []
+        for i, (key, ds) in enumerate(self.bands.items(), start=1):
+            info = dict(
+                index=i-1,
+                description=zcam_filter_to_name.get(key, 'NA'),
+                wavelength=zcam_filter_to_wavelength.get(key),
+                wavelength_str=str(zcam_filter_to_wavelength.get(key)),
+                wavelength_units=u.nm
+            )
+            band_info.append(info)
+        return band_info
+
+    def get_all_bands_at(self, x, y) -> np.ndarray:
+        """
+        For each available band, get the corresponding value at location x,y
+        using the disparity map of the ZCam Mspec observation to correct the position per band
+        returning the result as a numpy array
+
+        todo: the way WISER currently extracts spectra from multiple positions is inefficient.
+        For example when a kernel of pixels is used to produce a spectral plot this method
+        is called once per coordinate of the box around the user selected point. It would
+        be better if get_all_bands_at accepted numpy arrays instead of individual x/y coordinates
+
+        :param x: the x coordinate to extract spectra from
+        :param y: the y coordinate to extract spectra from
+        """
+        res = []
+        use_left = self.left_disparity is not None
+        for key, img in self.bands.items():
+            if key in {'LF', 'L0', 'R0', 'RF'}:
+                # todo: do work here to load multispectral information from the bayer filtered vis images
+                continue
+            if 'L' in key:
+                if use_left:
+                    data = img.get_all_bands_at(x, y)
+                else:
+                    lx, ly = self.right_to_left([x, y])
+                    data = img.get_all_bands_at(lx, ly)
+            else:
+                # this is a right image
+                if use_left:
+                    rx, ry = self.left_to_right([x, y])
+                    data = img.get_all_bands_at(rx, ry)
+                else:
+                    data = img.get_all_bands_at(x, y)
+            res.append(data)
+        return np.stack(res, axis=0)
+
+    def get_band_data(self, band_index: int) -> np.ndarray:
+        """
+        Get all data for a given band index as a numpy array
+        """
+        band_key = list(self.bands.keys())[band_index]
+        band = self.bands[band_key]
+        return np.ma.getdata(band.get_band_data(0))
+
+    @staticmethod
+    def _map_coords(disp: np.ndarray, xy):
+        """
+        Perform the mapping of the coordinates from one camera to another using the disparity map
+        """
+        xy = np.array([xy[::-1]]).T
+        # band 1 is y position (bottom is 1200, top is 0), band 2 is x
+        y = np.floor(map_coordinates(disp[0], xy, mode='grid-constant', order=1)).astype(int)
+        x = np.floor(map_coordinates(disp[1], xy, mode='grid-constant', order=1)).astype(int)
+        return int(x), int(y)
+
+    def left_to_right(self, xy):
+        """
+        given a set of points in the left image
+        get the corresponding right image coordinates
+
+        shape of xy needs to be 2,n
+        :param xy: ndarray of points in the left image coordinates
+        """
+        assert self.left_disparity is not None
+        rx, ry = self._map_coords(self.left_disparity, xy)
+        return rx, ry
+
+    def right_to_left(self, xy):
+        """
+        given a set of points in the right image
+        get the corresponding left image coordinates
+
+        shape of xy needs to be 2,n
+        :param xy: ndarray of points in the right image coordinates
+        """
+        assert self.right_disparity is not None
+        lx, ly = self._map_coords(self.right_disparity, xy)
+        return lx, ly

--- a/src/wiser/raster/loader.py
+++ b/src/wiser/raster/loader.py
@@ -9,7 +9,7 @@ from osgeo import gdal, gdalconst, gdal_array
 
 from .dataset import RasterDataSet
 from .dataset_impl import (RasterDataImpl, ENVI_GDALRasterDataImpl,
-    GTiff_GDALRasterDataImpl, NumPyRasterDataImpl)
+    GTiff_GDALRasterDataImpl, NumPyRasterDataImpl, MastcamZMultispectralDataImpl)
 
 from .spectrum import Spectrum
 
@@ -28,6 +28,7 @@ class RasterDataLoader:
         self._formats = {
             'ENVI': ENVI_GDALRasterDataImpl,
             'GTiff': GTiff_GDALRasterDataImpl,
+            'IMG': MastcamZMultispectralDataImpl
         }
 
         # This is a counter so we can generate names for unnamed datasets.

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -73,10 +73,10 @@ def calc_spectrum(dataset: RasterDataSet, points: List[QPoint],
     if len(spectra) > 1:
         # Need to compute mean/median/... of the collection of spectra
         if mode == SpectrumAverageMode.MEAN:
-            spectrum = np.mean(spectra, axis=0)
+            spectrum = np.nanmean(spectra, axis=0)
 
         elif mode == SpectrumAverageMode.MEDIAN:
-            spectrum = np.median(spectra, axis=0)
+            spectrum = np.nanmedian(spectra, axis=0)
 
         else:
             raise ValueError(f'Unrecognized average type {mode}')

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -309,7 +309,7 @@ class NumPyArraySpectrum(Spectrum):
         if isinstance(source, RasterDataSet):
             src_wavelengths = None
             if source.has_wavelengths():
-                src_wavelengths = [b['wavelength'] for b in source.band_list()]
+                src_wavelengths = [b.get('wavelength', None) for b in source.band_list()]
 
             self.set_wavelengths(src_wavelengths)
 
@@ -433,7 +433,7 @@ class RasterDataSetSpectrum(Spectrum):
         Returns a list of wavelength values corresponding to each band.  The
         individual values are astropy values-with-units.
         '''
-        bands =  [b['wavelength'] for b in self._dataset.band_list()]
+        bands = [b.get('wavelength', None) for b in self._dataset.band_list() if 'wavelength' in b]
 
         if filter_bad_bands:
             bad_bands = self._dataset.get_bad_bands()

--- a/src/wiser/raster/utils.py
+++ b/src/wiser/raster/utils.py
@@ -120,7 +120,7 @@ def find_band_near_wavelength(bands: List[Dict],
     If no suitable band is found, the function returns None.
     '''
 
-    wavelengths = [b.get('wavelength') for b in bands]
+    wavelengths = [b.get('wavelength') for b in bands if 'hidden' not in b]
     if None in wavelengths:
         raise ValueError('Not all bands specify a wavelength')
 

--- a/src/wiser/raster/utils.py
+++ b/src/wiser/raster/utils.py
@@ -43,6 +43,17 @@ KNOWN_SPECTRAL_UNITS: Dict[str, u.Unit] = {
 }
 
 
+def ensure_3d_with_band_first(image: np.ndarray):
+    """
+    Ensures that the input image is a 3D numpy array with the band dimension first.
+    :param image: A 2D or 3D numpy array representing an image.
+    :return: A 3D numpy array with the band dimension first.
+    """
+    if image.ndim == 2:
+        # For a 2D image, add a new axis at the front
+        image = np.expand_dims(image, axis=0)
+    return image
+
 def get_spectral_unit(unit_str: str) -> u.Unit:
     '''
     Given a string representation of the units, this function returns an


### PR DESCRIPTION
This is the start of a branch to add support for MastcamZ into WISER as part of a LPSC 2024 Abstract by Annex, Deen, and Ehlmann that will be submitted soon. This branch is not intended to be merged as-is. It is a work in progress to be expanded upon, possibly by others.

Mastcam Z is a multispectral imager on the Mars 2020 rover. It uses a set of filter wheels to select which wavelength is acquired. However, there are two complications. First, Mastcam Z is a stereo imager with different filter wheels in each camera (right and left). These cameras have different positions on the rover so there will be parallax and occlusions to be handled so you can't just load the 14 bands as a single 3d array as they are. Pixel disparity must be incorporated, which this branch does by looking for left to right and/or a right to left disparity map product as detailed in the 2024 LPSC abstract and correcting the coordinates used to load the correct spectral data. Lastly, MastcamZ's CCD's have a bayer filter pattern that must be handled differently depending on the filter wheel used, so that adds additional complexity to loading good spectra, which is a semi incomplete in this branch so far due to the complexity of existing implementations of the logic.  

To use this branch, Zcam IOF products are required for the spectral information. These can be found on the PDS in the Science Calibrated releases (e.g. https://planetarydata.jpl.nasa.gov/img/data/mars2020/mars2020_mastcamz_sci_calibrated/data/0397/iof/). Disparity products can be computed with some effort using data from the PDS using the workflow in the LPSC abstract, but hopefully I will be working on solving this problem...

To load a Zcam image, the disparity image and any/all IOF bands (.IMG files) desired must be located in the same directory. Selecting any one of the images in the GUI should be sufficient as the code looks for the other corresponding bands in the directory and should fail gracefully (not raise an exception) if bands are missing. In the GUI users can view multiple bands as expected although using bands from the left and right eye at the same time the code will show the images as is without warping the cameras into the same perspective. Spectral data will be correctly extracted using the disparity information.