### PR TITLE
Fix spectrum plot displaying spectra from closed dataset & dataset chooser check marks

### DIFF
--- a/src/wiser/gui/dataset_chooser.py
+++ b/src/wiser/gui/dataset_chooser.py
@@ -116,7 +116,6 @@ class DatasetChooser(QToolButton):
 
         for act in self._dataset_menu.actions():
             act_ds_id = act.data()[1]
-            # print(f"act_ds_id: {act_ds_id}")
             if act_ds_id == ds_id:
                 act.setChecked(True)
 

--- a/src/wiser/gui/dataset_chooser.py
+++ b/src/wiser/gui/dataset_chooser.py
@@ -82,7 +82,6 @@ class DatasetChooser(QToolButton):
 
 
     def _add_dataset_menu_items(self, menu: QMenu, rasterview_pos=(0, 0)):
-        print(f"Basic dataset chooser menu items")
         # Find the action that is currently selected (if any)
         current_data = None
         for act in menu.actions():
@@ -120,7 +119,7 @@ class DatasetChooser(QToolButton):
             # print(f"act_ds_id: {act_ds_id}")
             if act_ds_id == ds_id:
                 act.setChecked(True)
-    
+
     def _uncheck_all(self, menu: QMenu):
         for act in menu.actions():
             act.setChecked(False)

--- a/src/wiser/gui/dataset_chooser.py
+++ b/src/wiser/gui/dataset_chooser.py
@@ -58,9 +58,6 @@ class DatasetChooser(QToolButton):
         current list of datasets in the application state.
         '''
 
-        # Remove all existing actions
-        self._dataset_menu.clear()
-
         if self._rasterpane is not None:
             num_views = self._rasterpane.get_num_views()
         else:
@@ -84,12 +81,15 @@ class DatasetChooser(QToolButton):
             self._add_dataset_menu_items(self._dataset_menu)
 
 
-    def _add_dataset_menu_items(self, menu, rasterview_pos=(0, 0)):
+    def _add_dataset_menu_items(self, menu: QMenu, rasterview_pos=(0, 0)):
         # Find the action that is currently selected (if any)
         current_data = None
         for act in menu.actions():
             if act.isChecked():
                 current_data = act.data()
+
+        # Remove all existing actions
+        menu.clear()
 
         # Add an action for each dataset
         for dataset in self._app_state.get_datasets():

--- a/src/wiser/gui/dataset_chooser.py
+++ b/src/wiser/gui/dataset_chooser.py
@@ -82,6 +82,7 @@ class DatasetChooser(QToolButton):
 
 
     def _add_dataset_menu_items(self, menu: QMenu, rasterview_pos=(0, 0)):
+        print(f"Basic dataset chooser menu items")
         # Find the action that is currently selected (if any)
         current_data = None
         for act in menu.actions():
@@ -103,6 +104,26 @@ class DatasetChooser(QToolButton):
 
             menu.addAction(act)
 
+    def check_dataset(self, ds_id: int):
+        '''
+        Checks the desired dataset in the dataset chooser. This
+        function should only be called if the num views is (1, 1).
+        '''
+        if self._rasterpane.get_num_views() != (1, 1):
+            raise ValueError(f"The function check_dataset should only be called when raster " +
+                             f"pane has one view")
+
+        self._uncheck_all(self._dataset_menu)
+
+        for act in self._dataset_menu.actions():
+            act_ds_id = act.data()[1]
+            # print(f"act_ds_id: {act_ds_id}")
+            if act_ds_id == ds_id:
+                act.setChecked(True)
+    
+    def _uncheck_all(self, menu: QMenu):
+        for act in menu.actions():
+            act.setChecked(False)
 
     def _on_dataset_changed(self, act: QAction):
         '''

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -969,6 +969,8 @@ class RasterPane(QWidget):
         Sets the dataset being displayed in the specified view of the raster
         pane.
         '''
+        # TODO (Joshua G-K) Have this update what has a checked mark. 
+
         rasterview = self.get_rasterview(rasterview_pos)
 
         # If the rasterview is already showing the specified dataset, skip!
@@ -983,6 +985,10 @@ class RasterPane(QWidget):
             stretches = self._app_state.get_stretches(ds_id, bands)
 
         rasterview.set_raster_data(dataset, bands, stretches)
+        if dataset is not None and self._num_views == (1, 1):
+            self._dataset_chooser.check_dataset(dataset.get_id())
+
+        # This is a check to see if this is MainView
         if hasattr(self, "_link_view_scrolling"):
             self.on_rasterview_dataset_changed()
 

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -969,8 +969,6 @@ class RasterPane(QWidget):
         Sets the dataset being displayed in the specified view of the raster
         pane.
         '''
-        # TODO (Joshua G-K) Have this update what has a checked mark. 
-
         rasterview = self.get_rasterview(rasterview_pos)
 
         # If the rasterview is already showing the specified dataset, skip!
@@ -988,7 +986,7 @@ class RasterPane(QWidget):
         if dataset is not None and self._num_views == (1, 1):
             self._dataset_chooser.check_dataset(dataset.get_id())
 
-        # This is a check to see if this is MainView
+        # This is a check to see if this rasterpane is MainView
         if hasattr(self, "_link_view_scrolling"):
             self.on_rasterview_dataset_changed()
 

--- a/src/wiser/gui/spectrum_plot.py
+++ b/src/wiser/gui/spectrum_plot.py
@@ -352,7 +352,7 @@ class SpectrumPlotDatasetChooser(DatasetChooser):
         option.
         '''
 
-        # Find the action that is currently selected (if any) 
+        # Find the action that is currently selected (if any)
         current_data = None
         for act in self._dataset_menu.actions():
             if act.isChecked():

--- a/src/wiser/gui/spectrum_plot.py
+++ b/src/wiser/gui/spectrum_plot.py
@@ -352,16 +352,19 @@ class SpectrumPlotDatasetChooser(DatasetChooser):
         option.
         '''
 
-        # Find the action that is currently selected (if any)
+        # Find the action that is currently selected (if any) 
         current_data = None
         for act in self._dataset_menu.actions():
             if act.isChecked():
                 current_data = act.data()
 
-        act = menu.addAction(self.tr('Use clicked dataset'))
-        act.setCheckable(True)
-        act.setChecked(True)
-        act.setData( (None, -1) )
+        # Remove all existing actions
+        menu.clear()
+
+        actDefault: QAction = menu.addAction(self.tr('Use clicked dataset'))
+        actDefault.setCheckable(True)
+        actDefault.setChecked(True)
+        actDefault.setData( (None, -1) )
 
         menu.addSeparator()
 
@@ -374,6 +377,7 @@ class SpectrumPlotDatasetChooser(DatasetChooser):
             act.setData(act_data)
             if act_data == current_data:
                 act.setChecked(True)
+                actDefault.setChecked(False)
 
             menu.addAction(act)
 
@@ -841,10 +845,25 @@ class SpectrumPlot(QWidget):
             self._dataset = None
     
     def _on_dataset_removed(self, ds_id):
-        current_ds_id = self._dataset.get_id()
+        if self._dataset:
+            current_ds_id = self._dataset.get_id()
 
-        if current_ds_id == ds_id:
-            self._dataset = None
+            if current_ds_id == ds_id:
+                self._dataset = None
+        
+        # # Because the SpectrumPlotDatasetChooser resets itself every time
+        # # a dataset is removed, we have to set it to the correct dataset
+        # current_ds_id = self._dataset.get_id() if self._dataset is not None else -1
+        # print(f"current_ds_id: {current_ds_id}")
+        # for act in self._dataset_chooser._dataset_menu.actions():
+        #     act_ds_id = act.data()[1]
+        #     print(f"act_ds_id: {act_ds_id}")
+        #     if act_ds_id == current_ds_id:
+        #         act.setChecked(True)
+            
+
+
+
 
     def get_spectrum_dataset(self) -> Optional[RasterDataSet]:
         return self._dataset

--- a/src/wiser/gui/spectrum_plot.py
+++ b/src/wiser/gui/spectrum_plot.py
@@ -850,20 +850,6 @@ class SpectrumPlot(QWidget):
 
             if current_ds_id == ds_id:
                 self._dataset = None
-        
-        # # Because the SpectrumPlotDatasetChooser resets itself every time
-        # # a dataset is removed, we have to set it to the correct dataset
-        # current_ds_id = self._dataset.get_id() if self._dataset is not None else -1
-        # print(f"current_ds_id: {current_ds_id}")
-        # for act in self._dataset_chooser._dataset_menu.actions():
-        #     act_ds_id = act.data()[1]
-        #     print(f"act_ds_id: {act_ds_id}")
-        #     if act_ds_id == current_ds_id:
-        #         act.setChecked(True)
-            
-
-
-
 
     def get_spectrum_dataset(self) -> Optional[RasterDataSet]:
         return self._dataset

--- a/src/wiser/gui/spectrum_plot.py
+++ b/src/wiser/gui/spectrum_plot.py
@@ -413,7 +413,7 @@ class SpectrumPlot(QWidget):
         # General configuration for the spectrum plot
 
         # What dataset are we showing spectra from on new mouse-clicks?
-        self._dataset = None
+        self._dataset: RasterDataSet = None
 
         # Are we displaying a legend?
         self._legend_location: LegendPlacement = LegendPlacement.NO_LEGEND
@@ -477,6 +477,8 @@ class SpectrumPlot(QWidget):
 
         self._app_state.spectral_library_added.connect(self._on_spectral_library_added)
         self._app_state.spectral_library_removed.connect(self._on_spectral_library_removed)
+
+        self._app_state.dataset_removed.connect(self._on_dataset_removed)
 
 
     def _init_ui(self):
@@ -837,7 +839,12 @@ class SpectrumPlot(QWidget):
             self._dataset = self._app_state.get_dataset(ds_id)
         else:
             self._dataset = None
+    
+    def _on_dataset_removed(self, ds_id):
+        current_ds_id = self._dataset.get_id()
 
+        if current_ds_id == ds_id:
+            self._dataset = None
 
     def get_spectrum_dataset(self) -> Optional[RasterDataSet]:
         return self._dataset


### PR DESCRIPTION
As the title says, there two bugs. The first bug was that if you closed a dataset that you had chosen in the spectrum plot, the spectrum plot would still pull from that closed dataset but say it was "Using clicked dataset". 

I made it so the dataset it pulls from updates properly and the checked mark updates properly.

When solving this bug, I found another bug where the checked marks for dataset choosers would not update if a raster pane's displayed dataset was changed in a way where dataset chooser was not clicked. I fixed this too.