### PR TITLE
Fix linking dataset error when a dataset is not displayed

### DIFF
--- a/src/wiser/gui/app_state.py
+++ b/src/wiser/gui/app_state.py
@@ -356,9 +356,13 @@ class ApplicationState(QObject):
         return True
 
     def multiple_displayed_datasets_same_size(self):
+        '''
+        This function returns True if there are multiple visible datasets and
+        they are all the same size.
+        '''
         # Get access to the displayed datasets
         displayed_datasets = self._app._main_view.get_visible_datasets()
-        # If len is less than 2 return false
+
         if len(displayed_datasets) < 2:
             return False
 

--- a/src/wiser/gui/app_state.py
+++ b/src/wiser/gui/app_state.py
@@ -355,6 +355,22 @@ class ApplicationState(QObject):
 
         return True
 
+    def multiple_displayed_datasets_same_size(self):
+        # Get access to the displayed datasets
+        displayed_datasets = self._app._main_view.get_visible_datasets()
+        # If len is less than 2 return false
+        if len(displayed_datasets) < 2:
+            return False
+
+        # Else, make sure they're all the same size 
+        ds0_dim = (displayed_datasets[0].get_width(), displayed_datasets[0].get_height())
+        for ds in displayed_datasets[1:]:
+            ds_dim = (ds.get_width(), ds.get_height())
+            if ds_dim != ds0_dim:
+                return False
+
+        return True
+
 
     def unique_dataset_name(self, candidate):
         ds_names = {ds.get_name() for ds in self._datasets.values()}

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -318,11 +318,11 @@ class MainViewWidget(RasterPane):
 
     
     def on_rasterview_dataset_changed(self):
-        """
+        '''
         Currently, this function is used to change the dataset link state when
         a new dataset is showed to a raster view. If the new dataset's dimensions
         does not match the currently displayed datasets, we stop linking.
-        """
+        '''
         # We only do something if link_view_scroll is true, if not we do nothing
         if self._link_view_scrolling:
             if not self._app_state.multiple_displayed_datasets_same_size():

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -318,6 +318,11 @@ class MainViewWidget(RasterPane):
 
     
     def on_rasterview_dataset_changed(self):
+        """
+        Currently, this function is used to change the dataset link state when
+        a new dataset is showed to a raster view. If the new dataset's dimensions
+        does not match the currently displayed datasets, we stop linking.
+        """
         # We only do something if link_view_scroll is true, if not we do nothing
         if self._link_view_scrolling:
             if not self._app_state.multiple_displayed_datasets_same_size():

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -316,6 +316,14 @@ class MainViewWidget(RasterPane):
     def is_scrolling_linked(self):
         return self._link_view_scrolling
 
+    
+    def on_rasterview_dataset_changed(self):
+        # We only do something if link_view_scroll is true, if not we do nothing
+        if self._link_view_scrolling:
+            if not self._app_state.multiple_displayed_datasets_same_size():
+                self._act_link_view_scroll.setChecked(False)
+                self._link_view_scrolling = False
+
 
     def _on_link_view_scroll(self, checked):
         '''
@@ -323,8 +331,7 @@ class MainViewWidget(RasterPane):
         scrolling.  When raster-view scrolling is linked, all raster views must
         be updated to show the same coordinates as the top left raster view.
         '''
-
-        if checked and not self._app_state.multiple_datasets_same_size():
+        if checked and not self._app_state.multiple_displayed_datasets_same_size():
             # TODO(donnie):  Not sure if it's better to tell the user why the
             #     view scrolling can't be linked, or to disable it.  For now,
             #     we tell the user why it isn't possible.

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -615,6 +615,14 @@ class RasterPane(QWidget):
         return self._app_state
 
 
+    def get_visible_datasets(self) -> List[RasterDataSet]:
+        visible_ds = []
+        for rasterview in self._rasterviews.values():
+            if rasterview._raster_data is not None:
+                visible_ds.append(rasterview._raster_data)
+        return visible_ds
+
+
     def get_scale(self):
         '''
         Returns the current zoom scale of this raster pane.  Even when a pane
@@ -953,6 +961,8 @@ class RasterPane(QWidget):
             stretches = self._app_state.get_stretches(ds_id, bands)
 
         rasterview.set_raster_data(dataset, bands, stretches)
+        if hasattr(self, "_link_view_scrolling"):
+            self.on_rasterview_dataset_changed()
 
 
     def is_showing_dataset(self, dataset) -> Optional[Tuple[int, int]]:
@@ -979,7 +989,6 @@ class RasterPane(QWidget):
                     return pos
 
         return None
-
 
     def set_display_bands(self, ds_id: int, bands: Tuple, colormap: Optional[str] = None):
         # TODO(donnie):  Verify the dataset ID?

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -616,6 +616,10 @@ class RasterPane(QWidget):
 
 
     def get_visible_datasets(self) -> List[RasterDataSet]:
+        '''
+        Returns all of the datasets that are displayed in all of the 
+        RasterViews under this RasterPane
+        '''
         visible_ds = []
         for rasterview in self._rasterviews.values():
             if rasterview._raster_data is not None:

--- a/src/wiser/gui/stretch_builder.py
+++ b/src/wiser/gui/stretch_builder.py
@@ -183,9 +183,6 @@ class ChannelStretchWidget(QWidget):
         #============================================================
         # User Interface Config:
 
-        self._ui.lineedit_stretch_low.setEnabled(False)
-        self._ui.lineedit_stretch_high.setEnabled(False)
-
         self._histogram_figure, self._histogram_axes = plt.subplots(constrained_layout=True)
         self._histogram_figure.set_constrained_layout_pads(w_pad=0, h_pad=0, wspace=0, hspace=0)
         self._histogram_axes.tick_params(direction='in', labelsize=4, pad=2, width=0.5,
@@ -360,7 +357,8 @@ class ChannelStretchWidget(QWidget):
         self._update_histogram()
 
     def enable_stretch_ui(self, enabled):
-        for w in [self._ui.slider_stretch_low, self._ui.slider_stretch_high]:
+        for w in [self._ui.slider_stretch_low, self._ui.slider_stretch_high,
+                  self._ui.lineedit_stretch_low, self._ui.lineedit_stretch_high]:
             w.setEnabled(enabled)
 
         self._draw_stretch_lines = enabled

--- a/src/wiser/gui/stretch_builder.py
+++ b/src/wiser/gui/stretch_builder.py
@@ -811,6 +811,8 @@ class StretchBuilderDialog(QDialog):
             # Fallback for <Qt 5.14
             screen_height = self.window().windowHandle().screen().size().height()
 
+        accept_rejection_region_height = 75
+        screen_height -= accept_rejection_region_height
         dialog_height = self.size().height()
         scroll_height = self._channels_scrollarea.size().height()
         channels_minheight = self._channels_scrollarea.widget().minimumSize().height()

--- a/src/wiser/gui/stretch_builder.py
+++ b/src/wiser/gui/stretch_builder.py
@@ -183,6 +183,9 @@ class ChannelStretchWidget(QWidget):
         #============================================================
         # User Interface Config:
 
+        self._ui.lineedit_stretch_low.setEnabled(False)
+        self._ui.lineedit_stretch_high.setEnabled(False)
+
         self._histogram_figure, self._histogram_axes = plt.subplots(constrained_layout=True)
         self._histogram_figure.set_constrained_layout_pads(w_pad=0, h_pad=0, wspace=0, hspace=0)
         self._histogram_axes.tick_params(direction='in', labelsize=4, pad=2, width=0.5,
@@ -378,8 +381,7 @@ class ChannelStretchWidget(QWidget):
         self._update_histogram()
 
     def enable_stretch_ui(self, enabled):
-        for w in [self._ui.slider_stretch_low, self._ui.slider_stretch_high,
-                  self._ui.lineedit_stretch_low, self._ui.lineedit_stretch_high]:
+        for w in [self._ui.slider_stretch_low, self._ui.slider_stretch_high]:
             w.setEnabled(enabled)
 
         self._draw_stretch_lines = enabled


### PR DESCRIPTION
When you link datasets, it should now let you link the datasets as long as all the datasets displayed have the same dimensions. 

This means you can have a dataset that is open but not displayed and it won't affect the linking between any of the displayed datasets. 

Tests:
- I tested opening a new dataset when the current datasets were linked. The new one was not compatible. It disables linking.
- I tested creating a new dataset with bandmath, if the new dataset is not compatible, it unlinks the datasets. 

Notes:
- The context menu can still display a dataset that is not of the correct dimensions. I don't think this is a big issue but if it is I can change it. 