### PR TITLE
Fixed slow stretches for smaller band images on first stretch

### DIFF
--- a/src/wiser/gui/rasterview.py
+++ b/src/wiser/gui/rasterview.py
@@ -19,7 +19,7 @@ from wiser.raster.stretch import StretchBase
 
 from wiser.gui.app_state import ApplicationState
 
-from wiser.utils.numba_wrapper import numba_njit_wrapper
+from wiser.utils.numba_wrapper import numba_njit_wrapper, convert_to_float32_if_needed
 from wiser.raster.utils import ARRAY_NUMBA_THRESHOLD
 
 logger = logging.getLogger(__name__)
@@ -77,6 +77,7 @@ def make_channel_image(normalized_band: np.ndarray, stretch1: StretchBase = None
     if normalized_band.nbytes < ARRAY_NUMBA_THRESHOLD:
         return make_channel_image_python(normalized_band, stretch1, stretch2)
     else:
+        normalized_band = convert_to_float32_if_needed(normalized_band)
         return make_channel_image_numba(normalized_band, stretch1, stretch2)
 
 def check_channel(c):
@@ -203,6 +204,7 @@ def make_rgb_image(ch1: np.ndarray, ch2: np.ndarray, ch3: np.ndarray):
     if ch1.nbytes < ARRAY_NUMBA_THRESHOLD:
         return make_rgb_image_python(ch1, ch2, ch3)
     else:
+        ch1, ch2, ch3 = convert_to_float32_if_needed(ch1, ch2, ch3)
         return make_rgb_image_numba(ch1, ch2, ch3)
 
 

--- a/src/wiser/gui/stretch_builder.py
+++ b/src/wiser/gui/stretch_builder.py
@@ -30,40 +30,63 @@ def remove_nans_python(data):
 @numba_njit_wrapper(non_njit_func=remove_nans_python)
 def remove_nans_numba(data):
     """
-    Extracts non-NaN values from a 2D NumPy array and returns them as a 1D array.
+    Extracts non-NaN values from a 1D or 2D NumPy array and returns them as a 1D array.
 
-    Parameters:
+    Parameters
     ----------
-    norm_band_data : np.ndarray
-        A 2D NumPy array from which NaN values are to be removed.
+    data : np.ndarray
+        A 1D or 2D NumPy array from which NaN values are to be removed.
 
-    Returns:
+    Returns
     -------
     nonan_data : np.ndarray
-        A 1D NumPy array containing all non-NaN elements from `norm_band_data`.
+        A 1D NumPy array containing all non-NaN elements from `data`.
     """
-    rows, cols = data.shape
-    count = 0
-
-    # First pass: Count the number of non-NaN elements
-    for i in range(rows):
-        for j in range(cols):
-            if not np.isnan(data[i, j]):
+    # Handle 1D arrays
+    if data.ndim == 1:
+        n = data.shape[0]
+        count = 0
+        # First pass: count non-NaN elements
+        for i in range(n):
+            if not np.isnan(data[i]):
                 count += 1
 
-    # Allocate the output array with the exact size needed
-    nonan_data = np.empty(count, dtype=data.dtype)
-
-    # Second pass: Populate the nonan_data array with non-NaN elements
-    idx = 0
-    for i in range(rows):
-        for j in range(cols):
-            value = data[i, j]
-            if not np.isnan(value):
-                nonan_data[idx] = value
+        # Allocate the output array
+        nonan_data = np.empty(count, dtype=data.dtype)
+        idx = 0
+        # Second pass: store non-NaN elements
+        for i in range(n):
+            if not np.isnan(data[i]):
+                nonan_data[idx] = data[i]
                 idx += 1
 
-    return nonan_data
+        return nonan_data
+
+    # Handle 2D arrays
+    elif data.ndim == 2:
+        rows, cols = data.shape
+        count = 0
+        # First pass: count non-NaN elements
+        for i in range(rows):
+            for j in range(cols):
+                if not np.isnan(data[i, j]):
+                    count += 1
+
+        # Allocate the output array
+        nonan_data = np.empty(count, dtype=data.dtype)
+        idx = 0
+        # Second pass: store non-NaN elements
+        for i in range(rows):
+            for j in range(cols):
+                if not np.isnan(data[i, j]):
+                    nonan_data[idx] = data[i, j]
+                    idx += 1
+
+        return nonan_data
+
+    else:
+        # If the input is not 1D or 2D, we raise an error.
+        raise ValueError("Input array must be either 1D or 2D.")
 
 def remove_nans(data: np.ndarray) -> np.ndarray:
     if data.nbytes < ARRAY_NUMBA_THRESHOLD:

--- a/src/wiser/gui/stretch_builder.py
+++ b/src/wiser/gui/stretch_builder.py
@@ -10,7 +10,7 @@ from .generated.stretch_config_widget_ui import Ui_StretchConfigWidget
 from wiser.raster.dataset import RasterDataSet
 from wiser.raster.stretch import *
 from wiser.raster.utils import ARRAY_NUMBA_THRESHOLD
-from wiser.utils.numba_wrapper import numba_njit_wrapper
+from wiser.utils.numba_wrapper import numba_njit_wrapper, convert_to_float32_if_needed
 
 import numpy as np
 import numpy.ma as ma
@@ -92,6 +92,7 @@ def remove_nans(data: np.ndarray) -> np.ndarray:
     if data.nbytes < ARRAY_NUMBA_THRESHOLD:
         return remove_nans_python(data)
     else:
+        data = convert_to_float32_if_needed(data)
         return remove_nans_numba(data)
 
 def create_histogram_python(nonan_data: np.ndarray, min_bound, max_bound):
@@ -125,6 +126,7 @@ def create_histogram(nonan_data: np.ndarray, min_bound, max_bound) -> np.ndarray
     if nonan_data.nbytes < ARRAY_NUMBA_THRESHOLD:
         return create_histogram_python(nonan_data, min_bound, max_bound)
     else:
+        nonan_data, min_bound, max_bound = convert_to_float32_if_needed(nonan_data, min_bound, max_bound)
         return create_histogram_numba(nonan_data, min_bound, max_bound)
 
 def get_slider_percentage(slider, value=None):

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -228,7 +228,8 @@ class GDALRasterDataImpl(RasterDataImpl):
         return self.gdal_dataset.RasterCount
 
     def get_elem_type(self) -> np.dtype:
-        return gdal_array.GDALTypeCodeToNumericTypeCode(self.gdal_data_type)
+        elem_type = gdal_array.GDALTypeCodeToNumericTypeCode(int(self.gdal_data_type))
+        return np.dtype(elem_type)
 
     def get_image_data(self):
         '''

--- a/src/wiser/raster/utils.py
+++ b/src/wiser/raster/utils.py
@@ -246,6 +246,15 @@ def normalize_ndarray(arr: np.ndarray, minval=None, maxval=None) -> Union[None, 
     if arr.nbytes < ARRAY_NUMBA_THRESHOLD:
         return normalize_ndarray_python(array=arr, minval=minval, maxval=maxval)
     else:
+        if np.issubdtype(arr.dtype, np.floating):
+            if arr.dtype != np.float32:
+                arr = arr.astype(np.float32)
+        if isinstance(minval, np.number) and np.issubdtype(minval.dtype, np.floating):
+            if minval.dtype != np.float32:
+                minval = minval.astype(np.float32)
+        if isinstance(maxval, np.number) and np.issubdtype(maxval.dtype, np.floating):
+            if maxval.dtype != np.float32:
+                maxval = maxval.astype(np.float32)
         return normalize_ndarray_numba(arr, minval, maxval)
 
 

--- a/src/wiser/raster/utils.py
+++ b/src/wiser/raster/utils.py
@@ -5,7 +5,7 @@ from osgeo import gdal
 import numpy as np
 from astropy import units as u
 
-from wiser.utils.numba_wrapper import numba_njit_wrapper
+from wiser.utils.numba_wrapper import numba_njit_wrapper, convert_to_float32_if_needed
 
 ARRAY_NUMBA_THRESHOLD = 150000000 # 150 MB
 
@@ -246,15 +246,7 @@ def normalize_ndarray(arr: np.ndarray, minval=None, maxval=None) -> Union[None, 
     if arr.nbytes < ARRAY_NUMBA_THRESHOLD:
         return normalize_ndarray_python(array=arr, minval=minval, maxval=maxval)
     else:
-        if np.issubdtype(arr.dtype, np.floating):
-            if arr.dtype != np.float32:
-                arr = arr.astype(np.float32)
-        if isinstance(minval, np.number) and np.issubdtype(minval.dtype, np.floating):
-            if minval.dtype != np.float32:
-                minval = minval.astype(np.float32)
-        if isinstance(maxval, np.number) and np.issubdtype(maxval.dtype, np.floating):
-            if maxval.dtype != np.float32:
-                maxval = maxval.astype(np.float32)
+        arr, minval, maxval = convert_to_float32_if_needed(arr, minval, maxval)
         return normalize_ndarray_numba(arr, minval, maxval)
 
 

--- a/src/wiser/utils/numba_wrapper.py
+++ b/src/wiser/utils/numba_wrapper.py
@@ -109,3 +109,40 @@ def numba_jitclass_wrapper(numpy_spec, nonjit_class):
         else:
             return nonjit_class
     return decorator
+
+def convert_to_float32_if_needed(*args):
+    """
+    This function accepts a variable number of arguments. For each argument:
+      1. If it is NOT a NumPy array or a NumPy number, it is returned as is.
+      2. If it is a NumPy array or a NumPy number, check if its dtype/kind is float.
+         - If it's float but NOT float32, convert/cast it to float32.
+      3. Return all arguments in their original order, possibly with changed types.
+    This function is meant to ensure no float's get into numba that are not float32.
+    Numba also accepts float64, but we currently do not use float64.
+    """
+    result = []
+    for arg in args:
+        # Check if `arg` is a NumPy array or a NumPy scalar
+        if isinstance(arg, (np.ndarray, np.number)):
+
+            # If it's an array, check its dtype
+            if isinstance(arg, np.ndarray):
+                # Check if dtype is floating
+                if np.issubdtype(arg.dtype, np.floating):
+                    # If not float32, convert to float32
+                    if arg.dtype != np.float32:
+                        arg = arg.astype(np.float32)
+     
+            # If it's a NumPy scalar (np.number)
+            else:
+                # Check if the scalar is float-like
+                if np.issubdtype(arg.dtype, np.floating):
+                    # If not already float32, convert it
+                    if not isinstance(arg, np.float32):
+                        arg = np.float32(arg)
+
+        # Append the (possibly converted) argument to the result
+        result.append(arg)
+
+    # Return the new list of arguments
+    return result


### PR DESCRIPTION
The first time you pressed a stretch on a small band image, it would take a while (like 3-5 seconds).

Reason:
- This was because the stretch that was getting hashed in the cache was a numba class. This caused the whole class to be compiled which took the extra time.

Fix:
- To fix this I created a function to explicitly use a numba class vs a not numba class depending on the size of the band. 

Tests:
- I tested this with a small image that would not use numba (caltech image)
- I tested this with a large image that would use numba (1.5GB Gale HiRise Mosaic)

Extra fixes:
- This also has a fix for a numba bug that happened with arctan2 and uint8 images