### PR TITLE
Fixing spectrum plot not being clickable for band math produced datasets

### DIFF
--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -645,11 +645,6 @@ class RasterDataSetSpectrum(Spectrum):
     def get_wavelength_units(self) -> Optional[u.Unit]:
         '''
         Gets the wavelength units.
-
-        TODO (Joshua G-K): We need to find a better way to expose this. We can't 
-        just use self._dataset.get_band_units() because this reads from dataset_impl.
-        If the dataset_impl is not a gdal dataset (for example if its a numpy dataset)
-        then it will automatically return none. Consider using self._dataset._band_info.
         '''
         return self.get_wavelengths()[0].unit
 

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -203,8 +203,6 @@ def calc_spectrum_fast(dataset: RasterDataSet, roi: RegionOfInterest,
         else:
             raise TypeError(f'Expected 2 or 3 dimensions in rectangular aray, but got {s.ndim}')
 
-    assert(len(spectra) == len(roi.get_all_pixels()), f'Length of spectra is: {len(spectra)} while length of roi all pixels is: {len(roi.get_all_pixels())}')
-
     if len(spectra) > 1:
         spectra = np.asarray(spectra)
         # Need to compute mean/median/... of the collection of spectra

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -643,10 +643,15 @@ class RasterDataSetSpectrum(Spectrum):
         return bands
     
     def get_wavelength_units(self) -> Optional[u.Unit]:
-        if self.has_wavelengths():
-            return self._dataset.get_band_unit()
+        '''
+        Gets the wavelength units.
 
-        return None
+        TODO (Joshua G-K): We need to find a better way to expose this. We can't 
+        just use self._dataset.get_band_units() because this reads from dataset_impl.
+        If the dataset_impl is not a gdal dataset (for example if its a numpy dataset)
+        then it will automatically return none. Consider using self._dataset._band_info.
+        '''
+        return self.get_wavelengths()[0].unit
 
     def _calculate_spectrum(self):
         '''


### PR DESCRIPTION
The issue was because the spectrum's units did not match up with the dataset's units. This caused incorrect logic in spectrum_plot and thus the error. 

The current solution is somewhat of a band aid solution. But be warned , we can't just use self._dataset.get_band_units() because this reads from dataset_impl. If the dataset_impl is not a gdal dataset (for example if its a numpy dataset) then it will automatically return none. Consider using self._dataset._band_info, as that is basically what the current solution uses. 