### PR TITLE
Add polygon drawing ability to highlight boxes

### DIFF
--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -523,7 +523,7 @@ class MainViewWidget(RasterPane):
                     elif link_state == GeographicLinkState.PIXEL:
                         compatible_highlights.append(viewport)
                     elif link_state == GeographicLinkState.SPATIAL:
-                        transformed_viewport = self._transform_viewport(viewport, reference_ds, target_ds)
+                        transformed_viewport = self._transform_viewport_to_polygon(viewport, reference_ds, target_ds)
                         compatible_highlights.append(transformed_viewport)
                     else:
                         raise ValueError(f"Got the wrong GeographicLinkState. Got {link_state}!")

--- a/src/wiser/gui/rasterpane.py
+++ b/src/wiser/gui/rasterpane.py
@@ -1870,35 +1870,6 @@ class RasterPane(QWidget):
             viewports = [viewport for viewport in viewports if viewport is not None]
             return viewports
         return None
-
-    def _transform_viewport(self, viewport: QRect, reference_dataset: RasterDataSet, \
-                            target_dataset: RasterDataSet) -> QRect:
-        """
-        Transforms the viewport's pixel coordinates from the reference_dataset
-        into geographic coordinates, then into target_dataset pixel coordinates,
-        and returns a QRect defined by those transformed coordinates.
-
-        Written by LLM.
-        """
-
-        # 1. Extract top-left and bottom-right from the viewport
-        top_left_x = viewport.topLeft().x()
-        top_left_y = viewport.topLeft().y()
-        bottom_right_x = viewport.bottomRight().x()
-        bottom_right_y = viewport.bottomRight().y()
-        
-        # 2. Convert to geographic coordinates using the reference dataset
-        top_left_geo = reference_dataset.to_geographic_coords((top_left_x, top_left_y))
-        bottom_right_geo = reference_dataset.to_geographic_coords((bottom_right_x, bottom_right_y))
-        
-        # 3. Convert those geographic coords to pixel coords in the target dataset
-        top_left_pixel = target_dataset.geo_to_pixel_coords(top_left_geo)      # returns (x, y)
-        bottom_right_pixel = target_dataset.geo_to_pixel_coords(bottom_right_geo)
-        
-        # 4. Construct a new QRect from these transformed pixel coordinates
-        transformed_viewport = QRect(QPoint(*top_left_pixel), QPoint(*bottom_right_pixel))
-        
-        return transformed_viewport
     
     def _transform_viewport_to_polygon(self, viewport: QRect, reference_dataset: RasterDataSet,
                             target_dataset: RasterDataSet) -> QPolygon:


### PR DESCRIPTION
This MR focuses on adding the ability to draw polygons (instead of simple rectangles) for highlight boxes. This is currently used when images in the main view are spatially linked and the zoom pane's highlight box must show in all of them. If images are spatially linked the transformation between them can make the highlight box rectangle become at an angle. This MR  helps draw that. 

![image](https://github.com/user-attachments/assets/bcacb4ac-ead1-4d73-bbda-35bc7da2453f)
