### PR TITLE
test: add tests for Goto Pixel tab in Geo Coords Widget

### DIFF
--- a/src/tests/test_image_coords_widget_gui.py
+++ b/src/tests/test_image_coords_widget_gui.py
@@ -1,0 +1,84 @@
+import os
+
+import unittest
+
+import tests.context
+# import context
+
+import numpy as np
+
+from test_utils.test_model import WiserTestModel
+
+from PySide2.QtCore import *
+from PySide2.QtGui import *
+from PySide2.QtWidgets import *
+
+class TestImageCoordsWidget(unittest.TestCase):
+
+    def setUp(self):
+        self.test_model = WiserTestModel()
+
+    def tearDown(self):
+        self.test_model.close_app()
+        del self.test_model
+    
+    def test_go_to_pixel(self):
+        # Get the directory where the current file is located
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+
+        # Compute the absolute path to the target file
+        target_path = os.path.normpath( \
+            os.path.join(current_dir, "..", "test_utils", "test_datasets", "caltech_4_100_150_nm.hdr"))
+
+        self.test_model.load_dataset(target_path)
+
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+        self.test_model.click_main_view_zoom_in()
+
+        self.test_model.scroll_main_view_rv((0, 0), -100, -100)
+
+        self.test_model.goto_pixel_using_geo_coords_dialog((100, 100))
+
+        self.test_model.cancel_geo_coords_dialog()
+
+        active_spectrum = self.test_model.get_active_spectrum()
+
+        expected_spectrum = np.array([0.13855411, 0.16071412, 0.18646793, 0.18314502])
+
+        self.assertTrue(np.allclose(active_spectrum.get_spectrum(), expected_spectrum))
+
+
+if __name__ == '__main__':
+    test_model = WiserTestModel(use_gui=True)
+
+    # Get the directory where the current file is located
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Compute the absolute path to the target file
+    target_path = os.path.normpath( \
+        os.path.join(current_dir, "..", "test_utils", "test_datasets", "caltech_4_100_150_nm.hdr"))
+
+    test_model.load_dataset(target_path)
+
+    test_model.set_main_view_zoom_level(10)
+
+    test_model.scroll_main_view_rv((0, 0), -100, -100)
+
+    test_model.goto_pixel_using_geo_coords_dialog((100, 100))
+
+    test_model.cancel_geo_coords_dialog()
+
+    active_spectrum = test_model.get_active_spectrum()
+
+    expected_spectrum = np.array([0.13855411, 0.16071412, 0.18646793, 0.18314502])
+
+    test_model.app.exec_()
+
+

--- a/src/tests/test_image_coords_widget_gui.py
+++ b/src/tests/test_image_coords_widget_gui.py
@@ -22,37 +22,37 @@ class TestImageCoordsWidget(unittest.TestCase):
         self.test_model.close_app()
         del self.test_model
 
-    def test_go_to_pixel(self):
-        # Get the directory where the current file is located
-        current_dir = os.path.dirname(os.path.abspath(__file__))
+    # def test_go_to_pixel(self):
+    #     # Get the directory where the current file is located
+    #     current_dir = os.path.dirname(os.path.abspath(__file__))
 
-        # Compute the absolute path to the target file
-        target_path = os.path.normpath( \
-            os.path.join(current_dir, "..", "test_utils", "test_datasets", "caltech_4_100_150_nm.hdr"))
+    #     # Compute the absolute path to the target file
+    #     target_path = os.path.normpath( \
+    #         os.path.join(current_dir, "..", "test_utils", "test_datasets", "caltech_4_100_150_nm.hdr"))
 
-        self.test_model.load_dataset(target_path)
+    #     self.test_model.load_dataset(target_path)
 
-        self.test_model.click_main_view_zoom_in()
-        self.test_model.click_main_view_zoom_in()
-        self.test_model.click_main_view_zoom_in()
-        self.test_model.click_main_view_zoom_in()
-        self.test_model.click_main_view_zoom_in()
-        self.test_model.click_main_view_zoom_in()
-        self.test_model.click_main_view_zoom_in()
-        self.test_model.click_main_view_zoom_in()
-        self.test_model.click_main_view_zoom_in()
+    #     self.test_model.click_main_view_zoom_in()
+    #     self.test_model.click_main_view_zoom_in()
+    #     self.test_model.click_main_view_zoom_in()
+    #     self.test_model.click_main_view_zoom_in()
+    #     self.test_model.click_main_view_zoom_in()
+    #     self.test_model.click_main_view_zoom_in()
+    #     self.test_model.click_main_view_zoom_in()
+    #     self.test_model.click_main_view_zoom_in()
+    #     self.test_model.click_main_view_zoom_in()
 
-        self.test_model.scroll_main_view_rv((0, 0), -100, -100)
+    #     self.test_model.scroll_main_view_rv((0, 0), -100, -100)
 
-        self.test_model.goto_pixel_using_geo_coords_dialog((100, 100))
+    #     self.test_model.goto_pixel_using_geo_coords_dialog((100, 100))
 
-        self.test_model.cancel_geo_coords_dialog()
+    #     self.test_model.cancel_geo_coords_dialog()
 
-        active_spectrum = self.test_model.get_active_spectrum()
+    #     active_spectrum = self.test_model.get_active_spectrum()
 
-        expected_spectrum = np.array([0.13855411, 0.16071412, 0.18646793, 0.18314502])
+    #     expected_spectrum = np.array([0.13855411, 0.16071412, 0.18646793, 0.18314502])
 
-        self.assertTrue(np.allclose(active_spectrum.get_spectrum(), expected_spectrum))
+    #     self.assertTrue(np.allclose(active_spectrum.get_spectrum(), expected_spectrum))
 
 
 if __name__ == '__main__':

--- a/src/tests/test_image_coords_widget_gui.py
+++ b/src/tests/test_image_coords_widget_gui.py
@@ -2,8 +2,8 @@ import os
 
 import unittest
 
-# import tests.context
-import context
+import tests.context
+# import context
 
 import numpy as np
 

--- a/src/tests/test_image_coords_widget_gui.py
+++ b/src/tests/test_image_coords_widget_gui.py
@@ -2,8 +2,8 @@ import os
 
 import unittest
 
-import tests.context
-# import context
+# import tests.context
+import context
 
 import numpy as np
 
@@ -21,7 +21,7 @@ class TestImageCoordsWidget(unittest.TestCase):
     def tearDown(self):
         self.test_model.close_app()
         del self.test_model
-    
+
     def test_go_to_pixel(self):
         # Get the directory where the current file is located
         current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/src/tests/test_image_coords_widget_gui.py
+++ b/src/tests/test_image_coords_widget_gui.py
@@ -71,9 +71,11 @@ if __name__ == '__main__':
 
     test_model.scroll_main_view_rv((0, 0), -100, -100)
 
-    test_model.goto_pixel_using_geo_coords_dialog((100, 100))
+    test_model.open_geo_coords_dialog()
 
-    test_model.cancel_geo_coords_dialog()
+    # test_model.goto_pixel_using_geo_coords_dialog((100, 100))
+
+    # test_model.cancel_geo_coords_dialog()
 
     active_spectrum = test_model.get_active_spectrum()
 

--- a/src/wiser/gui/image_coords_widget.py
+++ b/src/wiser/gui/image_coords_widget.py
@@ -65,6 +65,8 @@ class ImageCoordsWidget(QDialog):
 
         self._ui.tbtn_geo_goto.clicked.connect(self._on_geo_dialog)
 
+        self._dialog: Optional[GeoCoordsDialog] = None
+
     def _set_all_visible(self, visible):
         for w in [self._ui.lbl_pixel, self._ui.lbl_pixel_coords,
                   self._ui.lbl_geo, self._ui.lbl_geo_coords]:
@@ -205,20 +207,20 @@ class ImageCoordsWidget(QDialog):
             self.update_coords(default_dataset, None)
 
         config = self._get_config_for_dataset(self._dataset)
-        dialog = GeoCoordsDialog(self._dataset, config, parent=self)
+        self._dialog = GeoCoordsDialog(self._dataset, config, parent=self)
         dataset_has_geo_srs = (self._dataset is not None and
             self._dataset.get_spatial_ref() is not None)
         if not dataset_has_geo_srs:
-            dialog._ui.tabWidget.setTabVisible(0, False)
-            dialog._ui.tabWidget.setTabVisible(1, False)
-        dialog.config_changed.connect(self._on_display_config_changed)
-        dialog.goto_coord.connect(self._on_goto_coordinate)
+            self._dialog._ui.tabWidget.setTabVisible(0, False)
+            self._dialog._ui.tabWidget.setTabVisible(1, False)
+        self._dialog.config_changed.connect(self._on_display_config_changed)
+        self._dialog.goto_coord.connect(self._on_goto_coordinate)
 
         # corner = self.mapToGlobal(QPoint(self.width(), 0.0))
-        # corner = QPoint(corner.x() - dialog.width(), corner.y() - dialog.height())
-        # dialog.move(corner)
+        # corner = QPoint(corner.x() - self._dialog.width(), corner.y() - self._dialog.height())
+        # self._dialog.move(corner)
 
-        dialog.exec()
+        self._dialog.exec()
 
 
     def _on_display_config_changed(self, ds_id, config):


### PR DESCRIPTION
This MR does what the title says.

This only adds one tests, although it is a pretty important integration tests, but it creates the functionality needed to interact with the Goto Pixel tab. This will allow future tests to be created for this piece with much more ease.

I problem that I ran out of time to fix is that the tests to open up the Geo Coord dialog makes it so when you close the dialog, you can not interact with the main window. Currently, this has only caused an inconvenience when I am testing my tests by having the Gui show what it is doing. This does not affect the test implemented in this MR.