### PR TITLE
Jgk/improve roi speed

### DIFF
--- a/src/tests/test_roi_avg_spectrum.py
+++ b/src/tests/test_roi_avg_spectrum.py
@@ -1,0 +1,121 @@
+import unittest
+
+import tests.context
+from wiser.raster import utils
+
+import numpy as np
+from astropy import units as u
+from wiser.raster.spectrum import raster_to_combined_rectangles_x_axis, create_raster_from_roi
+from wiser.raster.roi import RegionOfInterest
+from wiser.raster.selection import Selection, RectangleSelection, SinglePixelSelection, PolygonSelection, MultiPixelSelection
+from PySide2.QtCore import QPoint
+
+class TestRoiAvgSpectrum(unittest.TestCase):
+
+    def test_raster_to_combined_rectangles1(self):
+        raster1 = np.array([
+            [0, 1, 1, 0, 1, 1],
+            [0, 1, 1, 1, 1, 0],
+            [1, 1, 1, 1, 0, 1],
+            [1, 1, 1, 1, 0, 1],
+            [0, 0, 1, 1, 0, 0]
+        ])
+        raster_RLE_truth = [[1, 2, 0, 0], [4, 5, 0, 0], [1, 4, 1, 1], [0, 3, 2, 3], [5, 5, 2, 3], [2, 3, 4, 4]]
+        assert(set([tuple(lst) for lst in raster_to_combined_rectangles_x_axis(raster1).tolist()]) == set([tuple(list) for list in raster_RLE_truth]))
+
+    def test_raster_to_combined_rectangles2(self):
+        raster2 = np.array([
+            [1, 1, 0, 0, 1, 1],
+            [1, 1, 0, 1, 1, 1],
+            [0, 1, 1, 1, 0, 0],
+            [0, 1, 1, 1, 1, 0],
+            [0, 0, 1, 1, 1, 0]
+        ])
+        raster_RLE_truth = np.array([[0, 1, 0, 1], [4, 5, 0, 0], [3, 5, 1, 1], [1, 3, 2, 2], [1, 4, 3, 3], [2, 4, 4, 4]])
+        assert(set([tuple(lst) for lst in raster_to_combined_rectangles_x_axis(raster2).tolist()]) == set([tuple(list) for list in raster_RLE_truth]))
+
+    def test_raster_to_combined_rectangles3(self):
+        raster3 = np.array([
+            [0, 0, 1, 1, 0],
+            [0, 1, 1, 0, 1],
+            [1, 1, 0, 1, 1],
+            [0, 1, 1, 0, 0]
+        ])
+        raster_RLE_truth = [[2, 3, 0, 0], [1, 2, 1, 1], [4, 4, 1, 1], [0, 1, 2, 2], [3, 4, 2, 2], [1, 2, 3, 3]]
+        assert(set([tuple(lst) for lst in raster_to_combined_rectangles_x_axis(raster3).tolist()]) == set([tuple(list) for list in raster_RLE_truth]))
+
+    def test_raster_to_combined_rectangles4(self):
+        raster4 = np.array([
+            [0, 1, 0, 1],
+            [1, 1, 1, 0],
+            [0, 1, 1, 1],
+            [1, 1, 0, 0]
+        ])
+        raster_RLE_truth = [[1, 1, 0, 0], [3, 3, 0, 0], [0, 2, 1, 1], [1, 3, 2, 2], [0, 1, 3, 3]]
+        assert(set([tuple(lst) for lst in raster_to_combined_rectangles_x_axis(raster4).tolist()]) == set([tuple(list) for list in raster_RLE_truth]))
+
+    def test_raster_to_combined_rectangles5(self):
+        raster5 = np.array([
+            [1, 1, 1, 1],
+            [1, 1, 0, 0],
+            [1, 1, 1, 1],
+            [0, 0, 1, 1]
+        ])
+        raster_RLE_truth = [[0, 3, 0, 0], [0, 1, 1, 1], [0, 3, 2, 2], [2, 3, 3, 3]]
+        assert(set([tuple(lst) for lst in raster_to_combined_rectangles_x_axis(raster5).tolist()]) == set([tuple(list) for list in raster_RLE_truth]))
+
+    def test_raster_to_combined_rectangles6(self):
+        raster6 = np.array([
+            [0, 1, 1, 0],
+            [1, 1, 1, 1],
+            [0, 0, 1, 1],
+            [1, 1, 0, 1],
+            [0, 0, 1, 0]
+        ])
+        raster_RLE_truth = [[1, 2, 0, 0], [0, 3, 1, 1], [2, 3, 2, 2], [0, 1, 3, 3], [3, 3, 3, 3], [2, 2, 4, 4]]
+        assert(set([tuple(lst) for lst in raster_to_combined_rectangles_x_axis(raster6).tolist()]) == set([tuple(list) for list in raster_RLE_truth]))
+
+    def test_raster_to_combined_rectangles7(self):
+        raster7 = np.array([
+            [1, 1, 0],
+            [1, 1, 1],
+            [0, 1, 0],
+            [1, 1, 1]
+        ])
+        raster_RLE_truth = [[0, 1, 0, 0], [0, 2, 1, 1], [1, 1, 2, 2], [0, 2, 3, 3]]
+        assert(set([tuple(lst) for lst in raster_to_combined_rectangles_x_axis(raster7).tolist()]) == set([tuple(list) for list in raster_RLE_truth]))
+    
+    def test_raster_to_combined_rectangles8(self):
+        raster8 = np.array([
+            [1, 1, 1],
+            [1, 1, 1],
+            [1, 1, 1],
+            [1, 1, 1]
+        ])
+        raster_RLE_truth_x = [[0, 2, 0, 3]]
+        assert(set([tuple(lst) for lst in raster_to_combined_rectangles_x_axis(raster8).tolist()]) == set([tuple(list) for list in raster_RLE_truth_x]))
+    
+    def test_create_raster_from_roi(self):
+        roi = RegionOfInterest(name="testing_roi")
+        roi.add_selection(RectangleSelection(QPoint(0, 0), QPoint(5, 4)))
+        poly_point_list = [QPoint(1, 2), QPoint(7, 0), QPoint(6, 6)]
+        roi.add_selection(PolygonSelection(poly_point_list))
+        multi_point_list = [QPoint(2, 5), QPoint(4, 2), QPoint(8, 5), QPoint(9, 9)]
+        roi.add_selection(MultiPixelSelection(multi_point_list))
+
+        raster = create_raster_from_roi(roi)
+        ground_truth = np.array([
+            [1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+            [1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+            [1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+            [1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+            [0, 0, 0, 0, 1, 1, 1, 0, 0, 0],
+            [0, 0, 1, 0, 0, 1, 1, 0, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+        ])
+        np.testing.assert_equal(raster, ground_truth)
+
+

--- a/src/wiser/raster/dataset.py
+++ b/src/wiser/raster/dataset.py
@@ -14,6 +14,8 @@ from .dataset_impl import RasterDataImpl
 from .utils import RED_WAVELENGTH, GREEN_WAVELENGTH, BLUE_WAVELENGTH
 from .utils import find_band_near_wavelength
 
+from PySide2.QtCore import QRect
+
 Number = Union[int, float]
 DisplayBands = Union[Tuple[int], Tuple[int, int, int]]
 
@@ -420,6 +422,39 @@ class RasterDataSet:
 
         return arr
 
+    def get_all_bands_at_rect(self, rect: QRect , filter_bad_values=True):
+        '''
+        Returns a numpy 2D array of the values of all bands at the specified
+        rectangle in the raster data.
+        If filter_bad_values is set to True, bands that are marked as "bad" in
+        the metadata will be set to NaN, and bands with the "data ignore value"
+        will also be set to NaN.
+        '''
+
+        arr = self._impl.get_all_bands_at_rect(rect)
+        if filter_bad_values:
+            # TODO: (Joshua G-K) Ask donnie if we copy here because the numpy array 
+            # has direct access to the memory and we don't want to change thet memory
+            arr = arr.copy()
+
+            # Make mask for the bad band values
+            mask = np.array(self.get_bad_bands())
+            assert np.all((mask == 0) | (mask == 1)), "Bad bands mask contains values other than 0 or 1"
+            assert (arr.shape[0] == len(mask)), "Length of mask does not match number of spectra"
+            # In the mask, 1 means keep and 0 means get rid of, I use XOR with 1 to reverse this
+            # because np's mask operation (arr[mask]) would switch all the values where the mask is 1
+            mask = np.where((mask==0)|(mask==1), mask^1, mask)
+            mask = mask.astype(bool)
+
+            for i in range(arr.shape[1]):
+                for j in range(arr.shape[2]):
+                    arr[:,i,j][mask] = np.nan
+
+            if self._data_ignore_value is not None:
+                mask_ignore_val = np.isclose(arr, self._data_ignore_value)
+                arr[mask_ignore_val] = np.nan
+
+        return arr
 
     def get_geo_transform(self) -> Tuple:
         '''

--- a/src/wiser/raster/dataset.py
+++ b/src/wiser/raster/dataset.py
@@ -14,8 +14,6 @@ from .dataset_impl import RasterDataImpl
 from .utils import RED_WAVELENGTH, GREEN_WAVELENGTH, BLUE_WAVELENGTH
 from .utils import find_band_near_wavelength
 
-from PySide2.QtCore import QRect
-
 Number = Union[int, float]
 DisplayBands = Union[Tuple[int], Tuple[int, int, int]]
 
@@ -422,7 +420,7 @@ class RasterDataSet:
 
         return arr
 
-    def get_all_bands_at_rect(self, rect: QRect , filter_bad_values=True):
+    def get_all_bands_at_rect(self, x: int, y: int, dx: int, dy: int, filter_bad_values=True):
         '''
         Returns a numpy 2D array of the values of all bands at the specified
         rectangle in the raster data.
@@ -431,7 +429,7 @@ class RasterDataSet:
         will also be set to NaN.
         '''
 
-        arr = self._impl.get_all_bands_at_rect(rect)
+        arr = self._impl.get_all_bands_at_rect(x, y, dx, dy)
         if filter_bad_values:
             # TODO: (Joshua G-K) Ask donnie if we copy here because the numpy array 
             # has direct access to the memory and we don't want to change thet memory

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -15,6 +15,7 @@ import numpy as np
 from astropy import units as u
 from osgeo import gdal, gdalconst, gdal_array, osr
 
+from PySide2.QtCore import QRect
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,9 @@ class RasterDataImpl(abc.ABC):
         pass
 
     def get_all_bands_at(self, x, y) -> np.ndarray:
+        pass
+
+    def get_all_bands_at_rect(self, rect: QRect) -> np.ndarray:
         pass
 
     def read_description(self) -> Optional[str]:
@@ -223,6 +227,23 @@ class GDALRasterDataImpl(RasterDataImpl):
         # The numpy array comes back as a 3D array with the shape (bands,1,1),
         # so reshape into a 1D array with shape (bands).
         np_array = np_array.reshape(np_array.shape[0])
+
+        return np_array
+
+    def get_all_bands_at_rect(self, rect: QRect):
+        '''
+        Returns a numpy 2D array of the values of all bands at the specified
+        rectangle in the raster data.
+        '''
+
+        # TODO(donnie):  All kinds of potential pitfalls here!  In GDAL,
+        #     different raster bands can have different dimensions, data types,
+        #     etc.  Should probably do some sanity checking in the initializer.
+        # TODO(donnie):  This doesn't work with a virtual-memory array, but
+        #     maybe the non-virtual-memory approach is faster.
+        # np_array = self.gdal_dataset.GetVirtualMemArray(xoff=x, yoff=y,
+        #     xsize=1, ysize=1)
+        np_array = self.gdal_dataset.ReadAsArray(xoff=rect.left(), yoff=rect.top(), xsize=rect.width(), ysize=rect.height())
 
         return np_array
 
@@ -760,6 +781,9 @@ class NumPyRasterDataImpl(RasterDataImpl):
 
     def get_all_bands_at(self, x, y) -> np.ndarray:
         return self._arr[:, y, x]
+
+    def get_all_bands_at_rect(self, rect: QRect) -> np.ndarray:
+        return self._arr[:, rect.top():rect.top()+rect.height(), rect.left():rect.left()+rect.width()]
 
     def read_description(self) -> Optional[str]:
         return None

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -15,8 +15,6 @@ import numpy as np
 from astropy import units as u
 from osgeo import gdal, gdalconst, gdal_array, osr
 
-from PySide2.QtCore import QRect
-
 logger = logging.getLogger(__name__)
 
 
@@ -58,7 +56,7 @@ class RasterDataImpl(abc.ABC):
     def get_all_bands_at(self, x, y) -> np.ndarray:
         pass
 
-    def get_all_bands_at_rect(self, rect: QRect) -> np.ndarray:
+    def get_all_bands_at_rect(self, x: int, y: int, dx: int, dy: int) -> np.ndarray:
         pass
 
     def read_description(self) -> Optional[str]:
@@ -230,7 +228,7 @@ class GDALRasterDataImpl(RasterDataImpl):
 
         return np_array
 
-    def get_all_bands_at_rect(self, rect: QRect):
+    def get_all_bands_at_rect(self, x: int, y: int, dx: int, dy: int):
         '''
         Returns a numpy 2D array of the values of all bands at the specified
         rectangle in the raster data.
@@ -243,7 +241,7 @@ class GDALRasterDataImpl(RasterDataImpl):
         #     maybe the non-virtual-memory approach is faster.
         # np_array = self.gdal_dataset.GetVirtualMemArray(xoff=x, yoff=y,
         #     xsize=1, ysize=1)
-        np_array = self.gdal_dataset.ReadAsArray(xoff=rect.left(), yoff=rect.top(), xsize=rect.width(), ysize=rect.height())
+        np_array = self.gdal_dataset.ReadAsArray(xoff=x, yoff=y, xsize=dx, ysize=dy)
 
         return np_array
 
@@ -782,8 +780,8 @@ class NumPyRasterDataImpl(RasterDataImpl):
     def get_all_bands_at(self, x, y) -> np.ndarray:
         return self._arr[:, y, x]
 
-    def get_all_bands_at_rect(self, rect: QRect) -> np.ndarray:
-        # return self._arr[:, rect.top():rect.top()+rect.height(), rect.left():rect.left()+rect.width()]
+    def get_all_bands_at_rect(self, x: int, y: int, dx: int, dy: int) -> np.ndarray:
+        # return self._arr[:, y:y+dy, x:x+dx]
         return NotImplementedError
 
     def read_description(self) -> Optional[str]:

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -783,7 +783,8 @@ class NumPyRasterDataImpl(RasterDataImpl):
         return self._arr[:, y, x]
 
     def get_all_bands_at_rect(self, rect: QRect) -> np.ndarray:
-        return self._arr[:, rect.top():rect.top()+rect.height(), rect.left():rect.left()+rect.width()]
+        # return self._arr[:, rect.top():rect.top()+rect.height(), rect.left():rect.left()+rect.width()]
+        return NotImplementedError
 
     def read_description(self) -> Optional[str]:
         return None

--- a/src/wiser/raster/roi.py
+++ b/src/wiser/raster/roi.py
@@ -2,9 +2,10 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from .selection import (
     Selection, RectangleSelection, PolygonSelection, MultiPixelSelection,
-    selection_from_pyrep
+    selection_from_pyrep, SelectionType,
     )
 
+from PySide2.QtCore import QRect
 
 class RegionOfInterest:
     '''
@@ -80,6 +81,18 @@ class RegionOfInterest:
             all_pixels.update(sel.get_all_pixels())
 
         return all_pixels
+
+    def get_bounding_box(self) -> QRect:
+        all_pixels = self.get_all_pixels()
+        xs = [p[0] for p in all_pixels]
+        ys = [p[1] for p in all_pixels]
+
+        x_min = min(xs)
+        x_max = max(xs)
+        y_min = min(ys)
+        y_max = max(ys)
+
+        return QRect(x_min, y_min, x_max - x_min + 1, y_max - y_min + 1)
 
     def pprint(self):
         print(f'RegionOfInterest[{self._name}, {self._color}, {self._description}')

--- a/src/wiser/raster/selection.py
+++ b/src/wiser/raster/selection.py
@@ -8,6 +8,7 @@ from .polygon import rasterize_polygon
 
 from wiser.gui.geom import get_rectangle, manhattan_distance
 
+from wiser.raster.polygon import RasterizedPolygon
 
 class SelectionType(Enum):
     # A selection that is a single pixel
@@ -221,6 +222,7 @@ class PolygonSelection(Selection):
             raise ValueError('points list must contain at least 3 points')
 
         self._points = list(points)
+        self._rasterized_poly = None
 
     def num_points(self):
         return len(self._points)
@@ -242,10 +244,16 @@ class PolygonSelection(Selection):
     def is_picked_by(self, coord):
         # TODO(donnie):  Implement proper polygon picking
         return self.get_bounding_box().contains(coord)
-
+    
+    def get_rasterized_polygon(self) -> RasterizedPolygon:
+        if self._rasterized_poly == None:
+            self._rasterized_poly = rasterize_polygon([p.toTuple() for p in self._points])
+        return self._rasterized_poly
+    
     def get_all_pixels(self) -> Set[Tuple[int, int]]:
-        rasterized = rasterize_polygon([p.toTuple() for p in self._points])
-        return rasterized.get_set()
+        if self._rasterized_poly == None:
+            self._rasterized_poly = rasterize_polygon([p.toTuple() for p in self._points])
+        return self._rasterized_poly.get_set()
 
     def __str__(self):
         return f'PolygonSelection[points={self._points}]'

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -123,6 +123,12 @@ def raster_to_combined_rectangles_x_axis(raster):
 
     return np.array(rectangles)
 
+def raster_to_combined_rectangles_y_axis(raster_y: np.ndarray):
+    raster_x = raster_y.T
+    rectangles_x = raster_to_combined_rectangles_x_axis(raster_x)
+    rectangles_y = rectangles_x[:, [0, 1, 2, 3]] = rectangles_x[:, [2, 3, 0, 1]]
+    return rectangles_y
+
 def calc_rect_spectrum(dataset: RasterDataSet, rect: QRect, mode=SpectrumAverageMode.MEAN):
     '''
     Calculate a spectrum over a rectangular area of the specified dataset.

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -187,7 +187,7 @@ def calc_spectrum_fast(dataset: RasterDataSet, roi: RegionOfInterest,
     # Accessing by rectangular blocks is faster than accessing point by point
     qrects = array_to_qrects(rects)
     for qrect in qrects:
-        s = dataset.get_all_bands_at_rect(qrect)
+        s = dataset.get_all_bands_at_rect(qrect.left(), qrect.top(), qrect.width(), qrect.height())
         for i in range(s.shape[1]):
             for j in range(s.shape[2]):
                 spectra.append(s[:,i,j])

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -291,7 +291,7 @@ def calc_roi_spectrum(dataset: RasterDataSet, roi: RegionOfInterest, mode=Spectr
     Calculate a spectrum over a Region of Interest from the specified dataset.
     The calculation mode can be specified with the mode argument.
     '''
-    return calc_spectrum(dataset, roi.get_all_pixels(), mode)
+    return calc_spectrum_fast(dataset, roi, mode)
 
 
 #============================================================================

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -129,6 +129,16 @@ def raster_to_combined_rectangles_y_axis(raster_y: np.ndarray):
     rectangles_y = rectangles_x[:, [0, 1, 2, 3]] = rectangles_x[:, [2, 3, 0, 1]]
     return rectangles_y
 
+def array_to_qrects(array):
+    qrects = []
+    for row in array:
+        x1, x2, y1, y2 = row
+        # QRect takes (x, y, width, height), so calculate width and height
+        width = x2 - x1 + 1
+        height = y2 - y1 + 1
+        qrects.append(QRect(x1, y1, width, height))
+    return qrects
+
 def calc_rect_spectrum(dataset: RasterDataSet, rect: QRect, mode=SpectrumAverageMode.MEAN):
     '''
     Calculate a spectrum over a rectangular area of the specified dataset.

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -188,7 +188,6 @@ def calc_spectrum_fast(dataset: RasterDataSet, roi: RegionOfInterest,
     qrects = array_to_qrects(rects)
     for qrect in qrects:
         s = dataset.get_all_bands_at_rect(qrect)
-        print(qrect)
         for i in range(s.shape[1]):
             for j in range(s.shape[2]):
                 spectra.append(s[:,i,j])

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -139,6 +139,21 @@ def array_to_qrects(array):
         qrects.append(QRect(x1, y1, width, height))
     return qrects
 
+def create_raster_from_pixels(roi: RegionOfInterest) -> np.ndarray:
+    bbox = roi.get_bounding_box()
+    pixels = roi.get_all_pixels()
+
+    xmin = bbox.topLeft().x()
+    ymin = bbox.topLeft().y()
+    
+    raster = np.zeros((bbox.height(), bbox.width()), dtype=np.uint8)
+    
+    for pixel in pixels:
+        pixel_x, pixel_y = pixel[0], pixel[1]
+        pixel_index_x, pixel_index_y = pixel_x - xmin, pixel_y - ymin
+        raster[pixel_index_y][pixel_index_x] = 1
+    return raster
+
 def calc_rect_spectrum(dataset: RasterDataSet, rect: QRect, mode=SpectrumAverageMode.MEAN):
     '''
     Calculate a spectrum over a rectangular area of the specified dataset.


### PR DESCRIPTION
**Why this is needed?**

We want to make the roi average calculation faster.

**What did I do?**

Instead of accessing each individual pixel one at a time, I created an algorithm that can access chunks (rectangles) of pixels so we do less reads from memory.

**What I did to accomplish this?**

Essentially, I implemented a variant of the run length encoding algorithm. I go through the rastered version of the region of interest along the x-axis. I find where all of the rectangles on the x-axis are. I merge rectangles with rectangle above if the columns exactly match. This lets us do less memory accesses. I do this for the x and the y axis and choose whichever axis gives me less rectangles.

**Results**

On below image

<img width="353" alt="caltech-roi-complex" src="https://github.com/user-attachments/assets/246d9926-67f6-464f-8a9f-0d89d40df5ec">


New algorithm takes about 3.5 seconds

Old algorithm takes about 1 min, 10 seconds


**Testing**

Look in tests/test_roi_average_spectrum

**Future improvements**

The current bottle neck seems to be the function find_rectangles_in_row. I have experimented with speeding it up with numpy but I didn't finish because I thought it would be better to move on. If we want to optimize this further, this function would be where to start. I testedo n a 5GB image, getting the avg spectrum of the whole image but putting a bunch of rectangles on it and the whole process took 51 seconds, the find_rectangles_in_row took 17 of those seconds.