### PR TITLE
Fix the spectrum builder caching when state is linked

### DIFF
--- a/src/wiser/gui/stretch_builder.py
+++ b/src/wiser/gui/stretch_builder.py
@@ -835,7 +835,6 @@ class StretchBuilderDialog(QDialog):
 
         self._enable_stretch_changed_events = True
 
-        print(f"reseting stretch builder!!")
         self._existing_stretch_min_max_state = {}
 
         self._existing_slider_link_state = {}
@@ -1071,8 +1070,6 @@ class StretchBuilderDialog(QDialog):
     def _on_link_sliders(self, checked):
         self._link_sliders = checked
         key = self._get_key_from_all_channels()
-        print(f"_on_link_sliders, key: {key}")
-        print(f"_on_link_sliders, checked: {checked}")
         self._existing_slider_link_state[key] = checked
         # If the "link sliders" option was checked, update all the sliders to
         # match.
@@ -1282,7 +1279,6 @@ class StretchBuilderDialog(QDialog):
             else:
                 self._cb_link_sliders.setChecked(False)
                 self._on_link_sliders(False)
-
             
             link_min_max_check = self._existing_min_max_link_state.get(key, None)
             if link_min_max_check is not None:

--- a/src/wiser/gui/stretch_builder.py
+++ b/src/wiser/gui/stretch_builder.py
@@ -1276,7 +1276,7 @@ class StretchBuilderDialog(QDialog):
             if link_slider_check is not None:
                 self._cb_link_sliders.setChecked(link_slider_check)
                 self._on_link_sliders(link_slider_check)
-            else:
+            else:  # If it is None, then it hasn't been set and so we should set it to unchecked (False)
                 self._cb_link_sliders.setChecked(False)
                 self._on_link_sliders(False)
             

--- a/src/wiser/gui/stretch_builder.py
+++ b/src/wiser/gui/stretch_builder.py
@@ -835,6 +835,7 @@ class StretchBuilderDialog(QDialog):
 
         self._enable_stretch_changed_events = True
 
+        print(f"reseting stretch builder!!")
         self._existing_stretch_min_max_state = {}
 
         layout = QGridLayout()
@@ -1149,7 +1150,7 @@ class StretchBuilderDialog(QDialog):
             for c in self._channel_widgets:
                 if c.get_channel_no() != channel_no:
                     c.set_min_max_bounds(min_bound, max_bound)
-                key = (channel_no, c.get_dataset_id(), c.get_band_index())
+                key = (c.get_channel_no(), c.get_dataset_id(), c.get_band_index())
                 self._existing_stretch_min_max_state[key] = (min_bound, max_bound)
         else:
             channel_widget = self._channel_widgets[channel_no]


### PR DESCRIPTION
This fixes the spectrum builder caching when state is linked between channel stretches. 

There was a bug where the min and max values weren't being properly cached if they were changed when the stretches were linked.

Also, the min max link state and the slider link state weren't properly saved for different channel stretches.