### PR TITLE
Make bandmatch batch jobs look less editable 

### DIFF
--- a/src/wiser/gui/bandmath_dialog.py
+++ b/src/wiser/gui/bandmath_dialog.py
@@ -656,9 +656,9 @@ class BatchJobInfoWidget(QWidget):
         layout.addWidget(QLabel(self.tr("Input Folder:")))
         le_input = QLineEdit()
         le_input.setReadOnly(True)
+        le_input.setEnabled(False)
         le_input.setText(input_folder)
         le_input.setCursorPosition(0)
-        le_input.setEnabled(False)
         le_input.setToolTip(input_folder)
         layout.addWidget(le_input)
 
@@ -667,9 +667,9 @@ class BatchJobInfoWidget(QWidget):
             layout.addWidget(QLabel(self.tr("Output Folder:")))
             le_output = QLineEdit()
             le_output.setReadOnly(True)
+            le_output.setEnabled(False)
             le_output.setText(output_folder)
             le_output.setCursorPosition(0)
-            le_output.setEnabled(False)
             le_output.setToolTip(output_folder)
             layout.addWidget(le_output)
 

--- a/src/wiser/gui/bandmath_dialog.py
+++ b/src/wiser/gui/bandmath_dialog.py
@@ -635,14 +635,15 @@ class BatchJobInfoWidget(QWidget):
         layout.setSpacing(4)
 
         # Expression (label + read-only line edit)
-        layout.addWidget(QLabel("Expression:"))
+        layout.addWidget(QLabel(self.tr("Expression:")))
         le_expr = QLineEdit()
         le_expr.setReadOnly(True)
+        le_expr.setEnabled(False)
         le_expr.setText(expression)
         le_expr.setToolTip(expression)
         layout.addWidget(le_expr)
 
-        layout.addWidget(QLabel("Assignments:"))
+        layout.addWidget(QLabel(self.tr("Assignments:")))
 
         lbl_assign = QLabel()
         lbl_assign.setWordWrap(False)  # single line
@@ -652,21 +653,23 @@ class BatchJobInfoWidget(QWidget):
         layout.addWidget(lbl_assign)
 
         # Input Folder (label + read-only line edit)
-        layout.addWidget(QLabel("Input Folder:"))
+        layout.addWidget(QLabel(self.tr("Input Folder:")))
         le_input = QLineEdit()
         le_input.setReadOnly(True)
         le_input.setText(input_folder)
         le_input.setCursorPosition(0)
+        le_input.setEnabled(False)
         le_input.setToolTip(input_folder)
         layout.addWidget(le_input)
 
         # Output Folder (only if exists)
         if output_folder:
-            layout.addWidget(QLabel("Output Folder:"))
+            layout.addWidget(QLabel(self.tr("Output Folder:")))
             le_output = QLineEdit()
             le_output.setReadOnly(True)
             le_output.setText(output_folder)
-            le_input.setCursorPosition(0)
+            le_output.setCursorPosition(0)
+            le_output.setEnabled(False)
             le_output.setToolTip(output_folder)
             layout.addWidget(le_output)
 
@@ -674,9 +677,10 @@ class BatchJobInfoWidget(QWidget):
                                  ":/icons/wiser.ico"))
 
         # Result Prefix (label + read-only line edit)
-        layout.addWidget(QLabel("Result Prefix:"))
+        layout.addWidget(QLabel(self.tr("Result Prefix:")))
         le_result = QLineEdit()
         le_result.setReadOnly(True)
+        le_result.setEnabled(False)
         le_result.setText(result_name)
         le_result.setToolTip(result_name)
         layout.addWidget(le_result)


### PR DESCRIPTION
Make the bandmatch batch jobs look less editable. They now look like this:
<img width="336" height="282" alt="image" src="https://github.com/user-attachments/assets/edd41ae1-7f2c-4fad-ad69-1b60ce4c7e26" />

Before, the line edits for expression, input folder, output folder, and result prefix looked editable (they were not greyed out) even though they weren't editable.
