### PR TITLE
Jgk/roi mean viz

### DIFF
--- a/src/wiser/gui/spectrum_info_editor.py
+++ b/src/wiser/gui/spectrum_info_editor.py
@@ -49,7 +49,6 @@ class SpectrumInfoEditor(QDialog):
 
     def configure_ui(self, spectrum: Spectrum):
         self._spectrum = spectrum
-        self._should_plot_update = False
 
         #========================================
         # Constants:
@@ -140,7 +139,6 @@ class SpectrumInfoEditor(QDialog):
     def _on_choose_color(self, checked):
         initial_color = QColor(self._ui.lineedit_plot_color.text())
         color = QColorDialog.getColor(parent=self, initial=initial_color)
-        print("COLOR PRESSED")
         if color.isValid():
             # self._spectrum.set_color(color.name())
             self._ui.lineedit_plot_color.setText(color.name())
@@ -150,7 +148,6 @@ class SpectrumInfoEditor(QDialog):
         '''
         If the user edits the spectrum name, clear the "auto-generate name" flag
         '''
-        print("NAME EDITED")
         self._ui.ckbox_autogen_name.setChecked(False)
 
 
@@ -162,9 +159,6 @@ class SpectrumInfoEditor(QDialog):
         self._maybe_regenerate_name()
 
     def _on_aavg_mode_changed(self, index):
-        print("Average mode changed!!!")
-        print("self._ui.combobox_avg_mode.currentIndex(): ", self._ui.combobox_avg_mode.currentIndex())
-        print("self._initial_avg_mode: ", self._initial_avg_mode)
         if self._ui.combobox_avg_mode.currentIndex() != self._initial_avg_mode:
             self._compute_values_changed['_initial_avg_mode'] = True
         else:
@@ -173,9 +167,6 @@ class SpectrumInfoEditor(QDialog):
         self._maybe_regenerate_name()
 
     def _on_finish_aavg(self):
-        print("Editing finished!!!")
-        print("self._ui.lineedit_area_avg_x.text() : ",  self._ui.lineedit_area_avg_x.text())
-        print("self._initial_area_avg_x : ", self._initial_area_avg_x)
         if (self._ui.lineedit_area_avg_x.text() != self._initial_area_avg_x):
             self._compute_values_changed['_initial_area_avg_x'] = True
         else:
@@ -194,6 +185,7 @@ class SpectrumInfoEditor(QDialog):
         # Verify UI values before making any changes.
 
         # Name
+
         use_autogen_name = False  # RasterDataSetSpectrum-specific field
         if isinstance(self._spectrum, RasterDataSetSpectrum):
             use_autogen_name = self._ui.ckbox_autogen_name.isChecked()
@@ -257,8 +249,6 @@ class SpectrumInfoEditor(QDialog):
         # Process values so object using this knows what changed
 
         self.should_recalculate = any(self._compute_values_changed.values())
-        print("In Accept")
-        print("self.should_recalculate: ", self.should_recalculate)
         #=======================================================================
         # All done!
 

--- a/src/wiser/gui/spectrum_info_editor.py
+++ b/src/wiser/gui/spectrum_info_editor.py
@@ -34,10 +34,22 @@ class SpectrumInfoEditor(QDialog):
         self._ui.combobox_avg_mode.activated.connect(self._on_aavg_mode_changed)
         self._ui.lineedit_area_avg_x.editingFinished.connect(self._on_finish_aavg)
         self._ui.lineedit_area_avg_y.editingFinished.connect(self._on_finish_aavg)
+    
+        self._initial_area_avg_x = None
+        self._initial_area_avg_y = None
+        self._initial_avg_mode = None
+        self._compute_values_changed = {
+            '_initial_area_avg_x' : False,
+            '_initial_area_avg_y' : False,
+            '_initial_avg_mode' : False
+        }
+
+        self.should_recalculate = False
 
 
     def configure_ui(self, spectrum: Spectrum):
         self._spectrum = spectrum
+        self._should_plot_update = False
 
         #========================================
         # Constants:
@@ -93,6 +105,7 @@ class SpectrumInfoEditor(QDialog):
             avg_mode = self._spectrum.get_avg_mode()
             i = self._ui.combobox_avg_mode.findData(avg_mode)
             self._ui.combobox_avg_mode.setCurrentIndex(i)
+            self._initial_avg_mode = i
 
             self._ui.combobox_avg_mode.setEnabled(True)
 
@@ -107,6 +120,8 @@ class SpectrumInfoEditor(QDialog):
 
             self._ui.lineedit_area_avg_x.setText(str(area_avg_x))
             self._ui.lineedit_area_avg_y.setText(str(area_avg_y))
+            self._initial_area_avg_y = str(area_avg_y)
+            self._initial_area_avg_x = str(area_avg_x)
 
             # Enable the area-average line edit widgets.
             for le in [self._ui.lineedit_area_avg_x, self._ui.lineedit_area_avg_y]:
@@ -125,6 +140,7 @@ class SpectrumInfoEditor(QDialog):
     def _on_choose_color(self, checked):
         initial_color = QColor(self._ui.lineedit_plot_color.text())
         color = QColorDialog.getColor(parent=self, initial=initial_color)
+        print("COLOR PRESSED")
         if color.isValid():
             # self._spectrum.set_color(color.name())
             self._ui.lineedit_plot_color.setText(color.name())
@@ -134,6 +150,7 @@ class SpectrumInfoEditor(QDialog):
         '''
         If the user edits the spectrum name, clear the "auto-generate name" flag
         '''
+        print("NAME EDITED")
         self._ui.ckbox_autogen_name.setChecked(False)
 
 
@@ -145,9 +162,30 @@ class SpectrumInfoEditor(QDialog):
         self._maybe_regenerate_name()
 
     def _on_aavg_mode_changed(self, index):
+        print("Average mode changed!!!")
+        print("self._ui.combobox_avg_mode.currentIndex(): ", self._ui.combobox_avg_mode.currentIndex())
+        print("self._initial_avg_mode: ", self._initial_avg_mode)
+        if self._ui.combobox_avg_mode.currentIndex() != self._initial_avg_mode:
+            self._compute_values_changed['_initial_avg_mode'] = True
+        else:
+            self._compute_values_changed['_initial_avg_mode'] = False
+            
         self._maybe_regenerate_name()
 
     def _on_finish_aavg(self):
+        print("Editing finished!!!")
+        print("self._ui.lineedit_area_avg_x.text() : ",  self._ui.lineedit_area_avg_x.text())
+        print("self._initial_area_avg_x : ", self._initial_area_avg_x)
+        if (self._ui.lineedit_area_avg_x.text() != self._initial_area_avg_x):
+            self._compute_values_changed['_initial_area_avg_x'] = True
+        else:
+            self._compute_values_changed['_initial_area_avg_x'] = False
+
+        if (self._ui.lineedit_area_avg_y.text() != self._initial_area_avg_y):
+            self._compute_values_changed['_initial_area_avg_y'] = True
+        else:
+            self._compute_values_changed['_initial_area_avg_y'] = False
+
         self._maybe_regenerate_name()
 
 
@@ -156,7 +194,6 @@ class SpectrumInfoEditor(QDialog):
         # Verify UI values before making any changes.
 
         # Name
-
         use_autogen_name = False  # RasterDataSetSpectrum-specific field
         if isinstance(self._spectrum, RasterDataSetSpectrum):
             use_autogen_name = self._ui.ckbox_autogen_name.isChecked()
@@ -215,6 +252,13 @@ class SpectrumInfoEditor(QDialog):
 
         self._spectrum.set_color(color_name)
 
+        
+        #=======================================================================
+        # Process values so object using this knows what changed
+
+        self.should_recalculate = any(self._compute_values_changed.values())
+        print("In Accept")
+        print("self.should_recalculate: ", self.should_recalculate)
         #=======================================================================
         # All done!
 

--- a/src/wiser/gui/spectrum_plot.py
+++ b/src/wiser/gui/spectrum_plot.py
@@ -208,16 +208,6 @@ class SpectrumDisplayInfo:
             assert(len(lines) == 1)
             self._line2d = lines[0]
 
-    # def change_plot_color(self, axes, use_wavelengths):
-    #     # If we already have a plot, remove it.
-    #     self.remove_plot()
-
-    #     if self._values is not None:
-    #         self._values = self._spectrum.get_spectrum()
-    #     color = self._spectrum.get_color()
-    #     linewidth = 0.5
-
-
     def remove_plot(self):
         if self._line2d is not None:
             self._line2d.remove()
@@ -1506,12 +1496,11 @@ class SpectrumPlot(QWidget):
         if self._spectrum_edit_dialog.exec() != QDialog.Accepted:
             # User canceled out of the edit.
             return
-        print("!!!self._spectrum_edit_dialog!!!")
-        print(self._spectrum_edit_dialog)
+        
         # If we got here, update the tree-view item with the spectrum's info.
 
         treeitem.setText(0, spectrum.get_name())
-        print("self._spectrum_edit_dialog.should_recalculate: ", self._spectrum_edit_dialog.should_recalculate)
+        
         # Is the spectrum currently being displayed?
         display_info = self._spectrum_display_info.get(spectrum.get_id())
         if display_info is not None:

--- a/src/wiser/gui/spectrum_plot.py
+++ b/src/wiser/gui/spectrum_plot.py
@@ -151,6 +151,7 @@ class SpectrumDisplayInfo:
 
         self._icon: Optional[QIcon] = None
         self._line2d = None
+        self._values = None
 
     def reset(self) -> None:
         self._icon = None
@@ -168,15 +169,18 @@ class SpectrumDisplayInfo:
         return self._spectrum
 
 
-    def generate_plot(self, axes, use_wavelengths, wavelength_units=u.nm):
+    def generate_plot(self, axes, use_wavelengths, wavelength_units=u.nm, should_recalculate=True):
         # If we already have a plot, remove it.
         self.remove_plot()
 
-        values = self._spectrum.get_spectrum()
+        if should_recalculate or self._values is None:
+            self._values = self._spectrum.get_spectrum()
+
         color = self._spectrum.get_color()
         linewidth = 0.5
 
         if use_wavelengths:
+            print("use_Wavelengths is happening")
             # We should only be told to use wavelengths if all displayed spectra
             # have wavelengths for the bands.
             assert(self._spectrum.has_wavelengths())
@@ -189,7 +193,7 @@ class SpectrumDisplayInfo:
             wavelengths = raster_utils.get_band_values(
                 self._spectrum.get_wavelengths(), wavelength_units)
 
-            lines = axes.plot(wavelengths, values, color=color,
+            lines = axes.plot(wavelengths, self._values, color=color,
                 linewidth=linewidth, label=self._spectrum.get_name())
             assert(len(lines) == 1)
             self._line2d = lines[0]
@@ -199,10 +203,19 @@ class SpectrumDisplayInfo:
             # will be meaningful if there are multiple plots from different
             # datasets to display.
 
-            lines = axes.plot(values, color=color, linewidth=linewidth,
+            lines = axes.plot(self._values, color=color, linewidth=linewidth,
                 label=self._spectrum.get_name())
             assert(len(lines) == 1)
             self._line2d = lines[0]
+
+    # def change_plot_color(self, axes, use_wavelengths):
+    #     # If we already have a plot, remove it.
+    #     self.remove_plot()
+
+    #     if self._values is not None:
+    #         self._values = self._spectrum.get_spectrum()
+    #     color = self._spectrum.get_color()
+    #     linewidth = 0.5
 
 
     def remove_plot(self):
@@ -1493,16 +1506,17 @@ class SpectrumPlot(QWidget):
         if self._spectrum_edit_dialog.exec() != QDialog.Accepted:
             # User canceled out of the edit.
             return
-
+        print("!!!self._spectrum_edit_dialog!!!")
+        print(self._spectrum_edit_dialog)
         # If we got here, update the tree-view item with the spectrum's info.
 
         treeitem.setText(0, spectrum.get_name())
-
+        print("self._spectrum_edit_dialog.should_recalculate: ", self._spectrum_edit_dialog.should_recalculate)
         # Is the spectrum currently being displayed?
         display_info = self._spectrum_display_info.get(spectrum.get_id())
         if display_info is not None:
             display_info.reset()
-            display_info.generate_plot(self._axes, self._plot_uses_wavelengths)
+            display_info.generate_plot(self._axes, self._plot_uses_wavelengths, should_recalculate=self._spectrum_edit_dialog.should_recalculate)
             treeitem.setIcon(0, display_info.get_icon())
 
         # Are we showing a point on this spectrum?

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -453,7 +453,6 @@ class RasterDataSetSpectrum(Spectrum):
         Return the spectrum data as a 1D NumPy array.
         '''
         if self._spectrum is None:
-            print("Having to recalculate spectrum in get_spectrum")
             self._calculate_spectrum()
 
         return self._spectrum

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -453,6 +453,7 @@ class RasterDataSetSpectrum(Spectrum):
         Return the spectrum data as a 1D NumPy array.
         '''
         if self._spectrum is None:
+            print("Having to recalculate spectrum in get_spectrum")
             self._calculate_spectrum()
 
         return self._spectrum


### PR DESCRIPTION
**Why is this needed?**

When you update visualization parameters for a spectrum it causes the whole spectrum to get recalculated. We do not want this.

**How did I accomplish this?**
I made it so the state of the dialog window is compared before and after and only state changes that need the spectrum to be recalculated will cause this recalculation

**Testing**
I just manually tested this.