### PR TITLE
Adding finished version for oper_add

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Install-WISER-*.exe
 # This file contains secrets for distribution, DO NOT CHECK IN!
 Secret.mk
 
+src/wiser/bandmath/builtins/temp/*

--- a/src/wiser/bandmath/builtins/constants.py
+++ b/src/wiser/bandmath/builtins/constants.py
@@ -1,0 +1,5 @@
+import os
+
+MAX_RAM_BYTES = 4000000000
+SCALAR_BYTES = 4
+TEMP_FOLDER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'temp')

--- a/src/wiser/bandmath/builtins/oper_add.py
+++ b/src/wiser/bandmath/builtins/oper_add.py
@@ -1,6 +1,10 @@
 from typing import Any, Dict, List, Optional
 
 import numpy as np
+import dask.array as da
+import os
+import gc
+import psutil
 
 from wiser.bandmath import VariableType, BandMathValue, BandMathExprInfo
 from wiser.bandmath.functions import BandMathFunction
@@ -9,8 +13,10 @@ from wiser.bandmath.utils import (
     reorder_args,
     check_image_cube_compatible, check_image_band_compatible, check_spectrum_compatible,
     make_image_cube_compatible, make_image_band_compatible, make_spectrum_compatible,
+    make_image_cube_compatible_by_bands,
 )
 
+from .constants import MAX_RAM_BYTES, SCALAR_BYTES, TEMP_FOLDER_PATH
 
 class OperatorAdd(BandMathFunction):
     '''
@@ -111,20 +117,36 @@ class OperatorAdd(BandMathFunction):
         (lhs, rhs) = reorder_args(lhs.type, rhs.type, lhs, rhs)
 
         # Do the addition computation.
-
+        file_path = os.path.join(TEMP_FOLDER_PATH, 'oper_add_result.dat')
         if lhs.type == VariableType.IMAGE_CUBE:
             # Dimensions:  [band][y][x]
-            lhs_value = lhs.as_numpy_array()
-            assert lhs_value.ndim == 3
+            bands, y, x = lhs.get_shape()
 
-            rhs_value = make_image_cube_compatible(rhs, lhs_value.shape)
-            result_arr = lhs_value + rhs_value
+            result_arr = da.from_array(np.memmap(file_path, \
+                                   dtype=lhs.value.get_elem_type(), mode='w+', shape=lhs.value.get_shape()))
+            max_bytes = MAX_RAM_BYTES/SCALAR_BYTES
+            dbands = int(np.floor(max_bytes / (x*y)))
+            if dbands == 0:
+                dbands = 1
+            # We get by bands since the data is in bsq format
+            for band_start in range(0, bands, dbands):
+                if band_start + dbands > bands:
+                    dbands = bands - band_start
+                band_list = [band_start + inc for inc in range(0, dbands)]
+                lhs_value = lhs.as_numpy_array_by_bands(band_list)
+
+                assert lhs_value.ndim == 3
+
+                rhs_value = make_image_cube_compatible_by_bands(rhs, lhs_value.shape, band_list)
+                result_arr[band_start:band_start+dbands,:,:] = lhs_value + rhs_value
+
+                del lhs_value, rhs_value
 
             # The result array should have the same dimensions as the LHS input
             # array.
             assert result_arr.ndim == 3
-            assert result_arr.shape == lhs_value.shape
-            return BandMathValue(VariableType.IMAGE_CUBE, result_arr)
+            assert result_arr.shape == lhs.value.get_shape()
+            return BandMathValue(VariableType.IMAGE_CUBE, result_arr.compute())
 
         elif lhs.type == VariableType.IMAGE_BAND:
             # Dimensions:  [y][x]

--- a/src/wiser/bandmath/types.py
+++ b/src/wiser/bandmath/types.py
@@ -168,6 +168,25 @@ class BandMathValue:
         raise TypeError(f'Don\'t know how to convert {self.type} ' +
                         f'value {self.value} into a NumPy array')
 
+    def as_numpy_array_by_bands(self, band_list: List[int]) -> np.ndarray:
+        '''
+        If a band-math value is an image cube, image band, or spectrum, this
+        function returns the value as a NumPy ``ndarray``.  If a band-math
+        value is some other type, the function raises a ``TypeError``.
+        '''
+
+        # If the value is already a NumPy array, we are done!
+        if isinstance(self.value, np.ndarray):
+            return self.value
+
+        if self.type == VariableType.IMAGE_CUBE:
+            if isinstance(self.value, RasterDataSet):
+                return self.value.get_multiple_band_data(band_list)
+
+        # We only want this function to work for numpy arrays and RasterDataSets 
+        # because these can be very big 3D objects
+        raise TypeError(f'This function should only be called on numpy' +
+                        f'arrays and image cubes, not {self.type}')      
 
 class BandMathFunction(abc.ABC):
     '''

--- a/src/wiser/bandmath/utils.py
+++ b/src/wiser/bandmath/utils.py
@@ -334,6 +334,77 @@ def make_image_band_compatible(arg: BandMathValue,
 
     return result
 
+def make_image_cube_compatible_by_bands(arg: BandMathValue,
+        cube_shape: Tuple[int, int, int], band_list: List[int]) \
+        -> Union[np.ndarray, Scalar]:
+    '''
+    Given a band-math value, this function converts it to a value that is
+    "compatible with" a NumPy operation on an image-cube with the specified
+    shape. This generally means that the return value can be broadcast against
+    an image-cube to achieve the "expected" behavior. This function grabs the data
+    by bands. Doing so is faster because the data is stored in bsq format. It is
+    important that band_list is sorted from least to greatest and is continuous.
+    A ``TypeError`` is raised if the input argument isn't of one of these
+    ``VariableType`` values:
+    *   ``IMAGE_CUBE``
+    *   ``IMAGE_BAND``
+    *   ``SPECTRUM``
+    *   ``NUMBER``
+    *   ``BOOLEAN``
+    A ``ValueError`` is raised if the input argument has a shape incompatible
+    with the specified image-cube shape.
+    '''
+    if arg.type not in [VariableType.IMAGE_CUBE, VariableType.IMAGE_BAND,
+        VariableType.SPECTRUM, VariableType.NUMBER, VariableType.BOOLEAN]:
+        raise TypeError(f'Can\'t make a {arg.type} value compatible with ' +
+                        'an image-cube')
+
+    result: Union[np.ndarray, Scalar] = None
+
+    # Dimensions:  [band][y][x]
+
+    if arg.type == VariableType.IMAGE_CUBE:
+        # Dimensions:  [band][y][x]
+        result = arg.as_numpy_array_by_bands(band_list)
+        assert result.ndim == 3
+
+        if result.shape != cube_shape:
+            raise_shape_mismatch(VariableType.IMAGE_CUBE, cube_shape,
+                                 arg.type, arg.get_shape())
+
+    elif arg.type == VariableType.IMAGE_BAND:
+        # Dimensions:  [y][x]
+        # NumPy will broadcast the band across the entire image, band by band.
+        result = arg.as_numpy_array()
+        assert result.ndim == 2
+
+        if result.shape != cube_shape[1:]:
+            raise_shape_mismatch(VariableType.IMAGE_CUBE, cube_shape,
+                                 arg.type, arg.get_shape())
+
+    elif arg.type == VariableType.SPECTRUM:
+        # Dimensions:  [band]
+        result = arg.as_numpy_array()
+        band_start = band_list[0]
+        band_end = band_list[-1]
+        result=result[band_start:band_end+1]
+        assert result.ndim == 1
+
+        if result.shape != (cube_shape[0],):
+            raise_shape_mismatch(VariableType.IMAGE_CUBE, cube_shape,
+                                 arg.type, arg.get_shape())
+
+        # To ensure the spectrum is broadcast across the image's pixels,
+        # reshape to effectively create a 1x1 image.
+        # New dimensions:  [band][y=1][x=1]
+        result = result[:, np.newaxis, np.newaxis]
+
+    else:
+        # This is a scalar:  number or Boolean
+        assert arg.type in [VariableType.NUMBER, VariableType.BOOLEAN]
+        result = arg.value
+
+    return result
 
 def make_spectrum_compatible(arg: BandMathValue,
         spectrum_shape: Tuple[int]) -> Union[np.ndarray, Scalar]:

--- a/src/wiser/gui/bandmath_dialog.py
+++ b/src/wiser/gui/bandmath_dialog.py
@@ -46,7 +46,7 @@ def guess_variable_type_from_name(variable: str) -> bandmath.VariableType:
 def get_memory_size(size_bytes: int) -> str:
     '''
     This helper function takes a size in bytes, and generates a human-readable
-    string versino of the size.  The size will be reported using bytes,
+    string version of the size.  The size will be reported using bytes,
     kilobytes (=2**10 bytes), megabytes (=2**20 bytes), gigabytes, or terabytes,
     depending on the most appropriate option for the input size.
     '''

--- a/src/wiser/raster/dataset.py
+++ b/src/wiser/raster/dataset.py
@@ -308,7 +308,7 @@ class RasterDataSet:
 
 
     def set_data_ignore_value(self, ignore_value: Optional[Number]) -> None:
-        self._data_ignore_value = value
+        self._data_ignore_value = ignore_value
         self.set_dirty()
 
 
@@ -379,6 +379,23 @@ class RasterDataSet:
 
         return arr
 
+    def get_multiple_band_data(self, band_list: List[int], filter_data_ignore_value=True):
+        '''
+        Returns a numpy 3D array of the specified images band data for all pixels in those
+        bands.
+        The numpy array is configured such that the pixel (x, y) for band b values are at
+        element array[b][y][x].
+        If the data-set has a "data ignore value" and filter_data_ignore_value
+        is also set to True, the array will be filtered such that any element
+        with the "data ignore value" will be filtered to NaN.  Note that this
+        filtering will impact performance.
+        '''
+        arr = self._impl.get_multiple_band_data(band_list)
+
+        if filter_data_ignore_value and self._data_ignore_value is not None:
+            arr = np.ma.masked_values(arr, self._data_ignore_value)
+
+        return arr
 
     def get_band_stats(self, band_index: int):
         '''

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -63,6 +63,9 @@ class RasterDataImpl(abc.ABC):
     def read_band_unit(self) -> Optional[u.Unit]:
         return None
 
+    def get_multiple_band_data(self, band_list_orig: List[int]) -> np.ndarray:
+        return
+
     def read_band_info(self) -> List[Dict[str, Any]]:
         pass
 
@@ -225,6 +228,18 @@ class GDALRasterDataImpl(RasterDataImpl):
         np_array = np_array.reshape(np_array.shape[0])
 
         return np_array
+
+    def get_multiple_band_data(self, band_list_orig: List[int]) -> np.ndarray:
+        '''
+        Returns a numpy 3D array of all the x & y values at the specified bands.
+        '''
+        # Note that GDAL indexes bands from 1, not 0.
+        band_list = [band+1 for band in band_list_orig]
+
+        # Read the specified bands
+        data = self.gdal_dataset.ReadAsArray(band_list=band_list)
+
+        return data
 
     def read_band_info(self) -> List[Dict[str, Any]]:
         '''
@@ -763,6 +778,11 @@ class NumPyRasterDataImpl(RasterDataImpl):
 
     def read_description(self) -> Optional[str]:
         return None
+    
+    def get_multiple_band_data(self, band_list_orig: List[int]) -> np.ndarray:
+        '''Returns the bands specified by the band list. The band list is assumed
+            to be in sorted order from least to greatest.'''
+        return self._arr[band_list_orig[0]:band_list_orig[-1]+1,:,:]
 
     def read_band_info(self) -> List[Dict[str, Any]]:
         band_info = []


### PR DESCRIPTION
**Why is this needed?**

This is needed to let us control the amount of bytes we use when performing band math calculations so we don't have running out of memory errors. 

**How did I accomplish this?**

I went through the array in windows (specified by bands) to minimize the amount of memory that had to be allocated.

**Changes?**

<blank>

**Testing**

It does work, but if there is already a lot of your memory being used it will crash. 