### PR TITLE
Adds Context Pane dataset chooser option 'Use Clicked Dataset'

### DIFF
--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -141,6 +141,9 @@ class WiserTestModel:
 
         return dataset
 
+    def close_dataset(self, ds_id: int):
+        self.main_window._on_close_dataset(ds_id)
+
     def import_ascii_spectra(self, file_path: str):
         '''
         In the future, we want to implement this function to interact with ImportSpectraTextDialog

--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -472,7 +472,7 @@ class WiserTestModel:
         if ds_id not in self.app_state._datasets:
             raise ValueError(f"Dataset ID [{ds_id}] is not in app state")
 
-        action = next((act for act in dataset_menu.actions() if act.data()[1] == ds_id), None)
+        action = next((act for act in dataset_menu.actions() if not act.isSeparator() and act.data()[1] == ds_id), None)
         if action:
             self.context_pane._on_dataset_changed(action)
         else:

--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -459,6 +459,9 @@ class WiserTestModel:
     def get_context_pane_highlight_regions(self) -> Dict[int, List[Union[QRect, QRectF]]]:
         return self.context_pane._viewport_highlight
     
+    def get_context_pane_compatible_highlights(self, ds_id):
+        return self.context_pane._get_compatible_highlights(ds_id)
+    
     def get_context_pane_screen_size(self) -> QSize:
         return self.context_pane.get_rasterview()._image_widget.size()
 
@@ -657,7 +660,13 @@ class WiserTestModel:
         Clicks on the link view scrolling button. Returns the state of
         link view. (Either true or false)
         '''
-        self.main_view._act_link_view_scroll.trigger()
+        def func():
+            self.main_view._act_link_view_scroll.trigger()
+
+        function_event = FunctionEvent(func)
+
+        self.app.postEvent(self.testing_widget, function_event)
+        self.run()
 
         return self.main_view._link_view_scrolling
     

--- a/src/tests/test_context_pane_main_view_integ.py
+++ b/src/tests/test_context_pane_main_view_integ.py
@@ -137,9 +137,7 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
     def test_cp_highlight_equal_mv_after_scroll_linked(self):
         '''
         First zoom in. Then scroll the mainview. The context pane's highlight box should be
-        the same as the main view's visible region for the shared dataset. The context pane
-        should have a highlight box for linked datasets that aren't the same as the currently
-        selected dataset. 
+        the same as the main view's visible region for the shared dataset.
         '''
         # Create first array
         rows, cols, channels = 100, 100, 3
@@ -185,8 +183,6 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
         self.test_model.click_main_view_zoom_in()
         self.test_model.click_main_view_zoom_in()
         self.test_model.click_main_view_zoom_in()
-
-        self.test_model.scroll_main_view_rv_dx((0, 0), -1)
 
         cp_highlight = self.test_model.get_context_pane_compatible_highlights(ds1.get_id())[0]
 

--- a/src/tests/test_context_pane_main_view_integ.py
+++ b/src/tests/test_context_pane_main_view_integ.py
@@ -133,6 +133,82 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
         mv_region = self.test_model.get_main_view_rv_visible_region((0, 0))
 
         self.assertTrue(cp_highlight == mv_region)
+
+    def test_cp_highlight_equal_mv_after_scroll_linked(self):
+        '''
+        First zoom in. Then scroll the mainview. The context pane's highlight box should be
+        the same as the main view's visible region for the shared dataset. The context pane
+        should have a highlight box for linked datasets that aren't the same as the currently
+        selected dataset. 
+        '''
+        # Create first array
+        rows, cols, channels = 100, 100, 3
+        # Create a vertical gradient from 0 to 1: shape (50,1)
+        row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+        # Tile the values horizontally to get a 50x50 array
+        impl = np.tile(row_values, (1, cols))
+        # Repeat the 2D array across 3 channels to get a 3x50x50 array
+        np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+        # Create second array
+        # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+        row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+        impl2 = np.tile(row_values, (1, cols))
+        np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
+
+        # Create third array
+        # Start with an array of zeros (50x1)
+        row_values = np.zeros((rows, 1))
+        # Choose the row index corresponding to 75% of the height.
+        nonzero_index = int(0.75 * (rows - 1))
+        row_values[nonzero_index] = 0.75
+        impl3 = np.tile(row_values, (1, cols))
+        np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+
+        self.test_model.set_main_view_layout((2, 2))
+
+        ds1 = self.test_model.load_dataset(np_impl)
+        ds2 = self.test_model.load_dataset(np_impl2)
+        ds3 = self.test_model.load_dataset(np_impl3)
+
+        self.test_model.click_link_button()
+
+        self.test_model.set_context_pane_dataset(ds1.get_id())
+
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+
+        self.test_model.scroll_main_view_rv_dx((0, 0), -1)
+
+        cp_highlight = self.test_model.get_context_pane_compatible_highlights(ds1.get_id())[0]
+
+        mv_region = self.test_model.get_main_view_rv_visible_region((0, 0))
+
+        self.assertTrue(cp_highlight == mv_region)
+
+        self.test_model.scroll_main_view_rv_dx((0, 1), -100)
+
+        cp_highlight = self.test_model.get_context_pane_compatible_highlights(ds1.get_id())[0]
+
+        mv_region = self.test_model.get_main_view_rv_visible_region((0, 0))
+
+        self.assertTrue(cp_highlight == mv_region)
+
+        self.test_model.scroll_main_view_rv_dy((1, 0), -100)
+
+        cp_highlight = self.test_model.get_context_pane_compatible_highlights(ds1.get_id())[0]
+
+        mv_region = self.test_model.get_main_view_rv_visible_region((0, 0))
+
+        self.assertTrue(cp_highlight == mv_region)
     
     def test_cp_use_clicked(self):
         # Create first array
@@ -185,7 +261,6 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
     
         clicked_id = self.test_model.get_cp_dataset_chooser_checked_id()
         self.assertTrue(clicked_id == -1, "Context Pane dataset chooser changed when clicking in main view")
-
 
     def test_cp_use_clicked_while_linked(self):
         # Create first array
@@ -240,9 +315,6 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
     
         clicked_id = self.test_model.get_cp_dataset_chooser_checked_id()
         self.assertTrue(clicked_id == -1, "Context Pane dataset chooser changed when clicking in main view")
-        # Loads in multiple datasets
-
-        # Ensures the context pane only has the use click checked even when we switch between others
 
     
     def test_cp_use_specific_ds(self):
@@ -316,9 +388,6 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
         self.assertTrue(checked_id == ds2_id, "Context Pane dataset chooser changed when clicking in main view")
         cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
         self.assertTrue(cp_ds_id == checked_id, f"Context pane dataset changed when clicking in main view")
-    #     # Loads in multiple datasets
-
-    #     # Ensures the context pane only has the clicked dataset checked and used
 
     def test_cp_use_specific_ds_whlie_linked(self):
         # Create first array
@@ -393,9 +462,6 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
         self.assertTrue(checked_id == ds2_id, "Context Pane dataset chooser changed when clicking in main view")
         cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
         self.assertTrue(cp_ds_id == checked_id, f"Context pane dataset changed when clicking in main view")
-        # Loads in multiple datasets
-
-        # Ensures the context pane only has the clicked dataset checked and used
 
 if __name__ == '__main__':
     '''
@@ -404,7 +470,7 @@ if __name__ == '__main__':
     test_model = WiserTestModel(use_gui=True)
     
     # Create first array
-    rows, cols, channels = 75, 75, 3
+    rows, cols, channels = 100, 100, 3
     # Create a vertical gradient from 0 to 1: shape (50,1)
     row_values = np.linspace(0, 1, rows).reshape(rows, 1)
     # Tile the values horizontally to get a 50x50 array
@@ -426,10 +492,6 @@ if __name__ == '__main__':
     row_values[nonzero_index] = 0.75
     impl3 = np.tile(row_values, (1, cols))
     np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
-    # Loads in multiple datasets
-
-    # Ensures the context pane only has the use click checked even when we click between others
-    test_model.set_main_view_layout((2, 2))
 
     ds1 = test_model.load_dataset(np_impl)
     ds2 = test_model.load_dataset(np_impl2)
@@ -437,10 +499,35 @@ if __name__ == '__main__':
 
     test_model.click_link_button()
 
-    clicked_id = test_model.get_cp_dataset_chooser_checked_id()
+    test_model.set_context_pane_dataset(ds1.get_id())
 
-    test_model.set_context_pane_dataset_chooser_id(ds2.get_id())
+    test_model.click_main_view_zoom_in()
+    test_model.click_main_view_zoom_in()
+    test_model.click_main_view_zoom_in()
+    test_model.click_main_view_zoom_in()
+    test_model.click_main_view_zoom_in()
+    test_model.click_main_view_zoom_in()
+    test_model.click_main_view_zoom_in()
+    test_model.click_main_view_zoom_in()
+    test_model.click_main_view_zoom_in()
+    test_model.click_main_view_zoom_in()
 
-    print(f"test_model.get_cp_dataset_chooser_checked_id(): {test_model.get_cp_dataset_chooser_checked_id()}")
+    test_model.scroll_main_view_rv_dx((0, 0), -1)
+
+    # cp_highlight = test_model.get_context_pane_compatible_highlights(ds1.get_id())[0]
+
+    # mv_region = test_model.get_main_view_rv_visible_region((0, 0))
+
+    # test_model.scroll_main_view_rv_dx((0, 1), -100)
+
+    # cp_highlight = test_model.get_context_pane_compatible_highlights(ds1.get_id())[0]
+
+    # mv_region = test_model.get_main_view_rv_visible_region((0, 0))
+
+    # test_model.scroll_main_view_rv_dy((1, 0), -100)
+
+    # cp_highlight = test_model.get_context_pane_compatible_highlights(ds1.get_id())[0]
+
+    # mv_region = test_model.get_main_view_rv_visible_region((0, 0))
 
     test_model.app.exec_()

--- a/src/tests/test_context_pane_main_view_integ.py
+++ b/src/tests/test_context_pane_main_view_integ.py
@@ -2,6 +2,8 @@ import unittest
 
 import tests.context
 # import context
+from tests.utils import are_pixels_close, are_qrects_close
+# from utils import are_pixels_close, are_qrects_close
 
 from test_utils.test_model import WiserTestModel
 
@@ -12,7 +14,6 @@ from PySide2.QtCore import *
 from PySide2.QtGui import *
 from PySide2.QtWidgets import *
 
-from .utils import are_pixels_close, are_qrects_close
 
 class TestContextPaneMainViewIntegration(unittest.TestCase):
 
@@ -58,8 +59,7 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
         pixel_point = QPoint(pixel[0], pixel[1])
 
         self.assertTrue(visible_region.contains(pixel_point))
-
-        
+     
     def test_cp_highlight_equal_mv_after_zoom(self):
         '''
         First zoom in. Then click in the context pane. The context pane highlight box
@@ -364,7 +364,6 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
         clicked_id = self.test_model.get_cp_dataset_chooser_checked_id()
         self.assertTrue(clicked_id == -1, "Context Pane dataset chooser changed when clicking in main view")
 
-    
     def test_cp_use_specific_ds(self):
         # Create first array
         rows, cols, channels = 75, 75, 3
@@ -437,7 +436,7 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
         cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
         self.assertTrue(cp_ds_id == checked_id, f"Context pane dataset changed when clicking in main view")
 
-    def test_cp_use_specific_ds_whlie_linked(self):
+    def test_cp_use_specific_ds_while_linked(self):
         # Create first array
         rows, cols, channels = 75, 75, 3
         # Create a vertical gradient from 0 to 1: shape (50,1)
@@ -511,6 +510,120 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
         cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
         self.assertTrue(cp_ds_id == checked_id, f"Context pane dataset changed when clicking in main view")
 
+    def test_cp_remove_chosen_dataset(self, func = lambda : None):
+        '''
+        Ensures that when we remove a dataset that is the same that was chosen
+        in the context pane, we update to the 'Use Clicked Dataset' value
+        '''
+        # Create first array
+        rows, cols, channels = 75, 75, 3
+        # Create a vertical gradient from 0 to 1: shape (50,1)
+        row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+        # Tile the values horizontally to get a 50x50 array
+        impl = np.tile(row_values, (1, cols))
+        # Repeat the 2D array across 3 channels to get a 3x50x50 array
+        np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+        # Create second array
+        # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+        row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+        impl2 = np.tile(row_values, (1, cols))
+        np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
+
+        # Create third array
+        # Start with an array of zeros (50x1)
+        row_values = np.zeros((rows, 1))
+        # Choose the row index corresponding to 75% of the height.
+        nonzero_index = int(0.75 * (rows - 1))
+        row_values[nonzero_index] = 0.75
+        impl3 = np.tile(row_values, (1, cols))
+        np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+
+        self.test_model.set_main_view_layout((2, 2))
+
+        ds1 = self.test_model.load_dataset(np_impl)
+        ds2 = self.test_model.load_dataset(np_impl2)
+        ds3 = self.test_model.load_dataset(np_impl3)
+
+        func()
+
+        ds1_id = ds1.get_id()
+        # Set the context pane to use dataset 1
+        self.test_model.set_context_pane_dataset_chooser_id(ds1_id)
+        # Make sure context pane dataset chooser was actually switched
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds1_id, f"Context pane dataset chooser not set to {ds1_id}")
+        # Make sure the shown dataset in context pane was switched
+        cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
+        self.assertTrue(cp_ds_id == checked_id, f"Context pane did not switch to showing the checked dataset")
+
+        self.test_model.close_dataset(ds1_id)
+        
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == -1, f"Context pane did not switch 'Use Clicked Dataset' when open dataset was closed")
+
+
+    def test_cp_remove_chosen_dataset_while_linked(self):
+        self.test_cp_remove_chosen_dataset(self.test_model.click_link_button)
+
+
+    def test_cp_remove_not_chosen_dataset(self, func = lambda : None):
+        '''
+        Ensures that when we remove a dataset that is not chosen in the context pane,
+        the context pane stays the same.
+        '''
+        # Create first array
+        rows, cols, channels = 75, 75, 3
+        # Create a vertical gradient from 0 to 1: shape (50,1)
+        row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+        # Tile the values horizontally to get a 50x50 array
+        impl = np.tile(row_values, (1, cols))
+        # Repeat the 2D array across 3 channels to get a 3x50x50 array
+        np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+        # Create second array
+        # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+        row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+        impl2 = np.tile(row_values, (1, cols))
+        np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
+
+        # Create third array
+        # Start with an array of zeros (50x1)
+        row_values = np.zeros((rows, 1))
+        # Choose the row index corresponding to 75% of the height.
+        nonzero_index = int(0.75 * (rows - 1))
+        row_values[nonzero_index] = 0.75
+        impl3 = np.tile(row_values, (1, cols))
+        np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+
+        self.test_model.set_main_view_layout((2, 2))
+
+        ds1 = self.test_model.load_dataset(np_impl)
+        ds2 = self.test_model.load_dataset(np_impl2)
+        ds3 = self.test_model.load_dataset(np_impl3)
+
+        func()
+
+        ds1_id = ds1.get_id()
+        ds2_id = ds2.get_id()
+        # Set the context pane to use dataset 1
+        self.test_model.set_context_pane_dataset_chooser_id(ds1_id)
+        # Make sure context pane dataset chooser was actually switched
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds1_id, f"Context pane dataset chooser not set to {ds1_id}")
+        # Make sure the shown dataset in context pane was switched
+        cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
+        self.assertTrue(cp_ds_id == checked_id, f"Context pane did not switch to showing the checked dataset")
+
+        self.test_model.close_dataset(ds2_id)
+        
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds1_id, f"Context pane changed datasets on removing a dataset")
+
+    def test_cp_remove_not_chosen_dataset_while_linked(self):
+        self.test_cp_remove_not_chosen_dataset(self.test_model.click_link_button)
+        
+
 if __name__ == '__main__':
     '''
     Code to make sure new tests work as desired
@@ -518,7 +631,7 @@ if __name__ == '__main__':
     test_model = WiserTestModel(use_gui=True)
     
     # Create first array
-    rows, cols, channels = 100, 100, 3
+    rows, cols, channels = 75, 75, 3
     # Create a vertical gradient from 0 to 1: shape (50,1)
     row_values = np.linspace(0, 1, rows).reshape(rows, 1)
     # Tile the values horizontally to get a 50x50 array
@@ -541,41 +654,24 @@ if __name__ == '__main__':
     impl3 = np.tile(row_values, (1, cols))
     np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
 
+    test_model.set_main_view_layout((2, 2))
+
     ds1 = test_model.load_dataset(np_impl)
     ds2 = test_model.load_dataset(np_impl2)
     ds3 = test_model.load_dataset(np_impl3)
 
-    test_model.click_link_button()
+    ds1_id = ds1.get_id()
+    # Set the context pane to use dataset 1
+    test_model.set_context_pane_dataset_chooser_id(ds1_id)
+    # Make sure context pane dataset chooser was actually switched
+    checked_id = test_model.get_cp_dataset_chooser_checked_id()
 
-    test_model.set_context_pane_dataset(ds1.get_id())
+    # Make sure the shown dataset in context pane was switched
+    cp_ds_id = test_model.get_context_pane_dataset().get_id()
 
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-
-    test_model.scroll_main_view_rv_dx((0, 0), -1)
-
-    # cp_highlight = test_model.get_context_pane_compatible_highlights(ds1.get_id())[0]
-
-    # mv_region = test_model.get_main_view_rv_visible_region((0, 0))
-
-    # test_model.scroll_main_view_rv_dx((0, 1), -100)
-
-    # cp_highlight = test_model.get_context_pane_compatible_highlights(ds1.get_id())[0]
-
-    # mv_region = test_model.get_main_view_rv_visible_region((0, 0))
-
-    # test_model.scroll_main_view_rv_dy((1, 0), -100)
-
-    # cp_highlight = test_model.get_context_pane_compatible_highlights(ds1.get_id())[0]
-
-    # mv_region = test_model.get_main_view_rv_visible_region((0, 0))
+    test_model.close_dataset(ds1_id)
+    
+    checked_id = test_model.get_cp_dataset_chooser_checked_id()
+    print(f"checked_id: {checked_id}")
 
     test_model.app.exec_()

--- a/src/tests/test_context_pane_main_view_integ.py
+++ b/src/tests/test_context_pane_main_view_integ.py
@@ -133,6 +133,269 @@ class TestContextPaneMainViewIntegration(unittest.TestCase):
         mv_region = self.test_model.get_main_view_rv_visible_region((0, 0))
 
         self.assertTrue(cp_highlight == mv_region)
+    
+    def test_cp_use_clicked(self):
+        # Create first array
+        rows, cols, channels = 75, 75, 3
+        # Create a vertical gradient from 0 to 1: shape (50,1)
+        row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+        # Tile the values horizontally to get a 50x50 array
+        impl = np.tile(row_values, (1, cols))
+        # Repeat the 2D array across 3 channels to get a 3x50x50 array
+        np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+        # Create second array
+        # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+        row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+        impl2 = np.tile(row_values, (1, cols))
+        np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
+
+        # Create third array
+        # Start with an array of zeros (50x1)
+        row_values = np.zeros((rows, 1))
+        # Choose the row index corresponding to 75% of the height.
+        nonzero_index = int(0.75 * (rows - 1))
+        row_values[nonzero_index] = 0.75
+        impl3 = np.tile(row_values, (1, cols))
+        np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+        # Loads in multiple datasets
+
+        # Ensures the context pane only has the use click checked even when we click between others
+        self.test_model.set_main_view_layout((2, 2))
+
+        ds1 = self.test_model.load_dataset(np_impl)
+        ds2 = self.test_model.load_dataset(np_impl2)
+        ds3 = self.test_model.load_dataset(np_impl3)
+
+        clicked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(clicked_id == -1, "Starting dataset option is not 'Use Clicked Dataset'")
+
+        self.test_model.click_raster_coord_main_view_rv(rv_pos=(0, 0), raster_coord=(10, 10))
+        ds_00 = self.test_model.get_main_view_rv((0, 0)).get_raster_data()
+        cp_ds = self.test_model.get_context_pane_dataset()
+        self.assertTrue(ds_00 == cp_ds, "Context pane dataset is not the same as the clicked dataset")
+    
+        clicked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(clicked_id == -1, "Context Pane dataset chooser changed when clicking in main view")
+
+        self.test_model.click_raster_coord_main_view_rv(rv_pos=(0, 1), raster_coord=(10, 10))
+        ds_01 = self.test_model.get_main_view_rv((0, 1)).get_raster_data()
+        cp_ds = self.test_model.get_context_pane_dataset()
+        self.assertTrue(ds_01 == cp_ds, "Context pane dataset is not the same as the clicked dataset")
+    
+        clicked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(clicked_id == -1, "Context Pane dataset chooser changed when clicking in main view")
+
+
+    def test_cp_use_clicked_while_linked(self):
+        # Create first array
+        rows, cols, channels = 75, 75, 3
+        # Create a vertical gradient from 0 to 1: shape (50,1)
+        row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+        # Tile the values horizontally to get a 50x50 array
+        impl = np.tile(row_values, (1, cols))
+        # Repeat the 2D array across 3 channels to get a 3x50x50 array
+        np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+        # Create second array
+        # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+        row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+        impl2 = np.tile(row_values, (1, cols))
+        np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
+
+        # Create third array
+        # Start with an array of zeros (50x1)
+        row_values = np.zeros((rows, 1))
+        # Choose the row index corresponding to 75% of the height.
+        nonzero_index = int(0.75 * (rows - 1))
+        row_values[nonzero_index] = 0.75
+        impl3 = np.tile(row_values, (1, cols))
+        np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+        # Loads in multiple datasets
+
+        # Ensures the context pane only has the use click checked even when we click between others
+        self.test_model.set_main_view_layout((2, 2))
+
+        ds1 = self.test_model.load_dataset(np_impl)
+        ds2 = self.test_model.load_dataset(np_impl2)
+        ds3 = self.test_model.load_dataset(np_impl3)
+
+        self.test_model.click_link_button()
+
+        clicked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(clicked_id == -1, "Starting dataset option is not 'Use Clicked Dataset'")
+
+        self.test_model.click_raster_coord_main_view_rv(rv_pos=(0, 0), raster_coord=(10, 10))
+        ds_00 = self.test_model.get_main_view_rv((0, 0)).get_raster_data()
+        cp_ds = self.test_model.get_context_pane_dataset()
+        self.assertTrue(ds_00 == cp_ds, "Context pane dataset is not the same as the clicked dataset")
+    
+        clicked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(clicked_id == -1, "Context Pane dataset chooser changed when clicking in main view")
+
+        self.test_model.click_raster_coord_main_view_rv(rv_pos=(0, 1), raster_coord=(10, 10))
+        ds_01 = self.test_model.get_main_view_rv((0, 1)).get_raster_data()
+        cp_ds = self.test_model.get_context_pane_dataset()
+        self.assertTrue(ds_01 == cp_ds, "Context pane dataset is not the same as the clicked dataset")
+    
+        clicked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(clicked_id == -1, "Context Pane dataset chooser changed when clicking in main view")
+        # Loads in multiple datasets
+
+        # Ensures the context pane only has the use click checked even when we switch between others
+
+    
+    def test_cp_use_specific_ds(self):
+        # Create first array
+        rows, cols, channels = 75, 75, 3
+        # Create a vertical gradient from 0 to 1: shape (50,1)
+        row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+        # Tile the values horizontally to get a 50x50 array
+        impl = np.tile(row_values, (1, cols))
+        # Repeat the 2D array across 3 channels to get a 3x50x50 array
+        np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+        # Create second array
+        # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+        row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+        impl2 = np.tile(row_values, (1, cols))
+        np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
+
+        # Create third array
+        # Start with an array of zeros (50x1)
+        row_values = np.zeros((rows, 1))
+        # Choose the row index corresponding to 75% of the height.
+        nonzero_index = int(0.75 * (rows - 1))
+        row_values[nonzero_index] = 0.75
+        impl3 = np.tile(row_values, (1, cols))
+        np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+
+        self.test_model.set_main_view_layout((2, 2))
+
+        ds1 = self.test_model.load_dataset(np_impl)
+        ds2 = self.test_model.load_dataset(np_impl2)
+        ds3 = self.test_model.load_dataset(np_impl3)
+        
+        # Ensure the checked id is set to 'Use Clicked Dataset'
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == -1, "Starting dataset option is not 'Use Clicked Dataset'")
+
+        ds1_id = ds1.get_id()
+        # Set the context pane to use dataset 1
+        self.test_model.set_context_pane_dataset_chooser_id(ds1_id)
+        # Make sure context pane dataset chooser was actually switched
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds1_id, f"Context pane dataset chooser not set to {ds1_id}")
+        # Make sure the shown dataset in context pane was switched
+        cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
+        self.assertTrue(cp_ds_id == checked_id, f"Context pane did not switch to showing the checked dataset")
+
+        # Click somewhere in ds2'S raster view
+        self.test_model.click_raster_coord_main_view_rv(rv_pos=(0, 1), raster_coord=(10, 10))
+    
+        # Make sure the context pane is still showing dataset 1
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds1_id, f"Context pane dataset chooser not set to {ds1_id}")
+        cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
+        self.assertTrue(cp_ds_id == checked_id, f"Context pane dataset changed when clicking in main view")
+
+        ds2_id = ds2.get_id()
+        # Set context pane to show dataset 2
+        self.test_model.set_context_pane_dataset_chooser_id(ds2_id)
+
+        # Ensure context pane has dataset 2 checked and shown
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds2_id, f"Context pane dataset chooser not set to {ds2_id}")
+        cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
+        self.assertTrue(cp_ds_id == checked_id, f"Context pane did not switch to showing the checked dataset")
+
+        # Click somewhere in dataset 1's rasterview
+        self.test_model.click_raster_coord_main_view_rv(rv_pos=(0, 0), raster_coord=(10, 10))
+    
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds2_id, "Context Pane dataset chooser changed when clicking in main view")
+        cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
+        self.assertTrue(cp_ds_id == checked_id, f"Context pane dataset changed when clicking in main view")
+    #     # Loads in multiple datasets
+
+    #     # Ensures the context pane only has the clicked dataset checked and used
+
+    def test_cp_use_specific_ds_whlie_linked(self):
+        # Create first array
+        rows, cols, channels = 75, 75, 3
+        # Create a vertical gradient from 0 to 1: shape (50,1)
+        row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+        # Tile the values horizontally to get a 50x50 array
+        impl = np.tile(row_values, (1, cols))
+        # Repeat the 2D array across 3 channels to get a 3x50x50 array
+        np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+        # Create second array
+        # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+        row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+        impl2 = np.tile(row_values, (1, cols))
+        np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
+
+        # Create third array
+        # Start with an array of zeros (50x1)
+        row_values = np.zeros((rows, 1))
+        # Choose the row index corresponding to 75% of the height.
+        nonzero_index = int(0.75 * (rows - 1))
+        row_values[nonzero_index] = 0.75
+        impl3 = np.tile(row_values, (1, cols))
+        np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+
+        self.test_model.set_main_view_layout((2, 2))
+
+        ds1 = self.test_model.load_dataset(np_impl)
+        ds2 = self.test_model.load_dataset(np_impl2)
+        ds3 = self.test_model.load_dataset(np_impl3)
+        
+        self.test_model.click_link_button()
+
+        # Ensure the checked id is set to 'Use Clicked Dataset'
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == -1, "Starting dataset option is not 'Use Clicked Dataset'")
+
+        ds1_id = ds1.get_id()
+        # Set the context pane to use dataset 1
+        self.test_model.set_context_pane_dataset_chooser_id(ds1_id)
+        # Make sure context pane dataset chooser was actually switched
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds1_id, f"Context pane dataset chooser not set to {ds1_id}")
+        # Make sure the shown dataset in context pane was switched
+        cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
+        self.assertTrue(cp_ds_id == checked_id, f"Context pane did not switch to showing the checked dataset")
+
+        # Click somewhere in ds2'S raster view
+        self.test_model.click_raster_coord_main_view_rv(rv_pos=(0, 1), raster_coord=(10, 10))
+    
+        # Make sure the context pane is still showing dataset 1
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds1_id, f"Context pane dataset chooser not set to {ds1_id}")
+        cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
+        self.assertTrue(cp_ds_id == checked_id, f"Context pane dataset changed when clicking in main view")
+
+        ds2_id = ds2.get_id()
+        # Set context pane to show dataset 2
+        self.test_model.set_context_pane_dataset_chooser_id(ds2_id)
+
+        # Ensure context pane has dataset 2 checked and shown
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds2_id, f"Context pane dataset chooser not set to {ds2_id}")
+        cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
+        self.assertTrue(cp_ds_id == checked_id, f"Context pane did not switch to showing the checked dataset")
+
+        # Click somewhere in dataset 1's rasterview
+        self.test_model.click_raster_coord_main_view_rv(rv_pos=(0, 0), raster_coord=(10, 10))
+    
+        checked_id = self.test_model.get_cp_dataset_chooser_checked_id()
+        self.assertTrue(checked_id == ds2_id, "Context Pane dataset chooser changed when clicking in main view")
+        cp_ds_id = self.test_model.get_context_pane_dataset().get_id()
+        self.assertTrue(cp_ds_id == checked_id, f"Context pane dataset changed when clicking in main view")
+        # Loads in multiple datasets
+
+        # Ensures the context pane only has the clicked dataset checked and used
 
 if __name__ == '__main__':
     '''
@@ -141,7 +404,7 @@ if __name__ == '__main__':
     test_model = WiserTestModel(use_gui=True)
     
     # Create first array
-    rows, cols, channels = 100, 100, 3
+    rows, cols, channels = 75, 75, 3
     # Create a vertical gradient from 0 to 1: shape (50,1)
     row_values = np.linspace(0, 1, rows).reshape(rows, 1)
     # Tile the values horizontally to get a 50x50 array
@@ -149,28 +412,35 @@ if __name__ == '__main__':
     # Repeat the 2D array across 3 channels to get a 3x50x50 array
     np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
 
-    test_model.load_dataset(np_impl)
+    # Create second array
+    # Create 49 linearly spaced values from 0 to 0.75 and then append a 0
+    row_values = np.concatenate((np.linspace(0, 0.75, rows - 5), np.array([0, 0, 0, 0, 0]))).reshape(rows, 1)
+    impl2 = np.tile(row_values, (1, cols))
+    np_impl2 = np.repeat(impl2[np.newaxis, :, :], channels, axis=0)
 
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
-    test_model.click_main_view_zoom_in()
+    # Create third array
+    # Start with an array of zeros (50x1)
+    row_values = np.zeros((rows, 1))
+    # Choose the row index corresponding to 75% of the height.
+    nonzero_index = int(0.75 * (rows - 1))
+    row_values[nonzero_index] = 0.75
+    impl3 = np.tile(row_values, (1, cols))
+    np_impl3 = np.repeat(impl3[np.newaxis, :, :], channels, axis=0)
+    # Loads in multiple datasets
 
-    pixel = (79, 79)
+    # Ensures the context pane only has the use click checked even when we click between others
+    test_model.set_main_view_layout((2, 2))
 
-    test_model.click_raster_coord_context_pane(pixel)
+    ds1 = test_model.load_dataset(np_impl)
+    ds2 = test_model.load_dataset(np_impl2)
+    ds3 = test_model.load_dataset(np_impl3)
 
-    visible_region = test_model.get_main_view_rv_visible_region((0, 0))
+    test_model.click_link_button()
 
-    pixel_point = QPoint(pixel[0], pixel[1])
+    clicked_id = test_model.get_cp_dataset_chooser_checked_id()
 
-    print(f"pixel_point: {pixel_point}")
-    # print(f"clicked pixel: {actual_clicked_pixel}")
+    test_model.set_context_pane_dataset_chooser_id(ds2.get_id())
+
+    print(f"test_model.get_cp_dataset_chooser_checked_id(): {test_model.get_cp_dataset_chooser_checked_id()}")
 
     test_model.app.exec_()

--- a/src/tests/test_main_view_zoom_pane_integ.py
+++ b/src/tests/test_main_view_zoom_pane_integ.py
@@ -434,18 +434,24 @@ class TestMainViewZoomPaneIntegration(unittest.TestCase):
 
         self.test_model.set_main_view_layout((2, 2))
 
+        # Load in datasets
         ds1 = self.test_model.load_dataset(np_impl)
         ds2 = self.test_model.load_dataset(np_impl2)
         ds3 = self.test_model.load_dataset(np_impl3)
 
+        # Zoom in all datasets
         self.test_model.click_main_view_zoom_in()
         self.test_model.click_main_view_zoom_in()
         self.test_model.click_main_view_zoom_in()
         self.test_model.click_main_view_zoom_in()
 
+        # Make sure context pane shows first dataset
         self.test_model.set_context_pane_dataset(ds1.get_id())
 
+        # Get first dataset's visible region
         visible_region_00 = self.test_model.get_main_view_rv_visible_region((0, 0))
+
+        # Get the context pane's highlight region
         highlight_region = self.test_model.context_pane._get_compatible_highlights(ds1.get_id())[0]
 
         # For an unknown reason, when I run this test inside of pytest and outside,

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -975,6 +975,8 @@ class DataVisualizerApp(QMainWindow):
 
             sel = SinglePixelSelection(ds_point, ds)
 
+            self._context_pane.show_dataset(ds)
+
             self._main_view.set_pixel_highlight(sel, recenter=RecenterMode.IF_NOT_VISIBLE, are_views_linked=True)
 
             self._zoom_pane.set_pixel_highlight(sel)

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -930,20 +930,10 @@ class DataVisualizerApp(QMainWindow):
         if rasterview_position is None:
             return
 
-        if self._main_view.is_multi_view() and not self._main_view.is_scrolling_linked():
-            # Get a list of all visible regions from all views
-            visible_region = self._main_view.get_all_regions()
-            rasterview = self._main_view.get_all_rasterviews()
-        else:
-            # rasterview = self._main_view.get_rasterview(rasterview_position)
-            # visible_region = rasterview.get_visible_region()
-
-            # Context pane's set_viewport_highlight takes in lists
-            # rasterview = [rasterview]
-            # visible_region = [visible_region]
-    
-            visible_region = self._main_view.get_all_regions()
-            rasterview = self._main_view.get_all_rasterviews()
+        # In the context pane we just want to show the currently selected dataset.
+        # The function _get_compatible_dataset is used to filter out for this dataset.
+        visible_region = self._main_view.get_all_regions()
+        rasterview = self._main_view.get_all_rasterviews()
 
         self._context_pane.set_viewport_highlight(visible_region, rasterview)
         return

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -935,12 +935,15 @@ class DataVisualizerApp(QMainWindow):
             visible_region = self._main_view.get_all_regions()
             rasterview = self._main_view.get_all_rasterviews()
         else:
-            rasterview = self._main_view.get_rasterview(rasterview_position)
-            visible_region = rasterview.get_visible_region()
+            # rasterview = self._main_view.get_rasterview(rasterview_position)
+            # visible_region = rasterview.get_visible_region()
 
             # Context pane's set_viewport_highlight takes in lists
-            rasterview = [rasterview]
-            visible_region = [visible_region]
+            # rasterview = [rasterview]
+            # visible_region = [visible_region]
+    
+            visible_region = self._main_view.get_all_regions()
+            rasterview = self._main_view.get_all_rasterviews()
 
         self._context_pane.set_viewport_highlight(visible_region, rasterview)
         return

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -931,7 +931,8 @@ class DataVisualizerApp(QMainWindow):
             return
 
         # In the context pane we just want to show the currently selected dataset.
-        # The function _get_compatible_dataset is used to filter out for this dataset.
+        # The function _get_compatible_dataset is used to filter any view that
+        # doesn't belong to the context pane's dataset.
         visible_region = self._main_view.get_all_regions()
         rasterview = self._main_view.get_all_rasterviews()
 

--- a/src/wiser/gui/context_pane.py
+++ b/src/wiser/gui/context_pane.py
@@ -217,6 +217,8 @@ class ContextPane(RasterPane):
         with the rasterview displayed in the context pane to display.
         '''
         print(f"SETTING VIEWPORT HIGHLIGHT")
+        print(f"context pane viewports: {viewports}")
+        print(f"context pane rasterviews: {rasterviews}")
         self.create_viewport_highlight_dictionary(viewports, rasterviews)
 
         # If the specified viewport highlight region is not entirely within this
@@ -234,6 +236,7 @@ class ContextPane(RasterPane):
         # that have the same dataset id as the rasterview.
 
         for rv in self._rasterviews.values():
+            print(f"maybe changing context pane RV")
             visible = rv.get_visible_region()
             if visible is None or viewports is None or len(viewports) > 1:
                 rv.update()

--- a/src/wiser/gui/context_pane.py
+++ b/src/wiser/gui/context_pane.py
@@ -42,13 +42,11 @@ class ContextPaneDatasetChooser(DatasetChooser):
         actDefault.setCheckable(True)
         actDefault.setChecked(True)
         actDefault.setData( (None, -1) )
-        print(f"CREATED DEFAULT ACT: {actDefault}")
         menu.addSeparator()
 
         # Add an action for each dataset
         for dataset in self._app_state.get_datasets():
             # TODO(donnie):  Eventually, include the path if the name isn't unique.
-            print(f"CREATING act: {dataset.get_name()}")
             act = QAction(dataset.get_name(), menu)
             act.setCheckable(True)
             act_data = (rasterview_pos, dataset.get_id())
@@ -216,9 +214,6 @@ class ContextPane(RasterPane):
         rasterviews from the mainview, we only want those rasterviews that are compatible
         with the rasterview displayed in the context pane to display.
         '''
-        print(f"SETTING VIEWPORT HIGHLIGHT")
-        print(f"context pane viewports: {viewports}")
-        print(f"context pane rasterviews: {rasterviews}")
         self.create_viewport_highlight_dictionary(viewports, rasterviews)
 
         # If the specified viewport highlight region is not entirely within this
@@ -236,7 +231,6 @@ class ContextPane(RasterPane):
         # that have the same dataset id as the rasterview.
 
         for rv in self._rasterviews.values():
-            print(f"maybe changing context pane RV")
             visible = rv.get_visible_region()
             if visible is None or viewports is None or len(viewports) > 1:
                 rv.update()

--- a/src/wiser/gui/context_pane.py
+++ b/src/wiser/gui/context_pane.py
@@ -216,7 +216,7 @@ class ContextPane(RasterPane):
         rasterviews from the mainview, we only want those rasterviews that are compatible
         with the rasterview displayed in the context pane to display.
         '''
-
+        print(f"SETTING VIEWPORT HIGHLIGHT")
         self.create_viewport_highlight_dictionary(viewports, rasterviews)
 
         # If the specified viewport highlight region is not entirely within this

--- a/src/wiser/gui/context_pane.py
+++ b/src/wiser/gui/context_pane.py
@@ -216,7 +216,7 @@ class ContextPane(RasterPane):
         rasterviews from the mainview, we only want those rasterviews that are compatible
         with the rasterview displayed in the context pane to display.
         '''
-        
+
         self.create_viewport_highlight_dictionary(viewports, rasterviews)
 
         # If the specified viewport highlight region is not entirely within this

--- a/src/wiser/gui/context_pane.py
+++ b/src/wiser/gui/context_pane.py
@@ -6,9 +6,58 @@ from PySide2.QtWidgets import *
 
 import wiser.gui.generated.resources
 
+from wiser.raster.dataset import RasterDataSet
+
 from .rasterview import ScaleToFitMode, RasterView
 from .rasterpane import RasterPane
+from .dataset_chooser import DatasetChooser
+from .util import add_toolbar_action
+from .app_state import ApplicationState
 
+class ContextPaneDatasetChooser(DatasetChooser):
+    '''
+    A customized subclass of the DatasetChooser toolbar-button/widget for the
+    Context Pane window to use to "lock" the dataset that the Context Pane
+    can show.
+    '''
+    def __init__(self, raster_pane: RasterPane, app_state: ApplicationState):
+        super().__init__(raster_pane, app_state)
+
+
+    def _add_dataset_menu_items(self, menu, rasterview_pos=(0, 0)):
+        '''
+        Override the parent-class implementation to add a "use clicked dataset"
+        option.
+        '''
+        # Find the action that is currently selected (if any)
+        current_data = None
+        for act in menu.actions():
+            if act.isChecked():
+                current_data = act.data()
+
+        # Remove all existing actions
+        menu.clear()
+
+        actDefault: QAction = menu.addAction(self.tr('Use clicked dataset'))
+        actDefault.setCheckable(True)
+        actDefault.setChecked(True)
+        actDefault.setData( (None, -1) )
+        print(f"CREATED DEFAULT ACT: {actDefault}")
+        menu.addSeparator()
+
+        # Add an action for each dataset
+        for dataset in self._app_state.get_datasets():
+            # TODO(donnie):  Eventually, include the path if the name isn't unique.
+            print(f"CREATING act: {dataset.get_name()}")
+            act = QAction(dataset.get_name(), menu)
+            act.setCheckable(True)
+            act_data = (rasterview_pos, dataset.get_id())
+            act.setData(act_data)
+            if act_data == current_data:
+                act.setChecked(True)
+                # actDefault.setChecked(False)
+
+            menu.addAction(act)
 
 class ContextPane(RasterPane):
     '''
@@ -30,6 +79,26 @@ class ContextPane(RasterPane):
         self._init_dataset_tools()
         self._toolbar.addSeparator()
         self._init_zoom_tools()
+
+    def _init_dataset_tools(self):
+        '''
+        Initialize dataset-management toolbar buttons.
+        '''
+
+        # Dataset / Band Tools
+
+        self._dataset_chooser = ContextPaneDatasetChooser(self, self._app_state)
+        self._toolbar.addWidget(self._dataset_chooser)
+        self._dataset_chooser.triggered.connect(self._on_dataset_changed)
+        self._ds_id = -1
+
+        self._act_band_chooser = add_toolbar_action(self._toolbar,
+            ':/icons/choose-bands.svg', self.tr('Band chooser'), self)
+        # TODO(donnie):  If we just pop up a widget...
+        # self._band_chooser = BandChooser(self._app_state)
+        # toolbar.addWidget(self._band_chooser)
+        self._act_band_chooser.triggered.connect(self._on_band_chooser)
+        self._act_band_chooser.setEnabled(False)
 
 
     def _init_zoom_tools(self):
@@ -64,6 +133,36 @@ class ContextPane(RasterPane):
         self._update_image_scale()
 
 
+    def show_dataset(self, dataset: RasterDataSet, rasterview_pos=(0, 0)):
+        '''
+        Sets the dataset being displayed in the specified view of the raster
+        pane.
+        '''
+        if self._ds_id == -1 or self._ds_id == dataset.get_id():
+            rasterview = self.get_rasterview(rasterview_pos)
+
+            # If the rasterview is already showing the specified dataset, skip!
+            if rasterview.get_raster_data() is dataset:
+                return
+
+            bands = None
+            stretches = None
+            if dataset is not None:
+                ds_id = dataset.get_id()
+                bands = self._display_bands[ds_id]
+                stretches = self._app_state.get_stretches(ds_id, bands)
+
+            rasterview.set_raster_data(dataset, bands, stretches)
+
+
+    def _on_dataset_changed(self, act):
+        (rasterview_pos, ds_id) = act.data()
+        self._ds_id = ds_id
+        if ds_id != -1:
+            dataset = self._app_state.get_dataset(ds_id)
+            self.show_dataset(dataset, rasterview_pos)
+
+
     def _on_dataset_added(self, ds_id):
         '''
         Override the base-class implementation so we can also update the
@@ -80,6 +179,8 @@ class ContextPane(RasterPane):
         '''
         super()._on_dataset_removed(ds_id)
         self._update_image_scale()
+        if ds_id == self._ds_id:
+            self._ds_id = -1
 
 
     def _on_toggle_fit_to_window(self):

--- a/src/wiser/gui/context_pane.py
+++ b/src/wiser/gui/context_pane.py
@@ -53,7 +53,7 @@ class ContextPaneDatasetChooser(DatasetChooser):
             act.setData(act_data)
             if act_data == current_data:
                 act.setChecked(True)
-                # actDefault.setChecked(False)
+                actDefault.setChecked(False)
 
             menu.addAction(act)
 

--- a/src/wiser/gui/dataset_chooser.py
+++ b/src/wiser/gui/dataset_chooser.py
@@ -114,15 +114,13 @@ class DatasetChooser(QToolButton):
 
         self._uncheck_all(self._dataset_menu)
 
-        print(f"STARTING CHECK====")
         for act in self._dataset_menu.actions():
-            print(f"Act: {act}, data: {act.data()}, name: {act.text()}")
+
             if act.isSeparator():
                 continue
             act_ds_id = act.data()[1]
             if act_ds_id == ds_id:
                 act.setChecked(True)
-        print(f"ENDING CHECK====")
 
     def _uncheck_all(self, menu: QMenu):
         for act in menu.actions():

--- a/src/wiser/gui/dataset_chooser.py
+++ b/src/wiser/gui/dataset_chooser.py
@@ -132,7 +132,6 @@ class DatasetChooser(QToolButton):
         has a check-mark by it; all other datasets will be (or become)
         deselected.
         '''
-        print(f'_on_dataset_changed Selected action:  {act}1111111111111111111')
         for oact in self._dataset_menu.actions():
             # print(f'Action:  {oact}\t\tChecked?  {oact == act}')
             oact.setChecked(oact == act)

--- a/src/wiser/gui/dataset_chooser.py
+++ b/src/wiser/gui/dataset_chooser.py
@@ -114,10 +114,15 @@ class DatasetChooser(QToolButton):
 
         self._uncheck_all(self._dataset_menu)
 
+        print(f"STARTING CHECK====")
         for act in self._dataset_menu.actions():
+            print(f"Act: {act}, data: {act.data()}, name: {act.text()}")
+            if act.isSeparator():
+                continue
             act_ds_id = act.data()[1]
             if act_ds_id == ds_id:
                 act.setChecked(True)
+        print(f"ENDING CHECK====")
 
     def _uncheck_all(self, menu: QMenu):
         for act in menu.actions():
@@ -129,7 +134,7 @@ class DatasetChooser(QToolButton):
         has a check-mark by it; all other datasets will be (or become)
         deselected.
         '''
-        # print(f'Selected action:  {act}')
+        print(f'_on_dataset_changed Selected action:  {act}1111111111111111111')
         for oact in self._dataset_menu.actions():
             # print(f'Action:  {oact}\t\tChecked?  {oact == act}')
             oact.setChecked(oact == act)

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -529,8 +529,7 @@ class MainViewWidget(RasterPane):
                         raise ValueError(f"Got the wrong GeographicLinkState. Got {link_state}!")
             return compatible_highlights
         else:
-            viewports = self._viewport_highlight.get(ds_id, None)
-            return viewports
+            return super()._get_compatible_highlights(ds_id)
 
     def _draw_pixel_highlight(self, rasterview, widget, paint_event):
         if self._pixel_highlight is None:

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -515,6 +515,9 @@ class MainViewWidget(RasterPane):
                 # Check if they are link compatible
                 link_state = target_ds.determine_link_state(reference_ds)
                 for viewport in viewports:
+                    # Happens when you close out of zoom pane
+                    if viewport is None:
+                        continue
                     if link_state == GeographicLinkState.NO_LINK:
                         continue
                     elif link_state == GeographicLinkState.PIXEL:

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -762,6 +762,7 @@ class RasterPane(QWidget):
         This function is called when the scroll-area moves around.  Fire an
         event that the visible region of the raster-view has changed.
         '''
+        print(f"!!!!!!!!!!!!!!!!!!!!12222222222222222221111111111111111111")
         self._emit_viewport_change()
 
 
@@ -1109,6 +1110,8 @@ class RasterPane(QWidget):
                 self._viewport_highlight[ds_id].append(rv_viewport)
             else:    
                 self._viewport_highlight[ds_id] = [rv_viewport]
+        
+        print(f"self._viewport_highlight: {self._viewport_highlight}")
 
     def set_viewport_highlight(self, viewport: Union[List[QRect], QRect, QRectF], \
                                rasterview: Union[List[RasterView], RasterView]):

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -691,6 +691,7 @@ class RasterPane(QWidget):
         Override the QtWidget resizeEvent() virtual method to fire an event that
         the visible region of the raster-view has changed.
         '''
+        print(f"RESIZE EVENT")
         self._emit_viewport_change()
 
 

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -691,7 +691,6 @@ class RasterPane(QWidget):
         Override the QtWidget resizeEvent() virtual method to fire an event that
         the visible region of the raster-view has changed.
         '''
-        print(f"RESIZE EVENT")
         self._emit_viewport_change()
 
 
@@ -762,7 +761,6 @@ class RasterPane(QWidget):
         This function is called when the scroll-area moves around.  Fire an
         event that the visible region of the raster-view has changed.
         '''
-        print(f"!!!!!!!!!!!!!!!!!!!!12222222222222222221111111111111111111")
         self._emit_viewport_change()
 
 
@@ -1110,8 +1108,6 @@ class RasterPane(QWidget):
                 self._viewport_highlight[ds_id].append(rv_viewport)
             else:    
                 self._viewport_highlight[ds_id] = [rv_viewport]
-        
-        print(f"self._viewport_highlight: {self._viewport_highlight}")
 
     def set_viewport_highlight(self, viewport: Union[List[QRect], QRect, QRectF], \
                                rasterview: Union[List[RasterView], RasterView]):

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -1073,10 +1073,9 @@ class RasterPane(QWidget):
         """
         This function is used to create the viewport highlight dictionary. It associates viewports
         with the dataset ID's of the rasterviews that the viewport corresponds to.
-        """
-        if not viewport or not rasterview:
-            return
 
+        self._viewport_highlight values can be a list with Nones in them
+        """
         # We make sure both the viewport and rasterviews are lists
         if not isinstance(rasterview, list):
             rasterviews = [rasterview]
@@ -1121,8 +1120,6 @@ class RasterPane(QWidget):
         viewports. The function just has basic functionality. If it does not meet
         the expectation for your subclass, then override it. 
         '''
-        if not viewport or not rasterview:
-            return
         # We make sure both the viewport and rasterviews are lists
         if not isinstance(rasterview, list):
             rasterviews = [rasterview]
@@ -1835,6 +1832,9 @@ class RasterPane(QWidget):
         """
         if self._viewport_highlight:
             viewports = self._viewport_highlight.get(ds_id, None)
+            if viewports is None:
+                return viewports
+            viewports = [viewport for viewport in viewports if viewport is not None]
             return viewports
         return None
 

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -1073,6 +1073,9 @@ class RasterPane(QWidget):
         This function is used to create the viewport highlight dictionary. It associates viewports
         with the dataset ID's of the rasterviews that the viewport corresponds to.
         """
+        if not viewport or not rasterview:
+            return
+
         # We make sure both the viewport and rasterviews are lists
         if not isinstance(rasterview, list):
             rasterviews = [rasterview]
@@ -1117,6 +1120,8 @@ class RasterPane(QWidget):
         viewports. The function just has basic functionality. If it does not meet
         the expectation for your subclass, then override it. 
         '''
+        if not viewport or not rasterview:
+            return
         # We make sure both the viewport and rasterviews are lists
         if not isinstance(rasterview, list):
             rasterviews = [rasterview]


### PR DESCRIPTION
This MR adds the option in the context pane dataset chooser to use the clicked dataset.

Also changes the logic of linking rasterviews so when they are linked and you click on one, it will still change the context pane's dataset if the context pane is set to 'Use Clicked Dataset'

Adds tests for this behavior. 