### PR TITLE
Fixed issue with weird white spacing when batch processing is enabled

### DIFF
--- a/src/wiser/gui/bandmath_dialog.py
+++ b/src/wiser/gui/bandmath_dialog.py
@@ -1330,7 +1330,12 @@ class BandMathDialog(QDialog):
             self._ui.btn_output_folder,
             self._ui.chkbox_load_into_wiser,
             self._ui.btn_create_batch_job,
-            self._ui.lbl_select_batch_output
+            self._ui.lbl_select_batch_output,
+            self._ui.hlayout_load_wiser,
+            self._ui.hspace_output_folder,
+            self._ui.hspacer_load_wiser,
+            self._ui.wdgt_load_wiser,
+            self._ui.wdgt_output_folder
         ]
         return ui_components
 

--- a/src/wiser/gui/ui_files/band_math.ui
+++ b/src/wiser/gui/ui_files/band_math.ui
@@ -6,59 +6,348 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>937</width>
-    <height>457</height>
+    <width>988</width>
+    <height>465</height>
    </rect>
+  </property>
+  <property name="contextMenuPolicy">
+   <enum>Qt::PreventContextMenu</enum>
   </property>
   <property name="windowTitle">
    <string>Band Math</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0" columnstretch="1,0,0,0">
-   <property name="horizontalSpacing">
-    <number>6</number>
-   </property>
-   <item row="23" column="0">
-    <widget class="QComboBox" name="cbox_saved_exprs"/>
-   </item>
-   <item row="17" column="0">
-    <layout class="QHBoxLayout" name="hlayout_output_folder">
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="QLabel" name="lbl_output_folder">
-       <property name="text">
-        <string>Output Folder (on disk):</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="ledit_output_folder">
-       <property name="readOnly">
-        <bool>true</bool>
-       </property>
-      </widget>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="11" column="1">
+        <widget class="QPushButton" name="btn_load_saved_exprs">
+         <property name="text">
+          <string>Load from file...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QPushButton" name="btn_create_batch_job">
+         <property name="text">
+          <string>Create Batch Job</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="2">
+        <widget class="QWidget" name="wdgt_output_folder" native="true">
+         <layout class="QGridLayout" name="gridLayout_4">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <layout class="QHBoxLayout" name="hlayout_output_folder">
+            <item>
+             <spacer name="hspace_output_folder">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="lbl_output_folder">
+              <property name="text">
+               <string>Output Folder (on disk):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="ledit_output_folder">
+              <property name="maximumSize">
+               <size>
+                <width>115</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="btn_output_folder">
+              <property name="maximumSize">
+               <size>
+                <width>50</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLineEdit" name="ledit_expression"/>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="lbl_math_expr">
+         <property name="text">
+          <string>Expression:</string>
+         </property>
+         <property name="buddy">
+          <cstring>ledit_expression</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0" colspan="2">
+        <widget class="QWidget" name="wgt_result_name" native="true">
+         <layout class="QGridLayout" name="gridLayout_2">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lbl_result_name">
+            <property name="text">
+             <string>Result name (optional):</string>
+            </property>
+            <property name="buddy">
+             <cstring>ledit_result_name</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="ledit_result_name"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QComboBox" name="cbox_saved_exprs"/>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="lbl_variables">
+           <property name="text">
+            <string>Variable bindings:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="lbl_result_info">
+           <property name="text">
+            <string>Result:  (unknown)</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="chkbox_enable_batch">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bandmath batch processing will perform your&lt;br/&gt;expression on each of the files in the input folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Enable Batch Processing</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="lbl_saved_exprs">
+         <property name="text">
+          <string>Saved expressions:</string>
+         </property>
+         <property name="buddy">
+          <cstring>cbox_saved_exprs</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0" colspan="2">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="QTableWidget" name="tbl_variables">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOn</enum>
+         </property>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="verticalHeaderMinimumSectionSize">
+          <number>23</number>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Variable</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Type</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Variable Assignments</string>
+          </property>
+          <property name="toolTip">
+           <string extracomment="What each variable is assigned to.  When batch processing is enabled, variables can still be none-batch variables."/>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QPushButton" name="btn_input_folder">
+         <property name="text">
+          <string>...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <layout class="QHBoxLayout" name="hlayout_input_folder">
+         <item>
+          <widget class="QLabel" name="lbl_input_folder">
+           <property name="text">
+            <string>Input Folder:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="ledit_input_folder">
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="1">
+        <widget class="QPushButton" name="btn_add_to_saved">
+         <property name="text">
+          <string>Save expression</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1">
+        <widget class="QPushButton" name="btn_save_saved_exprs">
+         <property name="text">
+          <string>Save to file...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QPushButton" name="btn_toggle_help">
+         <property name="text">
+          <string>Toggle Help</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0" colspan="2">
+        <widget class="QWidget" name="wdgt_load_wiser" native="true">
+         <layout class="QGridLayout" name="gridLayout_5">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <layout class="QHBoxLayout" name="hlayout_load_wiser">
+            <item>
+             <widget class="QLabel" name="lbl_select_batch_output">
+              <property name="text">
+               <string>Select Batch Output Destination(s):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="hspacer_load_wiser">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="chkbox_load_into_wiser">
+              <property name="text">
+               <string>Load Into WISER (in memory)</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="chkbox_enable_batch">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bandmath batch processing will perform your&lt;br/&gt;expression on each of the files in the input folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Enable Batch Processing</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lbl_math_expr">
-     <property name="text">
-      <string>Expression:</string>
-     </property>
-     <property name="buddy">
-      <cstring>ledit_expression</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2" rowspan="23">
+   <item row="0" column="1">
     <widget class="QTextEdit" name="tedit_bandmath_help">
      <property name="focusPolicy">
       <enum>Qt::NoFocus</enum>
@@ -110,194 +399,7 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="btn_add_to_saved">
-     <property name="text">
-      <string>Save expression</string>
-     </property>
-    </widget>
-   </item>
-   <item row="18" column="1">
-    <widget class="QPushButton" name="btn_create_batch_job">
-     <property name="text">
-      <string>Create Batch Job</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="lbl_select_batch_output">
-     <property name="text">
-      <string>Select Batch Output Destination(s):</string>
-     </property>
-    </widget>
-   </item>
-   <item row="20" column="0" colspan="2">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0" colspan="2">
-    <widget class="QTableWidget" name="tbl_variables">
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOn</enum>
-     </property>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="verticalHeaderMinimumSectionSize">
-      <number>23</number>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Variable</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Type</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Variable Assignments</string>
-      </property>
-      <property name="toolTip">
-       <string extracomment="What each variable is assigned to.  When batch processing is enabled, variables can still be none-batch variables."/>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="13" column="0" colspan="2">
-    <widget class="QWidget" name="wgt_result_name" native="true">
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="lbl_result_name">
-        <property name="text">
-         <string>Result name (optional):</string>
-        </property>
-        <property name="buddy">
-         <cstring>ledit_result_name</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="ledit_result_name"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QPushButton" name="btn_input_folder">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" rowspan="2" colspan="2">
-    <widget class="QLabel" name="lbl_variables">
-     <property name="text">
-      <string>Variable bindings:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="22" column="0">
-    <widget class="QLabel" name="lbl_saved_exprs">
-     <property name="text">
-      <string>Saved expressions:</string>
-     </property>
-     <property name="buddy">
-      <cstring>cbox_saved_exprs</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="1">
-    <widget class="QPushButton" name="btn_output_folder">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" rowspan="2" colspan="2">
-    <widget class="QLabel" name="lbl_result_info">
-     <property name="text">
-      <string>Result:  (unknown)</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="30" column="3">
-    <layout class="QHBoxLayout" name="hlayout_run_cancel_all">
-     <item>
-      <widget class="QPushButton" name="btn_run_all">
-       <property name="text">
-        <string>Run All</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btn_cancel_all">
-       <property name="text">
-        <string>Cancel All</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="22" column="1">
-    <widget class="QPushButton" name="btn_load_saved_exprs">
-     <property name="text">
-      <string>Load from file...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="30" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="btn_toggle_help">
-     <property name="text">
-      <string>Toggle Help</string>
-     </property>
-    </widget>
-   </item>
-   <item row="23" column="1">
-    <widget class="QPushButton" name="btn_save_saved_exprs">
-     <property name="text">
-      <string>Save to file...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="0">
-    <widget class="QCheckBox" name="chkbox_load_into_wiser">
-     <property name="text">
-      <string>Load Result Into WISER (in memory)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3" rowspan="23">
+   <item row="0" column="2">
     <widget class="QTableWidget" name="tbl_wdgt_batch_jobs">
      <property name="minimumSize">
       <size>
@@ -343,22 +445,29 @@ p, li { white-space: pre-wrap; }
      </column>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLineEdit" name="ledit_expression"/>
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
+     </property>
+    </widget>
    </item>
-   <item row="4" column="0">
-    <layout class="QHBoxLayout" name="hlayout_input_folder">
+   <item row="1" column="2">
+    <layout class="QHBoxLayout" name="hlayout_run_cancel_all">
      <item>
-      <widget class="QLabel" name="lbl_input_folder">
+      <widget class="QPushButton" name="btn_run_all">
        <property name="text">
-        <string>Input Folder:</string>
+        <string>Run All</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="ledit_input_folder">
-       <property name="readOnly">
-        <bool>true</bool>
+      <widget class="QPushButton" name="btn_cancel_all">
+       <property name="text">
+        <string>Cancel All</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Issue occured because invisible batch processing elements still had spacing do to layouts and when everything was in a grid layout, the help screen and batch table widget took up extra rows causing other rows to expand

Closes #187