### PR TITLE
Jgk/band by band bm

### DIFF
--- a/src/wiser/bandmath/builtins/oper_add.py
+++ b/src/wiser/bandmath/builtins/oper_add.py
@@ -9,6 +9,7 @@ from wiser.bandmath.utils import (
     reorder_args,
     check_image_cube_compatible, check_image_band_compatible, check_spectrum_compatible,
     make_image_cube_compatible, make_image_band_compatible, make_spectrum_compatible,
+    make_image_cube_compatible_by_bands,
 )
 
 
@@ -91,7 +92,7 @@ class OperatorAdd(BandMathFunction):
         self._report_type_error(lhs.result_type, rhs.result_type)
 
 
-    def apply(self, args: List[BandMathValue]):
+    def apply(self, args: List[BandMathValue], index: int):
         '''
         Add the LHS and RHS and return the result.
         '''
@@ -114,18 +115,14 @@ class OperatorAdd(BandMathFunction):
 
         if lhs.type == VariableType.IMAGE_CUBE:
             # Dimensions:  [band][y][x]
-            lhs_value = lhs.as_numpy_array()
-            assert lhs_value.ndim == 3
-
-            rhs_value = make_image_cube_compatible(rhs, lhs_value.shape)
-            result_arr = lhs_value + rhs_value
-
-            # The result array should have the same dimensions as the LHS input
-            # array.
-            assert result_arr.ndim == 3
+            lhs_value = lhs.as_numpy_array_by_bands([index])
+            assert lhs_value.ndim == 2
+            rhs_value = make_image_cube_compatible_by_bands(rhs, lhs_value.shape, [index])
+        
+            # The dimension should be two because we are slicing by band
+            assert result_arr.ndim == 2
             assert result_arr.shape == lhs_value.shape
             return BandMathValue(VariableType.IMAGE_CUBE, result_arr)
-
         elif lhs.type == VariableType.IMAGE_BAND:
             # Dimensions:  [y][x]
             lhs_value = lhs.as_numpy_array()

--- a/src/wiser/bandmath/builtins/oper_add.py
+++ b/src/wiser/bandmath/builtins/oper_add.py
@@ -118,7 +118,8 @@ class OperatorAdd(BandMathFunction):
             lhs_value = lhs.as_numpy_array_by_bands([index])
             assert lhs_value.ndim == 2
             rhs_value = make_image_cube_compatible_by_bands(rhs, lhs_value.shape, [index])
-        
+            result_arr = lhs_value + rhs_value
+
             # The dimension should be two because we are slicing by band
             assert result_arr.ndim == 2
             assert result_arr.shape == lhs_value.shape

--- a/src/wiser/bandmath/builtins/oper_compare.py
+++ b/src/wiser/bandmath/builtins/oper_compare.py
@@ -8,6 +8,7 @@ from wiser.bandmath.functions import BandMathFunction
 from wiser.bandmath.utils import (
     check_image_cube_compatible, check_image_band_compatible, check_spectrum_compatible,
     make_image_cube_compatible, make_image_band_compatible, make_spectrum_compatible,
+    make_image_cube_compatible_by_bands,
 )
 
 
@@ -155,7 +156,7 @@ class OperatorCompare(BandMathFunction):
         self._report_type_error(lhs.result_type, rhs.result_type)
 
 
-    def apply(self, args: List[BandMathValue]):
+    def apply(self, args: List[BandMathValue], index: int):
         '''
         Perform a comparison between the LHS and RHS, and return the result.
         '''
@@ -182,16 +183,16 @@ class OperatorCompare(BandMathFunction):
 
         if lhs.type == VariableType.IMAGE_CUBE:
             # Dimensions:  [band][y][x]
-            lhs_value = lhs.as_numpy_array()
-            rhs_value = make_image_cube_compatible(rhs, lhs_value.shape)
+            lhs_value = lhs.as_numpy_array_by_bands([index])
+            rhs_value = make_image_cube_compatible_by_bands(rhs, lhs_value.shape, [index])
             result_arr = compare_fn(lhs_value, rhs_value)
             result_arr = result_arr.astype(np.byte)
             return BandMathValue(VariableType.IMAGE_CUBE, result_arr)
 
         elif rhs.type == VariableType.IMAGE_CUBE:
             # Dimensions:  [band][y][x]
-            rhs_value = rhs.as_numpy_array()
-            lhs_value = make_image_cube_compatible(lhs, rhs_value.shape)
+            rhs_value = rhs.as_numpy_array_by_bands([index])
+            lhs_value = make_image_cube_compatible_by_bands(lhs, rhs_value.shape, [index])
             result_arr = compare_fn(lhs_value, rhs_value)
             result_arr = result_arr.astype(np.byte)
             return BandMathValue(VariableType.IMAGE_CUBE, result_arr)

--- a/src/wiser/bandmath/builtins/oper_divide.py
+++ b/src/wiser/bandmath/builtins/oper_divide.py
@@ -8,6 +8,7 @@ from wiser.bandmath.functions import BandMathFunction
 from wiser.bandmath.utils import (
     check_image_cube_compatible, check_image_band_compatible, check_spectrum_compatible,
     make_image_cube_compatible, make_image_band_compatible, make_spectrum_compatible,
+    make_image_cube_compatible_by_bands,
 )
 
 
@@ -88,7 +89,7 @@ class OperatorDivide(BandMathFunction):
         self._report_type_error(lhs.result_type, rhs.result_type)
 
 
-    def apply(self, args: List[BandMathValue]):
+    def apply(self, args: List[BandMathValue], index: int):
         '''
         Divide the LHS by the RHS and return the result.
         '''
@@ -107,15 +108,15 @@ class OperatorDivide(BandMathFunction):
 
         if lhs.type == VariableType.IMAGE_CUBE:
             # Dimensions:  [band][x][y]
-            lhs_value = lhs.as_numpy_array()
-            assert lhs_value.ndim == 3
+            lhs_value = lhs.as_numpy_array_by_bands([index])
+            assert lhs_value.ndim == 2
 
-            rhs_value = make_image_cube_compatible(rhs, lhs_value.shape)
+            rhs_value = make_image_cube_compatible_by_bands(rhs, lhs_value.shape, [index])
             result_arr = lhs_value / rhs_value
 
             # The result array should have the same dimensions as the LHS input
             # array.
-            assert result_arr.ndim == 3
+            assert result_arr.ndim == 2
             assert result_arr.shape == lhs_value.shape
             return BandMathValue(VariableType.IMAGE_CUBE, result_arr)
 

--- a/src/wiser/bandmath/builtins/oper_multiply.py
+++ b/src/wiser/bandmath/builtins/oper_multiply.py
@@ -9,6 +9,7 @@ from wiser.bandmath.utils import (
     reorder_args,
     check_image_cube_compatible, check_image_band_compatible, check_spectrum_compatible,
     make_image_cube_compatible, make_image_band_compatible, make_spectrum_compatible,
+    make_image_cube_compatible_by_bands,
 )
 
 
@@ -90,7 +91,7 @@ class OperatorMultiply(BandMathFunction):
         self._report_type_error(lhs.result_type, rhs.result_type)
 
 
-    def apply(self, args: List[BandMathValue]):
+    def apply(self, args: List[BandMathValue], index: int):
         '''
         Multiply the LHS and RHS and return the result.
         '''
@@ -113,15 +114,15 @@ class OperatorMultiply(BandMathFunction):
 
         if lhs.type == VariableType.IMAGE_CUBE:
             # Dimensions:  [band][y][x]
-            lhs_value = lhs.as_numpy_array()
-            assert lhs_value.ndim == 3
+            lhs_value = lhs.as_numpy_array_by_bands([index])
+            assert lhs_value.ndim == 2
 
-            rhs_value = make_image_cube_compatible(rhs, lhs_value.shape)
+            rhs_value = make_image_cube_compatible_by_bands(rhs, lhs_value.shape, [index])
             result_arr = lhs_value * rhs_value
 
             # The result array should have the same dimensions as the LHS input
             # array.
-            assert result_arr.ndim == 3
+            assert result_arr.ndim == 2
             assert result_arr.shape == lhs_value.shape
             return BandMathValue(VariableType.IMAGE_CUBE, result_arr)
 

--- a/src/wiser/bandmath/builtins/oper_negate.py
+++ b/src/wiser/bandmath/builtins/oper_negate.py
@@ -44,10 +44,13 @@ class OperatorUnaryNegate(BandMathFunction):
 
         if arg.type == VariableType.NUMBER:
             return BandMathValue(VariableType.NUMBER, -arg.value)
-
-        elif arg.type in [VariableType.IMAGE_CUBE, VariableType.IMAGE_BAND,
-                          VariableType.SPECTRUM]:
+        elif arg.type == VariableType.IMAGE_CUBE:
             arr = arg.as_numpy_array_by_bands([index])
+            result_arr = -arr
+            return BandMathValue(arg.type, result_arr)
+        elif arg.type in [VariableType.IMAGE_BAND,
+                          VariableType.SPECTRUM]:
+            arr = arg.as_numpy_array()
             result_arr = -arr
             return BandMathValue(arg.type, result_arr)
 

--- a/src/wiser/bandmath/builtins/oper_negate.py
+++ b/src/wiser/bandmath/builtins/oper_negate.py
@@ -32,7 +32,7 @@ class OperatorUnaryNegate(BandMathFunction):
         return arg
 
 
-    def apply(self, args: List[BandMathValue]):
+    def apply(self, args: List[BandMathValue], index: int):
         '''
         Perform unary negation on the argument and return the result.
         '''
@@ -47,7 +47,7 @@ class OperatorUnaryNegate(BandMathFunction):
 
         elif arg.type in [VariableType.IMAGE_CUBE, VariableType.IMAGE_BAND,
                           VariableType.SPECTRUM]:
-            arr = arg.as_numpy_array()
+            arr = arg.as_numpy_array_by_bands([index])
             result_arr = -arr
             return BandMathValue(arg.type, result_arr)
 

--- a/src/wiser/bandmath/builtins/oper_power.py
+++ b/src/wiser/bandmath/builtins/oper_power.py
@@ -8,6 +8,7 @@ from wiser.bandmath.functions import BandMathFunction
 from wiser.bandmath.utils import (
     check_image_cube_compatible, check_image_band_compatible, check_spectrum_compatible,
     make_image_cube_compatible, make_image_band_compatible, make_spectrum_compatible,
+    make_image_cube_compatible_by_bands,
 )
 
 
@@ -88,7 +89,7 @@ class OperatorPower(BandMathFunction):
         self._report_type_error(lhs.result_type, rhs.result_type)
 
 
-    def apply(self, args: List[BandMathValue]):
+    def apply(self, args: List[BandMathValue], index: int):
         '''
         Raise the LHS to the power specified by RHS and return the result.
         '''
@@ -107,15 +108,15 @@ class OperatorPower(BandMathFunction):
 
         if lhs.type == VariableType.IMAGE_CUBE:
             # Dimensions:  [band][x][y]
-            lhs_value = lhs.as_numpy_array()
-            assert lhs_value.ndim == 3
+            lhs_value = lhs.as_numpy_array_by_bands([index])
+            assert lhs_value.ndim == 2
 
-            rhs_value = make_image_cube_compatible(rhs, lhs_value.shape)
+            rhs_value = make_image_cube_compatible_by_bands(rhs, lhs_value.shape, [index])
             result_arr = lhs_value ** rhs_value
 
             # The result array should have the same dimensions as the LHS input
             # array.
-            assert result_arr.ndim == 3
+            assert result_arr.ndim == 2
             assert result_arr.shape == lhs_value.shape
             return BandMathValue(VariableType.IMAGE_CUBE, result_arr)
 

--- a/src/wiser/bandmath/builtins/oper_subtract.py
+++ b/src/wiser/bandmath/builtins/oper_subtract.py
@@ -9,6 +9,7 @@ from wiser.bandmath.utils import (
     reorder_args,
     check_image_cube_compatible, check_image_band_compatible, check_spectrum_compatible,
     make_image_cube_compatible, make_image_band_compatible, make_spectrum_compatible,
+    make_image_cube_compatible_by_bands,
 )
 
 
@@ -102,7 +103,7 @@ class OperatorSubtract(BandMathFunction):
         self._report_type_error(lhs.result_type, rhs.result_type)
 
 
-    def apply(self, args: List[BandMathValue]):
+    def apply(self, args: List[BandMathValue], index: int):
         '''
         Subtract the RHS from the LHS and return the result.
         '''
@@ -124,15 +125,15 @@ class OperatorSubtract(BandMathFunction):
 
         if lhs.type == VariableType.IMAGE_CUBE:
             # Dimensions:  [band][x][y]
-            lhs_value = lhs.as_numpy_array()
-            assert lhs_value.ndim == 3
-
-            rhs_value = make_image_cube_compatible(rhs, lhs_value.shape)
+            lhs_value = lhs.as_numpy_array_by_bands([index])
+            assert lhs_value.ndim == 2
+    
+            rhs_value = make_image_cube_compatible_by_bands(rhs, lhs_value.shape, [index])
             result_arr = _apply_sign(lsign, lhs_value) + _apply_sign(rsign, rhs_value)
 
             # The result array should have the same dimensions as the LHS input
             # array.
-            assert result_arr.ndim == 3
+            assert result_arr.ndim == 2
             assert result_arr.shape == lhs_value.shape
             return BandMathValue(VariableType.IMAGE_CUBE, result_arr)
 

--- a/src/wiser/bandmath/evaluator.py
+++ b/src/wiser/bandmath/evaluator.py
@@ -260,6 +260,8 @@ def eval_bandmath_expr(bandmath_expr: str, expr_info: BandMathExprInfo, result_n
             result_value = eval.transform(tree)
             res = result_value.value
             if isinstance(result_value.value, np.ma.MaskedArray):
+                if not np.issubdtype(res.dtype, np.floating):
+                    res = res.astype(np.float32)
                 res[result_value.value.mask] = np.nan
 
             band = out_dataset.GetRasterBand(band_index+1)

--- a/src/wiser/bandmath/evaluator.py
+++ b/src/wiser/bandmath/evaluator.py
@@ -42,6 +42,8 @@ class BandMathEvaluator(lark.visitors.Transformer):
         lhs = args[0]
         oper = args[1]
         rhs = args[2]
+        # It is okay if we don't want to use index with bands or spectrum 
+        # because in each operator, index is only used with image cubes
         return OperatorCompare(oper).apply([lhs, rhs], self.index)
 
 
@@ -243,7 +245,7 @@ def eval_bandmath_expr(bandmath_expr: str, expr_info: BandMathExprInfo, result_n
 
     logger.debug('Beginning band-math evaluation')
     if expr_info.result_type == VariableType.IMAGE_CUBE:
-        eval = BandMathEvaluator(lower_variables, lower_functions, expr_info.interleave_type, expr_info.shape)
+        eval = BandMathEvaluator(lower_variables, lower_functions, expr_info.shape)
 
         bands, lines, samples = expr_info.shape
         result_path = os.path.join(TEMP_FOLDER_PATH, result_name)

--- a/src/wiser/bandmath/utils.py
+++ b/src/wiser/bandmath/utils.py
@@ -2,11 +2,13 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 Number = Union[int, float]
 Scalar = Union[int, float, bool]
 
+import os
 
 import numpy as np
 
 from .types import VariableType, BandMathExprInfo, BandMathValue
 
+TEMP_FOLDER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'temp_output')
 
 def get_dimensions(type: VariableType, shape: Tuple) -> str:
     '''
@@ -150,6 +152,73 @@ def check_image_cube_compatible(arg: BandMathExprInfo,
         # This is a scalar:  number or Boolean
         assert arg.result_type in [VariableType.NUMBER, VariableType.BOOLEAN]
 
+def make_image_cube_compatible_by_bands(arg: BandMathValue,
+        cube_shape: Tuple[int, int, int], band_list: List[int]) \
+        -> Union[np.ndarray, Scalar]:
+    '''
+    Given a band-math value and a list of bands, this function converts it to a value that is
+    "compatible with" a NumPy operation on an image-cube with the specified
+    shape and bands. This generally means that the return value can be broadcast against
+    an image-cube to achieve the "expected" behavior. This function grabs the data
+    by bands. Doing so is faster because the data is stored in bsq format. It is
+    important that band_list is sorted from least to greatest and is continuous.
+    A ``TypeError`` is raised if the input argument isn't of one of these
+    ``VariableType`` values:
+    *   ``IMAGE_CUBE``
+    *   ``IMAGE_BAND``
+    *   ``SPECTRUM``
+    *   ``NUMBER``
+    *   ``BOOLEAN``
+    A ``ValueError`` is raised if the input argument has a shape incompatible
+    with the specified image-cube shape.
+    '''
+    if arg.type not in [VariableType.IMAGE_CUBE, VariableType.IMAGE_BAND,
+        VariableType.SPECTRUM, VariableType.NUMBER, VariableType.BOOLEAN]:
+        raise TypeError(f'Can\'t make a {arg.type} value compatible with ' +
+                        'an image-cube')
+
+    result: Union[np.ndarray, Scalar] = None
+
+    # Dimensions:  [band][y][x]
+    if arg.type == VariableType.IMAGE_CUBE:
+        # Dimensions:  [band][y][x]
+        result = arg.as_numpy_array_by_bands(band_list)
+        assert result.ndim == 3 or (result.ndim == 2 and len(band_list) == 1)
+
+        if result.shape != cube_shape:
+            raise_shape_mismatch(VariableType.IMAGE_CUBE, cube_shape,
+                                 arg.type, arg.get_shape())
+
+    elif arg.type == VariableType.IMAGE_BAND:
+        # Dimensions:  [y][x]
+        # NumPy will broadcast the band across the entire image, band by band.
+        result = arg.as_numpy_array_by_bands(band_list)
+        assert result.ndim == 2
+
+        if (result.shape != cube_shape[1:]) and (result.shape != cube_shape and len(band_list) == 1):
+            raise_shape_mismatch(VariableType.IMAGE_CUBE, cube_shape,
+                                 arg.type, arg.get_shape())
+
+    elif arg.type == VariableType.SPECTRUM:
+        # Dimensions:  [band]
+        result = arg.as_numpy_array_by_bands(band_list)
+        assert result.ndim == 1
+
+        if (result.shape != (cube_shape[0],)) and len(band_list) != 1:
+            raise_shape_mismatch(VariableType.IMAGE_CUBE, cube_shape,
+                                 arg.type, arg.get_shape())
+
+        # To ensure the spectrum is broadcast across the image's pixels,
+        # reshape to effectively create a 1x1 image.
+        # New dimensions:  [band][y=1][x=1]
+        result = result[:, np.newaxis]
+
+    else:
+        # This is a scalar:  number or Boolean
+        assert arg.type in [VariableType.NUMBER, VariableType.BOOLEAN]
+        result = arg.value
+
+    return result
 
 def check_image_band_compatible(arg: BandMathExprInfo,
                                 band_shape: Tuple[int, int]) -> None:

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -17,6 +17,8 @@ from PySide2.QtWidgets import *
 
 from .app_config import PixelReticleType
 
+from wiser.bandmath.utils import TEMP_FOLDER_PATH
+
 from .about_dialog import AboutDialog
 
 from .rasterpane import RecenterMode
@@ -451,7 +453,7 @@ class DataVisualizerApp(QMainWindow):
         #     we must detect unsaved state.)
 
         # TODO(donnie):  Maybe save Qt state?
-
+        delete_all_files_in_folder(TEMP_FOLDER_PATH)
         super().closeEvent(event)
 
 
@@ -769,7 +771,7 @@ class DataVisualizerApp(QMainWindow):
                     functions.update(plugin_fns)
 
             try:
-                (result_type, result) = bandmath.eval_bandmath_expr(expression,
+                (result_type, result) = bandmath.eval_bandmath_expr(expression, expr_info, result_name,
                     variables, functions)
 
                 logger.debug(f'Result of band-math evaluation is type ' +

--- a/src/wiser/gui/util.py
+++ b/src/wiser/gui/util.py
@@ -13,6 +13,24 @@ import numpy as np
 
 import wiser.gui.generated.resources
 
+def delete_all_files_in_folder(folder_path):
+    # Check if the folder exists
+    if os.path.exists(folder_path) and os.path.isdir(folder_path):
+        # List all files in the directory
+        for filename in os.listdir(folder_path):
+            file_path = os.path.join(folder_path, filename)
+            
+            # Check if it's a file and not a directory
+            if os.path.isfile(file_path):
+                try:
+                    os.remove(file_path)  # Delete the file
+                    print(f"Deleted: {file_path}")
+                except Exception as e:
+                    print(f"Failed to delete {file_path}. Reason: {e}")
+            else:
+                print(f"Skipping: {file_path} (not a file)")
+    else:
+        print(f"Directory {folder_path} does not exist.")
 
 def str_or_none(s: Optional[str]) -> str:
     '''

--- a/src/wiser/raster/dataset.py
+++ b/src/wiser/raster/dataset.py
@@ -551,6 +551,12 @@ class RasterDataSet:
 
         self.set_dirty()
 
+    def get_save_state(self):
+        return self._impl.get_save_state()
+
+    def set_save_state(self, save_state: SaveState):
+        self._impl.set_save_state(save_state)
+
 
 class RasterDataBand:
     '''
@@ -614,12 +620,6 @@ class RasterDataBand:
         object.
         '''
         return self._dataset.get_band_stats(self._band_index)
-
-    def get_save_state(self):
-        return self._impl.get_save_state()
-
-    def set_save_state(self, save_state: SaveState):
-        self._impl.set_save_state(save_state)
 
 def find_truecolor_bands(dataset: RasterDataSet,
                          red: u.Quantity = RED_WAVELENGTH,

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -290,7 +290,7 @@ class GDALRasterDataImpl(RasterDataImpl):
                 self.gdal_dataset.FlushCache()
                 self.gdal_dataset = None
             driver.Delete(filepath)
-            print(f"Delete: {self.get_filepaths()[0]}.hdr")
+            print(f"Delete: {filepath}.hdr")
         except Exception as e:
             print(f"Couldn't delete dataset. Error: \n {e}")
 

--- a/src/wiser/raster/loader.py
+++ b/src/wiser/raster/loader.py
@@ -96,6 +96,9 @@ class RasterDataLoader:
         impl = NumPyRasterDataImpl(arr)
         return RasterDataSet(impl)
 
+    def dataset_from_gdal_dataset(self, dataset: gdal.Dataset):
+        impl = ENVI_GDALRasterDataImpl(dataset)
+        return RasterDataSet(impl)
 
     # TODO(donnie):  Not presently needed - can instantiate a NumPyArraySpectrum
     #     object from a NumPy array...


### PR DESCRIPTION
**Why is this needed?**
Currently, bandmath can not perform out of memory calculations. This implementation will allow it to by reading data from memory band by band.

**How did I accomplish this?**
I made it so bandmath reads the data band by band from disk and will write it out to one file (so there are no intermediate files,  the intermediates from the abstract syntax tree are just each band on ram which isn't much). Because there was not infrastructure for having a dataset that was on disk but not explicitly saved to disk by the user I added some for that.

**Testing**
I tested multiple bandmath functionality to make sure it stayed the same. This is one of the equations i tested with on the old vesrion and my new version and it looks exactly the same (a+b)*(-a-c)/d < e that used image bands, image, and spectrum types:
<img width="966" alt="comparing_bm_eq_img" src="https://github.com/user-attachments/assets/c136e75d-5744-43d1-a907-8822009b916c">

**Future Work**
I want to add in asynchronous loading of data while bandmath computation happens and asynchronous writing of the data for band by band.

I could possibly add a way to specify the amount of GB in memory that each raster band intermediate takes up and automatically calculate the number of bands to load in from memory. I could base this off the maximum number of intermediates in the abstract syntax tree (AST) and the amount of GB of RAM the computer has. (Might be a little too much though)

I need to add a way to tell the user if there band math operation will exceed the space left on disk.

** Stuff I tested (Feel free to skip)**
During this process I tested a lot of implementations that used the interleave type to directly access memory with np.memmap and I tried with gdal ReadAsArray. gdalReadAsArray may be promising because it can interface with multiple file types. The np.memmap code would only work for filetypes where data is stored exactly in the interleave format (like .hdr files) so it would not work for data formats like GeoTiff. However, the speedup was very good (adding two 20GB images on my 30GB ram in ~40 seconds when it normally would take around 1000seconds)