### PR TITLE
Allows the line edit in channel stretch to change the stretch

### DIFF
--- a/src/wiser/gui/stretch_builder.py
+++ b/src/wiser/gui/stretch_builder.py
@@ -612,6 +612,7 @@ class ChannelStretchWidget(QWidget):
         try:
             stretch_low_value = float(stretch_low_text)
         except BaseException as e:
+            self._ui.lineedit_stretch_low.clearFocus()
             QMessageBox.critical(self, 
                                  "Invalid Input",
                                  "Stretch Low is not a valid float",
@@ -619,6 +620,7 @@ class ChannelStretchWidget(QWidget):
             return False
 
         if stretch_low_value < self._min_bound:
+            self._ui.lineedit_stretch_low.clearFocus()
             QMessageBox.critical(self, 
                                  "Invalid Input",
                                  "Stretch Low value can not be greater than the minimum bound",
@@ -626,6 +628,7 @@ class ChannelStretchWidget(QWidget):
             return False
 
         if stretch_low_value > self.norm_to_bounded_value(self._stretch_high):
+            self._ui.lineedit_stretch_low.clearFocus()
             QMessageBox.critical(self, 
                                  "Invalid Input",
                                  "Stretch Low value can not be greater than stretch high value",
@@ -652,6 +655,7 @@ class ChannelStretchWidget(QWidget):
         try:
             stretch_high_value = float(stretch_high_text)
         except BaseException as e:
+            self._ui.lineedit_stretch_high.clearFocus()
             QMessageBox.critical(self, 
                                 "Invalid Input",
                                 "Stretch High is not a valid float",
@@ -659,6 +663,7 @@ class ChannelStretchWidget(QWidget):
             return False
 
         if stretch_high_value > self._max_bound:
+            self._ui.lineedit_stretch_high.clearFocus()
             QMessageBox.critical(self, 
                                 "Invalid Input",
                                 "Stretch High value can not be greater than the maximum bound",
@@ -666,6 +671,7 @@ class ChannelStretchWidget(QWidget):
             return False
 
         if stretch_high_value < self.norm_to_bounded_value(self._stretch_low):
+            self._ui.lineedit_stretch_high.clearFocus()
             QMessageBox.critical(self, 
                                 "Invalid Input",
                                 "Stretch High value can not be less than stretch low value",

--- a/src/wiser/gui/stretch_builder.py
+++ b/src/wiser/gui/stretch_builder.py
@@ -609,33 +609,26 @@ class ChannelStretchWidget(QWidget):
             self._on_high_slider_changed()
     
     def validate_stretch_low_string(self, stretch_low_text):
-        if any(x.isalpha() for x in stretch_low_text):
-            QMessageBox.critical(self, 
-                                 "Invalid Input",
-                                 "Stretch low can't contain alphabetic characters",
-                                 QMessageBox.Ok)
-            return False
-
         try:
             stretch_low_value = float(stretch_low_text)
         except BaseException as e:
             QMessageBox.critical(self, 
                                  "Invalid Input",
-                                 "Stretch low is not a valid float",
+                                 "Stretch Low is not a valid float",
                                  QMessageBox.Ok)
             return False
 
         if stretch_low_value < self._min_bound:
             QMessageBox.critical(self, 
                                  "Invalid Input",
-                                 "Stretch low value can not be greater than the minimum bound",
+                                 "Stretch Low value can not be greater than the minimum bound",
                                  QMessageBox.Ok)
             return False
 
         if stretch_low_value > self.norm_to_bounded_value(self._stretch_high):
             QMessageBox.critical(self, 
                                  "Invalid Input",
-                                 "Stretch low value can not be greater than stretch high value",
+                                 "Stretch Low value can not be greater than stretch high value",
                                  QMessageBox.Ok)
             return False
 
@@ -656,40 +649,32 @@ class ChannelStretchWidget(QWidget):
         self._on_low_slider_changed()
 
     def validate_stretch_high_string(self, stretch_high_text):
-        if any(x.isalpha() for x in stretch_high_text):
-            QMessageBox.critical(self, 
-                                "Invalid Input",
-                                "Stretch high can't contain alphabetic characters",
-                                QMessageBox.Ok)
-            return False
-
         try:
             stretch_high_value = float(stretch_high_text)
         except BaseException as e:
             QMessageBox.critical(self, 
                                 "Invalid Input",
-                                "Stretch high is not a valid float",
+                                "Stretch High is not a valid float",
                                 QMessageBox.Ok)
             return False
 
         if stretch_high_value > self._max_bound:
             QMessageBox.critical(self, 
                                 "Invalid Input",
-                                "Stretch high value can not be greater than the maximum bound",
+                                "Stretch High value can not be greater than the maximum bound",
                                 QMessageBox.Ok)
             return False
 
         if stretch_high_value < self.norm_to_bounded_value(self._stretch_low):
             QMessageBox.critical(self, 
                                 "Invalid Input",
-                                "Stretch high value can not be less than stretch low value",
+                                "Stretch High value can not be less than stretch low value",
                                 QMessageBox.Ok)
             return False
 
         return True
 
     def _set_stretch_high_from_ledit(self):
-        # Get the text in the self._ui.lineedit_stretch_low
         stretch_high_text = self._ui.lineedit_stretch_high.text()
 
         # Check to make sure the string is valid


### PR DESCRIPTION
When a user clicks on the line edit, enters in a value, and presses enter, the line edit will cause the slider, histogram, and image stretch to change.

Tests:
- I tested by putting in characters that would make the text not a number. 
- I also tested to make sure that when you are not in the lineedit, the default functionality occurs when the user presses enter.