### PR TITLE
Fixed bandmath not updating raster view due to cache

### DIFF
--- a/src/wiser/raster/dataset.py
+++ b/src/wiser/raster/dataset.py
@@ -745,7 +745,7 @@ class RasterDataSet:
         return False
 
     def __hash__(self):
-        return hash(tuple(self.get_filepaths()))
+        return self._id
 
     def __eq__(self, other) -> bool:
         if isinstance(other, RasterDataSet):


### PR DESCRIPTION
The bandmath output would not update in the rasterview due to the caching logic.

Fix:
- I fixed how datasets were cached to use the dataset id instead of the hash of the dataset file path