### PR TITLE
Stop duplicate Github actions when pushing to a pull request for all branches

### DIFF
--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   pre:
+    name: Skip Duplicate Actions Check
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip.outputs.should_skip }}

--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -2,19 +2,22 @@
 name: Run tests and linting with linux-cached-dev
 
 on:
-  # Run on any push EXCEPT when the lock changed
+  # Below code (on: push:) says whenever the main branch or a rel/** branch
+  # is pushed to, we run these jobs 
   push:
     paths-ignore:
       - "etc/dev-conda-lock.yml"
     branches:
       - main
       - 'rel/**'
-      - 'feat/*'
+  # Below code (on: pull_request:) says whenever the main branch or a rel/**
+  # has a PR opened for it, then whenever a push happens to that PR, we run
+  # these jobs. Duplicates job runs can occur if we have a rel/** branch
+  # PR that targets another rel/** branch or main 
   pull_request:
     branches:
       - main
       - 'rel/**'
-      - 'feat/*'
   # The idea here is that if someone made a change to just the lockfiles
   # we want to both refresh the cache and make sure our tests still run
   # so we ignore changes to dev lockfile changes here and let the

--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -6,7 +6,15 @@ on:
   push:
     paths-ignore:
       - "etc/dev-conda-lock.yml"
-  pull_request: {}
+    branches:
+      - main
+      - 'rel/**'
+      - 'feat/*'
+  pull_request:
+    branches:
+      - main
+      - 'rel/**'
+      - 'feat/*'
   # The idea here is that if someone made a change to just the lockfiles
   # we want to both refresh the cache and make sure our tests still run
   # so we ignore changes to dev lockfile changes here and let the
@@ -18,8 +26,18 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  pre:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip.outputs.should_skip }}
+    steps:
+      - id: skip
+        uses: fkirc/skip-duplicate-actions@v5
+
   lint:
     name: Ruff lint & format check
+    needs: [pre]
+    if: ${{ needs.pre.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We want to get rid of duplicate actions. We use fkirc/skip-duplicate-actions@v5 to do this (community github action that uses the [Check Runs API](https://docs.github.com/en/rest/checks?apiVersion=2022-11-28), learn more [here](https://stackoverflow.com/questions/74441152/how-to-avoid-the-duplicated-job-in-github-action-like-build-image?utm_source=chatgpt.com)). 

We also only want to automatically run the linting and tests when we are pushing to and we are PR targeting an important branch (like `main` or a release branch (`rel/**`)). 
I did this by only running the _Run tests and linting with linux-cached-dev_ workflow when a push is made directly to `main` or a release branch (`re/**`) or when a push is made to a PR that targets `main` or `rel/**` is done.

Currently, the only possible way duplication is to have a PR that goes from main to rel/** or rel/** to rel/** or rel** to main.

These PR implements these wants.