### PR TITLE
Fix highlight box logic

### DIFF
--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -581,7 +581,6 @@ class WiserTestModel:
         rv = self.get_main_view_rv(rv_pos)
         ds_id = rv.get_raster_data().get_id()
         return self.main_view._get_compatible_highlights(ds_id)
-        # return self.main_view._viewport_highlight.get(ds_id, None)
 
     def is_main_view_linked(self):
         return self.main_view._link_view_scrolling

--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -404,17 +404,35 @@ class WiserTestModel:
         Sets the zoom pane's zoom level. Scale should non-negative
         and non-zero. The zoom level will show up as {scale*100}%
         '''
-        if scale <= 0:
-            return
-        rv = self.get_zoom_pane_rasterview()
-        rv._scale_factor = scale+1
-        self.zoom_pane._on_zoom_in(None)
+        def func():
+            if scale <= 0:
+                return
+            rv = self.get_zoom_pane_rasterview()
+            rv._scale_factor = scale+1
+            self.zoom_pane._on_zoom_in(None)
+
+        function_event = FunctionEvent(func)
+
+        self.app.postEvent(self.testing_widget, function_event)
+        self.run()
 
     def click_zoom_pane_zoom_in(self):
-        self.zoom_pane._act_zoom_in.trigger()
+        def func():
+            self.zoom_pane._act_zoom_in.trigger()
+
+        function_event = FunctionEvent(func)
+
+        self.app.postEvent(self.testing_widget, function_event)
+        self.run()
     
     def click_zoom_pane_zoom_out(self):
-        self.zoom_pane._act_zoom_out.trigger()
+        def func():
+            self.zoom_pane._act_zoom_out.trigger()
+
+        function_event = FunctionEvent(func)
+
+        self.app.postEvent(self.testing_widget, function_event)
+        self.run()
 
 
     #==========================================
@@ -597,13 +615,25 @@ class WiserTestModel:
         return self.main_view._link_view_scrolling
     
     def click_main_view_zoom_in(self):
-        self.main_view._act_zoom_in.trigger()
+        def func():
+            self.main_view._act_zoom_in.trigger()
+
+        function_event = FunctionEvent(func)
+
+        self.app.postEvent(self.testing_widget, function_event)
+        self.run()
     
     def click_main_view_zoom_out(self):
-        self.main_view._act_zoom_out.trigger()
+        def func():
+            self.main_view._act_zoom_out.trigger()
+
+        function_event = FunctionEvent(func)
+
+        self.app.postEvent(self.testing_widget, function_event)
+        self.run()
     
     def scroll_main_view_rv(self, rv_pos: Tuple[int, int], dx: int, dy: int):
-        
+
         def scroll():
             rv = self.get_main_view_rv(rv_pos)
             scroll_area =  rv._scroll_area

--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -580,7 +580,8 @@ class WiserTestModel:
     def get_main_view_highlight_region(self, rv_pos: Tuple[int, int]):
         rv = self.get_main_view_rv(rv_pos)
         ds_id = rv.get_raster_data().get_id()
-        return self.main_view._viewport_highlight[ds_id]
+        return self.main_view._get_compatible_highlights(ds_id)
+        # return self.main_view._viewport_highlight.get(ds_id, None)
 
     def is_main_view_linked(self):
         return self.main_view._link_view_scrolling

--- a/src/tests/test_context_pane_main_view_integ.py
+++ b/src/tests/test_context_pane_main_view_integ.py
@@ -12,6 +12,8 @@ from PySide2.QtCore import *
 from PySide2.QtGui import *
 from PySide2.QtWidgets import *
 
+from .utils import are_pixels_close, are_qrects_close
+
 class TestContextPaneMainViewIntegration(unittest.TestCase):
 
     def setUp(self):
@@ -133,6 +135,56 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
         mv_region = self.test_model.get_main_view_rv_visible_region((0, 0))
 
         self.assertTrue(cp_highlight == mv_region)
+
+    def test_cp_highlight_box(self):
+        '''
+        Ensures that the context pane's compatible highlights is
+        just the dataset shown in the context pane
+        '''
+        # Create first array
+        rows, cols, channels = 75, 75, 3
+        # Create a vertical gradient from 0 to 1: shape (50,1)
+        row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+        # Tile the values horizontally to get a 50x50 array
+        impl = np.tile(row_values, (1, cols))
+        # Repeat the 2D array across 3 channels to get a 3x50x50 array
+        np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+        # Create second array
+        # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+        row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+        impl2 = np.tile(row_values, (1, cols))
+        np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
+
+        # Create third array
+        # Start with an array of zeros (50x1)
+        row_values = np.zeros((rows, 1))
+        # Choose the row index corresponding to 75% of the height.
+        nonzero_index = int(0.75 * (rows - 1))
+        row_values[nonzero_index] = 0.75
+        impl3 = np.tile(row_values, (1, cols))
+        np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+
+        self.test_model.set_main_view_layout((2, 2))
+
+        ds1 = self.test_model.load_dataset(np_impl)
+        ds2 = self.test_model.load_dataset(np_impl2)
+        ds3 = self.test_model.load_dataset(np_impl3)
+
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+
+        self.test_model.set_context_pane_dataset(ds1.get_id())
+
+        visible_region_00 = self.test_model.get_main_view_rv_visible_region((0, 0))
+        highlight_region = self.test_model.context_pane._get_compatible_highlights(ds1.get_id())[0]
+
+        # For an unknown reason, when I run this test inside of pytest and outside,
+        # I get two different results. Outside of pytests the below regions are the same, but
+        # in pytest, one of the values is off by 6, hence epsilon=6
+        self.assertTrue(are_qrects_close(highlight_region, visible_region_00, epsilon=6))
 
 if __name__ == '__main__':
     '''

--- a/src/tests/test_main_view_zoom_pane_integ.py
+++ b/src/tests/test_main_view_zoom_pane_integ.py
@@ -311,8 +311,8 @@ class TestMainViewZoomPaneIntegration(unittest.TestCase):
 
     def test_linked_highlight_box(self):
         '''
-        Ensures that when raster views aren't linked, the highlight box
-        only shows up in the rasterview's with the correct dataset
+        Ensures that when raster views are linked, the highlight box
+        shows up in all the rasterview's with the compatible dataset
         '''
         # Create first array
         rows, cols, channels = 75, 75, 3

--- a/src/tests/test_main_view_zoom_pane_integ.py
+++ b/src/tests/test_main_view_zoom_pane_integ.py
@@ -224,8 +224,6 @@ class TestMainViewZoomPaneIntegration(unittest.TestCase):
         center_pixel_mv = self.test_model.get_main_view_rv_center_raster_coord((0, 0))
 
         self.assertTrue(self.are_pixels_close(center_pixel_mv, center_pixel_zp))
-    
-    
 
     def test_scroll_zp_move_mv(self):
         '''
@@ -277,12 +275,117 @@ class TestMainViewZoomPaneIntegration(unittest.TestCase):
 
         self.assertTrue(self.are_pixels_close(center_pixel_zp, center_pixel_mv))
 
+    def test_not_linked_highlight_box(self):
+        '''
+        Ensures that when raster views aren't linked, the highlight box
+        only shows up in the rasterview's with the correct dataset
+        '''
+        # Create first array
+        rows, cols, channels = 75, 75, 3
+        # Create a vertical gradient from 0 to 1: shape (50,1)
+        row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+        # Tile the values horizontally to get a 50x50 array
+        impl = np.tile(row_values, (1, cols))
+        # Repeat the 2D array across 3 channels to get a 3x50x50 array
+        np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+        # Create second array
+        # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+        row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+        impl2 = np.tile(row_values, (1, cols))
+        np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
+
+        # Create third array
+        # Start with an array of zeros (50x1)
+        row_values = np.zeros((rows, 1))
+        # Choose the row index corresponding to 75% of the height.
+        nonzero_index = int(0.75 * (rows - 1))
+        row_values[nonzero_index] = 0.75
+        impl3 = np.tile(row_values, (1, cols))
+        np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+
+        self.test_model.set_main_view_layout((2, 2))
+
+        ds1 = self.test_model.load_dataset(np_impl)
+        ds2 = self.test_model.load_dataset(np_impl2)
+        ds3 = self.test_model.load_dataset(np_impl3)
+
+        self.test_model.click_zoom_pane_display_toggle()
+
+        self.test_model.set_zoom_pane_dataset(ds1.get_id())
+
+        self.test_model.set_zoom_pane_zoom_level(6)
+
+        rv_00_region = self.test_model.get_main_view_highlight_region((0, 0))[0]
+        rv_01_region = self.test_model.get_main_view_highlight_region((0, 1))
+        rv_10_region = self.test_model.get_main_view_highlight_region((1, 0))
+
+        zp_region = self.test_model.get_zoom_pane_visible_region()
+
+        self.assertTrue(zp_region == rv_00_region)
+        self.assertTrue(rv_01_region == None)
+        self.assertTrue(rv_10_region == None)
+
+    def test_linked_highlight_box(self):
+        '''
+        Ensures that when raster views aren't linked, the highlight box
+        only shows up in the rasterview's with the correct dataset
+        '''
+        # Create first array
+        rows, cols, channels = 75, 75, 3
+        # Create a vertical gradient from 0 to 1: shape (50,1)
+        row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+        # Tile the values horizontally to get a 50x50 array
+        impl = np.tile(row_values, (1, cols))
+        # Repeat the 2D array across 3 channels to get a 3x50x50 array
+        np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+        # Create second array
+        # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+        row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+        impl2 = np.tile(row_values, (1, cols))
+        np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
+
+        # Create third array
+        # Start with an array of zeros (50x1)
+        row_values = np.zeros((rows, 1))
+        # Choose the row index corresponding to 75% of the height.
+        nonzero_index = int(0.75 * (rows - 1))
+        row_values[nonzero_index] = 0.75
+        impl3 = np.tile(row_values, (1, cols))
+        np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+
+        self.test_model.set_main_view_layout((2, 2))
+
+        ds1 = self.test_model.load_dataset(np_impl)
+        ds2 = self.test_model.load_dataset(np_impl2)
+        ds3 = self.test_model.load_dataset(np_impl3)
+
+        self.test_model.click_zoom_pane_display_toggle()
+
+        self.test_model.click_link_button()
+
+        self.test_model.set_zoom_pane_dataset(ds1.get_id())
+
+        self.test_model.set_zoom_pane_zoom_level(6)
+
+        rv_00_region = self.test_model.get_main_view_highlight_region((0, 0))[0]
+        rv_01_region = self.test_model.get_main_view_highlight_region((0, 1))[0]
+        rv_10_region = self.test_model.get_main_view_highlight_region((1, 0))[0]
+
+        zp_region = self.test_model.get_zoom_pane_visible_region()
+
+        self.assertTrue(zp_region == rv_00_region)
+        self.assertTrue(zp_region == rv_01_region)
+        self.assertTrue(zp_region == rv_10_region)
+
+
 
 if __name__ == '__main__':
     test_model = WiserTestModel(use_gui=True)
 
     # Create first array
-    rows, cols, channels = 100, 100, 3
+    rows, cols, channels = 75, 75, 3
     # Create a vertical gradient from 0 to 1: shape (50,1)
     row_values = np.linspace(0, 1, rows).reshape(rows, 1)
     # Tile the values horizontally to get a 50x50 array
@@ -290,42 +393,43 @@ if __name__ == '__main__':
     # Repeat the 2D array across 3 channels to get a 3x50x50 array
     np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
 
+    # Create second array
+    # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+    row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+    impl2 = np.tile(row_values, (1, cols))
+    np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
 
-    test_model.load_dataset(np_impl)
+    # Create third array
+    # Start with an array of zeros (50x1)
+    row_values = np.zeros((rows, 1))
+    # Choose the row index corresponding to 75% of the height.
+    nonzero_index = int(0.75 * (rows - 1))
+    row_values[nonzero_index] = 0.75
+    impl3 = np.tile(row_values, (1, cols))
+    np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
 
-    # Get the main view and zoom pane in a position where the main view
-    # would have to snap to the zoom pane when zoom pane is clicked
+    test_model.set_main_view_layout((2, 2))
+
+    ds1 = test_model.load_dataset(np_impl)
+    ds2 = test_model.load_dataset(np_impl2)
+    ds3 = test_model.load_dataset(np_impl3)
+
     test_model.click_zoom_pane_display_toggle()
-    test_model.set_zoom_pane_zoom_level(4)
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
 
-    # # Make mainview scroll to top left
-    # test_model.scroll_main_view_rv_dx((0,0), 1000)
-    # test_model.scroll_main_view_rv_dx((0,0), 1000)
-    # test_model.scroll_main_view_rv_dy((0,0), 1000)
-    # test_model.scroll_main_view_rv_dy((0,0), 1000)
+    test_model.click_link_button()
 
-    # test_model.scroll_zoom_pane_dx(-1000)
+    test_model.set_zoom_pane_dataset(ds1.get_id())
 
-    test_model.scroll_main_view_rv((0,0), 500, 500)
+    test_model.set_zoom_pane_zoom_level(6)
 
-    # Ensure the visible regions overlap
-    mv_region = test_model.get_main_view_rv_visible_region((0, 0))
+    rv_00_region = test_model.get_main_view_highlight_region((0, 0))[0]
+    rv_01_region = test_model.get_main_view_highlight_region((0, 1))[0]
+    rv_10_region = test_model.get_main_view_highlight_region((1, 0))[0]
     zp_region = test_model.get_zoom_pane_visible_region()
 
-    center_pixel_zp = test_model.get_zoom_pane_center_raster_point()
-    center_pixel_mv = test_model.get_main_view_rv_center_raster_coord((0, 0))
-
-    print(f"center_pixel_zp: {center_pixel_zp}!")
-    print(f"center_pixel_mv: {center_pixel_mv}!")
+    print(f"zp_region: {zp_region}")
+    print(f"rv_00_region: {rv_00_region}")
+    print(f"rv_01_region: {rv_01_region}")
+    print(f"rv_10_region: {rv_10_region}")
 
     test_model.app.exec_()

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -1,0 +1,51 @@
+
+from PySide2.QtCore import *
+from PySide2.QtGui import *
+from PySide2.QtWidgets import *
+
+def are_pixels_close(pixel1, pixel2) -> bool:
+        '''
+        Helper functions to determine if two pixels are close. Used for when scrolling
+        in zoom pane and center's don't exactly align.
+        '''
+        if isinstance(pixel1, (QPoint, QPointF)):
+            pixel1 = (pixel1.x(), pixel1.y())
+
+        if isinstance(pixel2, (QPoint, QPointF)):
+            pixel2 = (pixel2.x(), pixel2.y())
+
+        pixel1_diff = abs(pixel1[0]-pixel1[1])
+        pixel2_diff = abs(pixel2[0]-pixel2[1])
+
+        diff_similar = abs(pixel1_diff - pixel2_diff) <= 2 
+
+        epsilon = 2
+        return abs(pixel1[0]-pixel2[0]) <= epsilon and diff_similar
+
+def are_qrects_close(qrect1: QRect, qrect2: QRect, epsilon=2) -> bool:
+    '''
+    Helper functions to determine if two qrects are close. Used for when scrolling
+    in zoom pane and center's don't exactly align. Not exact alignment seems to
+    occur when we enter the event loop.
+    '''
+    top_left_1 = qrect1.topLeft()
+    top_left_1 = (top_left_1.x(), top_left_1.y())
+
+    width_1 = qrect1.width()
+    height_1 = qrect1.height()
+
+    top_left_2 = qrect2.topLeft()
+    top_left_2 = (top_left_2.x(), top_left_2.y())
+
+    width_2 = qrect2.width()
+    height_2 = qrect2.height()
+
+    width_diff = abs(width_1-width_2)
+    height_diff = abs(height_1-height_2)
+
+    diff_similar = abs(width_diff-height_diff) <= epsilon
+
+    return top_left_1 == top_left_2 \
+        and diff_similar \
+        and width_diff <= epsilon \
+        and height_diff <= epsilon

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import traceback
-from typing import Union, Dict, List
+from typing import Union, Dict, List, Optional
 
 from PySide2.QtCore import *
 from PySide2.QtGui import *
@@ -486,7 +486,7 @@ class MainViewWidget(RasterPane):
             assert(len(list(self._viewport_highlight.values())) == 1), "self._viewport_highlight has more than 1 entry"
         super()._draw_viewport_highlight(rasterview, widget, paint_event)
 
-    def _get_compatible_highlights(self, ds_id) -> List[Union[QRect, QRectF]]:
+    def _get_compatible_highlights(self, ds_id) -> Optional[List[Union[QRect, QRectF]]]:
         """
         Retrieves a list of highlight regions (QRect or QRectF) that are compatible
         with the given dataset based on its link state with other datasets.
@@ -501,6 +501,9 @@ class MainViewWidget(RasterPane):
         Raises:
             ValueError: If an unexpected GeographicLinkState is encountered.
         """
+        if self._viewport_highlight is None:
+            return None
+
         if self._link_view_scrolling:
             target_ds = self._app_state.get_dataset(ds_id)
             compatible_highlights = []

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -390,6 +390,8 @@ class MainViewWidget(RasterPane):
         '''
         sb_state = rasterview.get_scrollbar_state()
         center_screen = rasterview.get_visible_region_center()
+        if sb_state or center_screen is None:
+            return
         link_state = self._link_view_state
         if len(self._rasterviews) > 1 and self._link_view_scrolling:
             for rv in self._rasterviews.values():

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -352,18 +352,16 @@ class MainViewWidget(RasterPane):
 
             self._act_link_view_scroll.setChecked(False)
             return
-        print(f"_on_link_view_scroll")
+
         # If we got here, we can link or unlink view scrolling.
         self._link_view_scrolling = checked
         self._link_view_state = link_type
         if checked:
-            print(f"checked!")
             self._app_state.show_status_text(self.tr('Linked view scrolling is ON'), 5)
 
             # Sync scroll state of all raster views to the one in the top left.
             self._sync_scroll_state(self.get_rasterview())
         else:
-            print(f"not checked!")
             self._app_state.show_status_text(self.tr('Linked view scrolling is OFF'), 5)
             for rv in self._rasterviews.values():
                 rv.update()
@@ -395,16 +393,12 @@ class MainViewWidget(RasterPane):
         sb_state = rasterview.get_scrollbar_state()
         center_screen = rasterview.get_visible_region_center()
         if sb_state is None or center_screen is None:
-            print(f"sb_state: {sb_state}, center_screen: {center_screen}")
             return
         link_state = self._link_view_state
-        print(f"about to if statement")
         if len(self._rasterviews) > 1 and self._link_view_scrolling:
             for rv in self._rasterviews.values():
-                print(f"sync scroll state for loop")
                 # Skip the rasterview that generated the scroll event
                 if rv is rasterview:
-                    print(f"continuing")
                     continue
 
                 # Even if we do not have to move the rv to make the point visible or scroll
@@ -412,16 +406,13 @@ class MainViewWidget(RasterPane):
                 rv.update()
                 # If we are linkinging by pixel, we simply do so
                 if link_state == GeographicLinkState.PIXEL:
-                    print(f"setting scroll bar state")
                     rv.set_scrollbar_state(sb_state)
                 # Now we are linking by spatial reference system
                 elif link_state == GeographicLinkState.SPATIAL:
                     ds = rv.get_raster_data()
                     if ds is None:
-                        print(f"ds is None")
                         continue
-                    
-                    print(f"making point visible")
+
                     x = center_screen[0]
                     y = center_screen[1]
                     rv.make_point_visible(x, y, margin=0.5, reference_rasterview=rasterview)

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -363,6 +363,8 @@ class MainViewWidget(RasterPane):
             self._sync_scroll_state(self.get_rasterview())
         else:
             self._app_state.show_status_text(self.tr('Linked view scrolling is OFF'), 5)
+            # We want this to updatethe main view raster view's highlight box, so the linked
+            # highlight boxes go away when we stop linking
             for rv in self._rasterviews.values():
                 rv.update()
 
@@ -473,7 +475,8 @@ class MainViewWidget(RasterPane):
                         center = viewport.center()
                         rv.make_point_visible(center.x(), center.y(), reference_rasterview=rasterview)
 
-                # Repaint raster-view
+                # Repaint raster-view. We always repaint to account
+                # for highlight boxes that may have been switched off
                 rv.update()
 
     def _draw_viewport_highlight(self, rasterview, widget, paint_event):

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -1814,7 +1814,8 @@ class RasterPane(QWidget):
     def _get_compatible_highlights(self, ds_id) -> List[Union[QRect, QRectF]]:
         """
         Retrieves a list of highlight regions (QRect or QRectF) that are compatible 
-        with the given dataset based on its link state with other datasets.
+        with the given dataset. Compatibility here is just if the datasets are the
+        same.
 
         Args:
             ds_id (str): The identifier of the target dataset.
@@ -1826,25 +1827,8 @@ class RasterPane(QWidget):
         Raises:
             ValueError: If an unexpected GeographicLinkState is encountered.
         """
-        target_ds = self._app_state.get_dataset(ds_id)
-        compatible_highlights = []
-        # Loop through the keys and vaues in self._viewport_highlight 
-        for reference_ds_id, viewports in self._viewport_highlight.items():
-            # Use app state to get the datasets for both
-            reference_ds = self._app_state.get_dataset(reference_ds_id)
-            # Check if they are link compatible
-            link_state = target_ds.determine_link_state(reference_ds)
-            for viewport in viewports:
-                if link_state == GeographicLinkState.NO_LINK:
-                    continue
-                elif link_state == GeographicLinkState.PIXEL:
-                    compatible_highlights.append(viewport)
-                elif link_state == GeographicLinkState.SPATIAL:
-                    transformed_viewport = self._transform_viewport(viewport, reference_ds, target_ds)
-                    compatible_highlights.append(transformed_viewport)
-                else:
-                    raise ValueError(f"Got the wrong GeographicLinkState. Got {link_state}!")
-        return compatible_highlights
+        viewports = self._viewport_highlight.get(ds_id, None)
+        return viewports
 
     def _transform_viewport(self, viewport: QRect, reference_dataset: RasterDataSet, \
                             target_dataset: RasterDataSet) -> QRect:

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -1811,7 +1811,7 @@ class RasterPane(QWidget):
 
                 painter.drawRect(scaled)
 
-    def _get_compatible_highlights(self, ds_id) -> List[Union[QRect, QRectF]]:
+    def _get_compatible_highlights(self, ds_id: int) -> Optional[List[Union[QRect, QRectF]]]:
         """
         Retrieves a list of highlight regions (QRect or QRectF) that are compatible 
         with the given dataset. Compatibility here is just if the datasets are the
@@ -1827,8 +1827,10 @@ class RasterPane(QWidget):
         Raises:
             ValueError: If an unexpected GeographicLinkState is encountered.
         """
-        viewports = self._viewport_highlight.get(ds_id, None)
-        return viewports
+        if self._viewport_highlight:
+            viewports = self._viewport_highlight.get(ds_id, None)
+            return viewports
+        return None
 
     def _transform_viewport(self, viewport: QRect, reference_dataset: RasterDataSet, \
                             target_dataset: RasterDataSet) -> QRect:


### PR DESCRIPTION
Main view unlinked state:
The highlight box from the zoom pane should only show up in main view rasterviews if it is the same dataset in both.

Main view linked state:
The highlight box from the zoom pane should show up in all the compatible datasets in the main view (which will be all the linked datasets). 