### PR TITLE
Fixed isse with tiled rasterviews showing while bandmath batch runs

### DIFF
--- a/src/wiser/gui/context_pane.py
+++ b/src/wiser/gui/context_pane.py
@@ -13,6 +13,7 @@ from .rasterpane import RasterPane
 from .dataset_chooser import DatasetChooser
 from .util import add_toolbar_action
 from .app_state import ApplicationState
+from wiser.raster.dataset import find_display_bands
 
 class ContextPaneDatasetChooser(DatasetChooser):
     '''
@@ -147,6 +148,9 @@ class ContextPane(RasterPane):
             stretches = None
             if dataset is not None:
                 ds_id = dataset.get_id()
+                if ds_id not in self._display_bands:
+                    display_bands = find_display_bands(dataset)
+                    self._display_bands[ds_id] = display_bands
                 bands = self._display_bands[ds_id]
                 stretches = self._app_state.get_stretches(ds_id, bands)
 


### PR DESCRIPTION
Fixed an issue. When bandmath runs and you exit out and you have a tiled raster view open, it would error when you clicked one of the tiled rasterviews to open the dataset that bandmath just created.