### PR TITLE
Adds test spectra to distributable, fixes issue with --test_mode in distributable

### DIFF
--- a/WISER-macOS.spec
+++ b/WISER-macOS.spec
@@ -21,6 +21,7 @@ existing_datas = [
                  ('./src/wiser/bandmath/bandmath.lark', 'wiser/bandmath'),
                  ('./src/wiser/data', 'wiser/data'),
                  ('./src/test_utils/test_datasets', 'test_utils/test_datasets'),
+                 ('./src/test_utils/test_spectra', 'test_utils/test_spectra'),
                  ('./src/tests', 'tests'),
              ]
 

--- a/WISER.spec
+++ b/WISER.spec
@@ -24,6 +24,7 @@ datas = [
          ('src\\wiser\\bandmath\\bandmath.lark', 'wiser\\bandmath'),
          ('src\\wiser\\data', 'wiser\\data'),
          ('src\\test_utils\\test_datasets', 'test_utils\\test_datasets'),
+         ('src\\test_utils\\test_spectra', 'test_utils\\test_spectra'),
          ('src\\tests', 'tests'),
         ]
 binaries = [

--- a/src/tests/test_continuum_removal.py
+++ b/src/tests/test_continuum_removal.py
@@ -89,8 +89,15 @@ class TestContinuumRemoval(unittest.TestCase):
         """
         plugin = ContinuumRemovalPlugin()
 
-        load_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        load_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         ground_truth_path = os.path.join(
+            os.path.dirname(__file__),
             "..",
             "test_utils",
             "test_datasets",
@@ -168,7 +175,13 @@ class TestContinuumRemoval(unittest.TestCase):
             raise RuntimeError("Couldn't extract all values from spectrum!")
 
         # Load in the dataset where the above continuum removed spectrum comes from
-        load_path = os.path.join("..", "test_utils", "test_datasets", "caltech_425_7_7_nm")
+        load_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_425_7_7_nm",
+        )
 
         dataset = self.test_model.load_dataset(load_path)
         img_data = dataset.get_image_data()
@@ -314,9 +327,19 @@ class TestContinuumRemoval(unittest.TestCase):
         """Test subsetting continuum removal for the 425x7x7 dataset to be a 225x4x3 dataset"""
         plugin = ContinuumRemovalPlugin()
 
-        load_path = os.path.join("..", "test_utils", "test_datasets", "caltech_425_7_7_nm")
+        load_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_425_7_7_nm",
+        )
         ground_truth_path = os.path.join(
-            "..", "test_utils", "test_datasets", "caltech_225_4_3_nm_continuum_removed"
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_225_4_3_nm_continuum_removed",
         )
 
         dataset = self.test_model.load_dataset(load_path)

--- a/src/tests/test_continuum_removal.py
+++ b/src/tests/test_continuum_removal.py
@@ -21,8 +21,12 @@ from typing import Optional
 from test_utils.test_model import WiserTestModel
 
 from wiser.gui.permanent_plugins.continuum_removal_plugin import (
-    ContinuumRemovalPlugin, continuum_removal_image_numba, continuum_removal_image,
-    continuum_removal_numba, continuum_removal)
+    ContinuumRemovalPlugin,
+    continuum_removal_image_numba,
+    continuum_removal_image,
+    continuum_removal_numba,
+    continuum_removal,
+)
 
 from wiser.utils.numba_wrapper import convert_to_float32_if_needed
 
@@ -74,7 +78,6 @@ class TestContinuumRemoval(unittest.TestCase):
         #     print(f"{name} = np.array([{arr_str}])\n")
 
         return header, data
-
 
     def test_continuum_removal_image_4_bands(self):
         """Tests image-based continuum removal against a ground-truth output.
@@ -133,9 +136,13 @@ class TestContinuumRemoval(unittest.TestCase):
 
     def test_numba_non_numba_same_425_bands_and_nan(self):
         # Load in the ground truth continuum removed spectrum
-        spectrum_file_path = \
-            os.path.join(os.path.dirname(__file__),
-                         "..", "test_utils", "test_spectra", "cr_single_spectrum_at_3_3_bands_425.txt")
+        spectrum_file_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_spectra",
+            "cr_single_spectrum_at_3_3_bands_425.txt",
+        )
         header, data = self.read_file(spectrum_file_path)
         wvls_arr: Optional[np.ndarray] = None
         spectrum_arr: Optional[np.ndarray] = None
@@ -144,18 +151,20 @@ class TestContinuumRemoval(unittest.TestCase):
 
         for i, name in enumerate(header):
             col = data[:, i]
-            if name == 'Wavelength (nm)':
+            if name == "Wavelength (nm)":
                 wvls_arr = col
-            elif name == 'Spectrum at (3, 3)':
+            elif name == "Spectrum at (3, 3)":
                 spectrum_arr = col
-            elif name == 'Spectrum at (3, 3) Continuum Removed':
+            elif name == "Spectrum at (3, 3) Continuum Removed":
                 spectrum_continuum_removed_arr = col
-            elif name == 'Convex Hull Spectrum at (3, 3)':
+            elif name == "Convex Hull Spectrum at (3, 3)":
                 convex_hull = col
-        if (wvls_arr is None or 
-            spectrum_arr is None or
-            convex_hull is None or
-            spectrum_continuum_removed_arr is None):
+        if (
+            wvls_arr is None
+            or spectrum_arr is None
+            or convex_hull is None
+            or spectrum_continuum_removed_arr is None
+        ):
             raise RuntimeError("Couldn't extract all values from spectrum!")
 
         # Load in the dataset where the above continuum removed spectrum comes from
@@ -180,16 +189,18 @@ class TestContinuumRemoval(unittest.TestCase):
         img_data, x_axis = convert_to_float32_if_needed(img_data, x_axis)
         bad_bands_arr = np.array(dataset.get_bad_bands())
         bad_bands_arr = np.logical_not(bad_bands_arr)
-        new_image_data_numba = continuum_removal_image_numba(img_data, bad_bands_arr, x_axis, rows, cols, bands)
+        new_image_data_numba = continuum_removal_image_numba(
+            img_data, bad_bands_arr, x_axis, rows, cols, bands
+        )
         new_image_data_non_numba = continuum_removal_image(img_data, bad_bands_arr, x_axis, rows, cols, bands)
 
-        first_band_all_ones = np.all((new_image_data_numba[0]==1) | np.isnan(new_image_data_numba[0]))
-        last_band_all_ones = np.all((new_image_data_numba[-1]==1) | np.isnan(new_image_data_numba[-1]))
+        first_band_all_ones = np.all((new_image_data_numba[0] == 1) | np.isnan(new_image_data_numba[0]))
+        last_band_all_ones = np.all((new_image_data_numba[-1] == 1) | np.isnan(new_image_data_numba[-1]))
         self.assertTrue(np.allclose(new_image_data_numba, new_image_data_non_numba, equal_nan=True))
         self.assertTrue(first_band_all_ones)
         self.assertTrue(last_band_all_ones)
 
-        new_spectrum_3_3_numba = new_image_data_numba[:,3,3]
+        new_spectrum_3_3_numba = new_image_data_numba[:, 3, 3]
 
         self.assertTrue(np.allclose(new_spectrum_3_3_numba, spectrum_continuum_removed_arr, equal_nan=True))
 
@@ -250,9 +261,9 @@ class TestContinuumRemoval(unittest.TestCase):
         """
         Calculate the spectra from numba and non numba and make sure they are equal
         """
-        spectrum_file_path = \
-            os.path.join(os.path.dirname(__file__),
-                         "..", "test_utils", "test_spectra", "cr_single_spectrum.txt")
+        spectrum_file_path = os.path.join(
+            os.path.dirname(__file__), "..", "test_utils", "test_spectra", "cr_single_spectrum.txt"
+        )
         header, data = self.read_file(spectrum_file_path)
         wvls_arr: Optional[np.ndarray] = None
         spectrum_arr: Optional[np.ndarray] = None
@@ -261,43 +272,42 @@ class TestContinuumRemoval(unittest.TestCase):
 
         for i, name in enumerate(header):
             col = data[:, i]
-            if name == 'Wavelength (nm)':
+            if name == "Wavelength (nm)":
                 wvls_arr = col
-            elif name == 'Spectrum':
+            elif name == "Spectrum":
                 spectrum_arr = col
-            elif name == 'Spectrum Continuum Removed':
+            elif name == "Spectrum Continuum Removed":
                 spectrum_continuum_removed_arr = col
-            elif name == 'Convex Hull Spectrum':
+            elif name == "Convex Hull Spectrum":
                 convex_hull = col
-        if (wvls_arr is None or 
-            spectrum_arr is None or
-            convex_hull is None or
-            spectrum_continuum_removed_arr is None):
+        if (
+            wvls_arr is None
+            or spectrum_arr is None
+            or convex_hull is None
+            or spectrum_continuum_removed_arr is None
+        ):
             raise RuntimeError("Couldn't extract all values from spectrum!")
 
-        spectrum = \
-            NumPyArraySpectrum(spectrum_arr, "Test_Spectrum", wavelengths=wvls_arr)
-        ground_truth_hull = \
-            NumPyArraySpectrum(convex_hull, "Convex_Hull", wavelengths=wvls_arr)
-        ground_truth_continuum_removed = \
-            NumPyArraySpectrum(spectrum_continuum_removed_arr, "Continuum_Removed", wavelengths=wvls_arr)
-        
-        cr_numba_spec, cr_numba_hull = \
-            continuum_removal_numba(
-                reflectance=spectrum_arr.astype(np.float32),
-                waves=wvls_arr.astype(np.float32)[::-1]
-            )
+        spectrum = NumPyArraySpectrum(spectrum_arr, "Test_Spectrum", wavelengths=wvls_arr)
+        ground_truth_hull = NumPyArraySpectrum(convex_hull, "Convex_Hull", wavelengths=wvls_arr)
+        ground_truth_continuum_removed = NumPyArraySpectrum(
+            spectrum_continuum_removed_arr, "Continuum_Removed", wavelengths=wvls_arr
+        )
 
-        cr_reg_spec, cr_reg_hull = \
-            continuum_removal(
-                reflectance=spectrum.get_spectrum(),
-                waves=spectrum.get_wavelengths()[::-1]
-            )
+        cr_numba_spec, cr_numba_hull = continuum_removal_numba(
+            reflectance=spectrum_arr.astype(np.float32), waves=wvls_arr.astype(np.float32)[::-1]
+        )
+
+        cr_reg_spec, cr_reg_hull = continuum_removal(
+            reflectance=spectrum.get_spectrum(), waves=spectrum.get_wavelengths()[::-1]
+        )
 
         assert cr_numba_spec.shape == cr_reg_spec.shape
         assert np.allclose(cr_numba_spec, cr_reg_spec, atol=1e-07, equal_nan=True)
         assert np.allclose(cr_numba_hull, cr_reg_hull, atol=1e-07, equal_nan=True)
-        assert np.allclose(cr_numba_spec, ground_truth_continuum_removed.get_spectrum(), atol=1e-07, equal_nan=True)
+        assert np.allclose(
+            cr_numba_spec, ground_truth_continuum_removed.get_spectrum(), atol=1e-07, equal_nan=True
+        )
         assert np.allclose(cr_numba_hull, ground_truth_hull.get_spectrum(), atol=1e-07, equal_nan=True)
 
     def test_subset_425_bands_and_nan(self):
@@ -305,23 +315,22 @@ class TestContinuumRemoval(unittest.TestCase):
         plugin = ContinuumRemovalPlugin()
 
         load_path = os.path.join("..", "test_utils", "test_datasets", "caltech_425_7_7_nm")
-        ground_truth_path = os.path.join("..", "test_utils", "test_datasets", "caltech_225_4_3_nm_continuum_removed")
+        ground_truth_path = os.path.join(
+            "..", "test_utils", "test_datasets", "caltech_225_4_3_nm_continuum_removed"
+        )
 
         dataset = self.test_model.load_dataset(load_path)
         gt_dataset = self.test_model.load_dataset(ground_truth_path)
 
         min_cols = 2
         min_rows = 2
-        max_cols = dataset.get_width()-2
-        max_rows = dataset.get_height()-1
+        max_cols = dataset.get_width() - 2
+        max_rows = dataset.get_height() - 1
 
         min_band = 100
-        max_band = dataset.num_bands()-100
+        max_band = dataset.num_bands() - 100
 
-        context = {
-            "wiser": self.test_model.app_state,
-            "dataset": dataset
-        }
+        context = {"wiser": self.test_model.app_state, "dataset": dataset}
 
         cr_dataset = plugin.image(min_cols, min_rows, max_cols, max_rows, min_band, max_band, context)
 
@@ -330,14 +339,14 @@ class TestContinuumRemoval(unittest.TestCase):
         self.assertTrue(cr_dataset_arr.shape == (225, 4, 3))
 
         # Continuum removal algorithm should make the first and last bands all one
-        first_band_all_ones = np.all((cr_dataset_arr[0]==1) | np.isnan(cr_dataset_arr[0]))
-        last_band_all_ones = np.all((cr_dataset_arr[-1]==1) | np.isnan(cr_dataset_arr[-1]))
+        first_band_all_ones = np.all((cr_dataset_arr[0] == 1) | np.isnan(cr_dataset_arr[0]))
+        last_band_all_ones = np.all((cr_dataset_arr[-1] == 1) | np.isnan(cr_dataset_arr[-1]))
         self.assertTrue(first_band_all_ones)
         self.assertTrue(last_band_all_ones)
 
         # Continuum removal algorithm should make everything less than one
         all_less_than_one = np.nanmax(cr_dataset_arr) <= 1
-        
+
         self.assertTrue(all_less_than_one)
         self.assertTrue(np.allclose(cr_dataset_arr, gt_dataset_arr, equal_nan=True))
         self.assertTrue(cr_dataset.get_spatial_ref().IsSame(gt_dataset.get_spatial_ref()))

--- a/src/tests/test_crs_creator_gui.py
+++ b/src/tests/test_crs_creator_gui.py
@@ -227,7 +227,13 @@ class TestCRSCreator(unittest.TestCase):
 
         added_crs = self.test_model.app_state.get_user_created_crs()[name][0]
 
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         ds = self.test_model.load_dataset(rel_path)
 
         self.test_model.set_geo_ref_target_dataset(ds.get_id())
@@ -235,7 +241,13 @@ class TestCRSCreator(unittest.TestCase):
 
         self.test_model.set_geo_ref_output_crs(UserGeneratedCRS(name, added_crs))
         self.test_model.set_geo_ref_polynomial_order("2")
-        save_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm_test_crs.tif")
+        save_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm_test_crs.tif",
+        )
         self.test_model.set_geo_ref_file_save_path(save_path)
 
         gcp_list = [
@@ -261,7 +273,11 @@ class TestCRSCreator(unittest.TestCase):
         test_geo_transform = testing_ds.get_geo_transform()
 
         ground_truth_ds_path = os.path.join(
-            "..", "test_utils", "test_datasets", "caltech_4_100_150_nm_epsg4087.tif"
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm_epsg4087.tif",
         )
         ground_truth_ds = self.test_model.load_dataset(ground_truth_ds_path)
         ground_truth_geo_transform = ground_truth_ds.get_geo_transform()
@@ -310,7 +326,13 @@ if __name__ == "__main__":
         [(58, 91), (395700.79550318926, 3778106.3770755623)],
     ]
 
-    rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+    rel_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "test_utils",
+        "test_datasets",
+        "caltech_4_100_150_nm",
+    )
     ds = test_model.load_dataset(rel_path)
 
     test_model.open_geo_referencer()
@@ -332,15 +354,33 @@ if __name__ == "__main__":
         test_model.press_enter_reference_image()
 
     test_model.set_geo_ref_polynomial_order("2")
-    save_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm_test_crs.tif")
+    save_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "test_utils",
+        "test_datasets",
+        "caltech_4_100_150_nm_test_crs.tif",
+    )
     test_model.set_geo_ref_file_save_path(save_path)
 
     test_model.set_geo_ref_output_crs(UserGeneratedCRS(name, added_crs))
 
-    rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm_test_crs.tif")
+    rel_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "test_utils",
+        "test_datasets",
+        "caltech_4_100_150_nm_test_crs.tif",
+    )
     ds = test_model.load_dataset(rel_path)
 
-    rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm_epsg4087.tif")
+    rel_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "test_utils",
+        "test_datasets",
+        "caltech_4_100_150_nm_epsg4087.tif",
+    )
     ds = test_model.load_dataset(rel_path)
 
     test_model.app.exec_()

--- a/src/tests/test_geo_ref_gui.py
+++ b/src/tests/test_geo_ref_gui.py
@@ -68,7 +68,13 @@ class TestGeoReferencerGUI(unittest.TestCase):
         - Runs the warp operation.
         - Compares the resulting geo-transform to a known ground truth.
         """
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         ds = self.test_model.load_dataset(rel_path)
 
         self.test_model.open_geo_referencer()
@@ -106,7 +112,14 @@ class TestGeoReferencerGUI(unittest.TestCase):
 
         self.test_model.set_geo_ref_polynomial_order("2")
 
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "artifacts", "test_warp_output.tif")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "artifacts",
+            "test_warp_output.tif",
+        )
         self.test_model.set_geo_ref_file_save_path(rel_path)
 
         ground_truth_geo_transform = (
@@ -145,7 +158,13 @@ class TestGeoReferencerGUI(unittest.TestCase):
         - Disables and removes invalid GCPs.
         - Executes the warp and checks the output affine transform.
         """
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         ds = self.test_model.load_dataset(rel_path)
 
         self.test_model.open_geo_referencer()
@@ -196,7 +215,14 @@ class TestGeoReferencerGUI(unittest.TestCase):
             self.test_model.enter_lon_east_geo_ref(lon_east)
             self.test_model.press_enter_lon_east_geo_ref()
 
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "artifacts", "test_warp_output.tif")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "artifacts",
+            "test_warp_output.tif",
+        )
         self.test_model.set_geo_ref_file_save_path(rel_path)
 
         ground_truth_geo_transform = (
@@ -231,7 +257,13 @@ Code to make sure tests work as desired
 if __name__ == "__main__":
     test_model = WiserTestModel(use_gui=True)
 
-    rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+    rel_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "test_utils",
+        "test_datasets",
+        "caltech_4_100_150_nm",
+    )
     ds = test_model.load_dataset(rel_path)
 
     test_model.open_geo_referencer()
@@ -282,7 +314,14 @@ if __name__ == "__main__":
         test_model.enter_lon_east_geo_ref(lon_east)
         test_model.press_enter_lon_east_geo_ref()
 
-    rel_path = os.path.join("..", "test_utils", "test_datasets", "artifacts", "test_warp_output.tif")
+    rel_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "test_utils",
+        "test_datasets",
+        "artifacts",
+        "test_warp_output.tif",
+    )
     test_model.set_geo_ref_file_save_path(rel_path)
 
     # Disables and re-enables

--- a/src/tests/test_interactive_scatter_plot.py
+++ b/src/tests/test_interactive_scatter_plot.py
@@ -1,6 +1,7 @@
 """
 Test to make sure the interactive scatter plot works as intended
 """
+import os
 import unittest
 
 from matplotlib import use
@@ -12,7 +13,7 @@ from test_utils.test_model import WiserTestModel
 
 import numpy as np
 
-from PySide2.QtTest import QTest
+
 from PySide2.QtCore import *
 from PySide2.QtGui import *
 from PySide2.QtWidgets import *
@@ -44,32 +45,59 @@ class TestInteractiveScatterPlot(unittest.TestCase):
         Ensure that all of the correct points are plotted in the scatter plot and the highlight
         region is created correctly.
         """
-        np_impl = np.array(
+        np_arr = np.array(
             [
                 [
                     [0.0, np.nan, 0.0, 1.0],
-                    [0.25, 0.25, 0.25, 0.25],
+                    [0.25, 0.25, 0.25, np.nan],
                     [0.5, 0.5, 0.5, 0.5],
                     [0.75, 0.75, 0.75, 0.75],
                     [1.0, 1.0, 1.0, 1.0],
                 ],
                 [
-                    [0.0, 1.0, 2.0, 0.0],
-                    [0.25, 0.25, 0.25, 0.25],
-                    [0.5, 0.5, 0.5, 0.5],
-                    [0.75, 0.75, 0.75, 0.75],
-                    [1.0, 1.0, 1.0, 1.0],
+                    [0.0, 1.0, np.nan, 0.0],
+                    [0.25, 0.25, np.nan, 0.25],
+                    [0.5, 0.5, np.nan, 0.5],
+                    [0.75, 0.75, np.nan, 0.75],
+                    [1.0, 1.0, np.nan, 1.0],
                 ],
                 [
                     [0.0, 2.0, 1.0, 2.0],
                     [0.25, 0.25, 0.25, 0.25],
-                    [0.5, 0.5, 0.5, 0.5],
+                    [0.5, np.nan, 0.5, 0.5],
                     [0.75, 0.75, np.nan, 0.75],
-                    [1.0, 1.0, 1.0, 1.0],
+                    [np.nan, 1.0, 1.0, 1.0],
                 ],
             ]
         )
 
+        np_mask = np.array(
+            [
+                [
+                    [0, 1, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                ],
+                [
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                ],
+                [
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 1, 0],
+                    [1, 0, 0, 0],
+                ],
+            ]
+        )
+
+        np_impl = np.ma.array(np_arr, mask=np_mask)
         ds = self.test_model.load_dataset(np_impl)
         self.test_model.click_zoom_to_fit()
         self.test_model.open_interactive_scatter_plot_context_menu()
@@ -85,7 +113,7 @@ class TestInteractiveScatterPlot(unittest.TestCase):
         xy_truth = np.column_stack([x_truth, y_truth])
         self.assertTrue(np.array_equal(xy, xy_truth, equal_nan=True))
 
-        highlighted_points_truth = [(1, 0), (1, 1), (1, 2), (1, 3)]
+        highlighted_points_truth = [(1, 0), (1, 1), (1, 2)]
         self.test_model.create_polygon_in_interactive_scatter_plot(
             [(0.1, 0), (0.1, 0.49), (0.49, 0.49), (0.49, 0.1), (0.1, 0)]
         )

--- a/src/tests/test_similarity_transform_gui.py
+++ b/src/tests/test_similarity_transform_gui.py
@@ -52,8 +52,15 @@ class TestSimliarityTransformGUI(unittest.TestCase):
             The transformed array matches the ground truth array.
             The geotransform metadata is identical to the ground truth.
         """
-        load_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        load_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         ground_truth_path = os.path.join(
+            os.path.dirname(__file__),
             "..",
             "test_utils",
             "test_datasets",
@@ -61,6 +68,7 @@ class TestSimliarityTransformGUI(unittest.TestCase):
         )
 
         temp_save_path = os.path.join(
+            os.path.dirname(__file__),
             "..",
             "test_utils",
             "test_datasets",
@@ -117,8 +125,15 @@ class TestSimliarityTransformGUI(unittest.TestCase):
         Asserts:
             The translated geotransform matches the expected values.
         """
-        load_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        load_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         temp_save_path = os.path.join(
+            os.path.dirname(__file__),
             "..",
             "test_utils",
             "test_datasets",
@@ -164,7 +179,13 @@ Code to make sure tests work as desired. Feel free to change to your needs.
 if __name__ == "__main__":
     test_model = WiserTestModel(use_gui=True)
 
-    rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+    rel_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "test_utils",
+        "test_datasets",
+        "caltech_4_100_150_nm",
+    )
     ds = test_model.load_dataset(rel_path)
 
     test_model.open_similarity_transform_dialog()
@@ -179,6 +200,7 @@ if __name__ == "__main__":
     test_model.choose_interpolation_rs(2)
 
     save_path = os.path.join(
+        os.path.dirname(__file__),
         "..",
         "test_utils",
         "test_datasets",

--- a/src/tests/test_spectrum_plot_gui.py
+++ b/src/tests/test_spectrum_plot_gui.py
@@ -94,7 +94,13 @@ class TestSpectrumPlotUI(unittest.TestCase):
 
         Loads an ENVI dataset and verifies that the x-axis of the spectrum plot is labeled in nanometers.
         """
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         self.test_model.load_dataset(rel_path)
 
         self.test_model.click_raster_coord_main_view_rv((0, 0), (0, 0))
@@ -110,7 +116,13 @@ class TestSpectrumPlotUI(unittest.TestCase):
 
         Loads an ENVI dataset and verifies that the x-axis of the spectrum plot is labeled in nanometers.
         """
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         self.test_model.load_dataset(rel_path)
 
         self.test_model.click_raster_coord_zoom_pane((0, 0))
@@ -130,11 +142,23 @@ class TestSpectrumPlotUI(unittest.TestCase):
         self.test_model.set_main_view_layout((1, 2))
 
         # This will be in the (0, 0) raster view position
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         self.test_model.load_dataset(rel_path)
 
         # This will be in the (0, 1) raster view position
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "circuit_4_100_150_um")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "circuit_4_100_150_um",
+        )
         self.test_model.load_dataset(rel_path)
 
         # Switch back to nanometer units
@@ -189,7 +213,13 @@ class TestSpectrumPlotUI(unittest.TestCase):
 
         np_ds = self.test_model.load_dataset(np_impl)
 
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         self.test_model.load_dataset(rel_path)
 
         # Get a spectrum with wavelength nm in spectrum plot
@@ -247,7 +277,13 @@ class TestSpectrumPlotUI(unittest.TestCase):
 
         np_ds = self.test_model.load_dataset(np_impl)
 
-        rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
         self.test_model.load_dataset(rel_path)
 
         # Get a spectrum with wavelength nm in spectrum plot
@@ -448,7 +484,13 @@ if __name__ == "__main__":
     # # Repeat the 2D array across 3 channels to get a 3x50x50 array
     # np_impl = np.repeat(impl[np.newaxis, :, :], channels, axis=0)
 
-    rel_path = os.path.join("..", "test_utils", "test_datasets", "caltech_4_100_150_nm")
+    rel_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "test_utils",
+        "test_datasets",
+        "caltech_4_100_150_nm",
+    )
     ds = test_model.load_dataset(rel_path)
 
     pixel_to_click = (0, 0)

--- a/src/wiser/gui/scatter_plot_2D.py
+++ b/src/wiser/gui/scatter_plot_2D.py
@@ -111,10 +111,15 @@ def _create_scatter_plot_intensive_operations(
     # Safe mins/maxes for axes panel defaults
     new_x = np.array([n for n in x if not np.isnan(n)])
     new_y = np.array([m for m in y if not np.isnan(m)])
-    default_x_min = min(new_x)
-    default_x_max = max(new_x)
-    default_y_min = min(new_y)
-    default_y_max = max(new_y)
+    default_x_min = np.nanmin(new_x)
+    default_x_max = np.nanmax(new_x)
+    default_y_min = np.nanmin(new_y)
+    default_y_max = np.nanmax(new_y)
+
+    assert not np.isnan(default_x_min), "default_x_min is nan"
+    assert not np.isnan(default_x_max), "default_x_max is nan"
+    assert not np.isnan(default_y_min), "default_y_min is nan"
+    assert not np.isnan(default_y_max), "default_y_max is nan"
 
     return_queue.put(
         {
@@ -865,6 +870,12 @@ class ScatterPlot2DDialog(QDialog):
         density = ax.scatter_density(x, y, cmap=colormap[1])
         x_range = max(self._x_max - self._x_min, 0)
         y_range = max(self._y_max - self._y_min, 0)
+        print(f"x_range: {x_range}")
+        print(f"y_range: {y_range}")
+        print(f"self._x_min: {self._x_min}")
+        print(f"self._x_max: {self._x_max}")
+        print(f"self._y_min: {self._y_min}")
+        print(f"self._y_max: {self._y_max}")
         ax.set_xlim(self._x_min - x_range / 10, self._x_max + x_range / 10)
         ax.set_ylim(self._y_min - y_range / 10, self._y_max + y_range / 10)
         fig.colorbar(density, label="Number of points per spectral value")
@@ -893,6 +904,12 @@ class ScatterPlot2DDialog(QDialog):
         ax.scatter(x, y, s=1, c="#1f77b4", alpha=0.6, linewidths=0)
         x_range = max(self._x_max - self._x_min, 0)
         y_range = max(self._y_max - self._y_min, 0)
+        print(f"x_range: {x_range}")
+        print(f"y_range: {y_range}")
+        print(f"self._x_min: {self._x_min}")
+        print(f"self._x_max: {self._x_max}")
+        print(f"self._y_min: {self._y_min}")
+        print(f"self._y_max: {self._y_max}")
         ax.set_xlim(self._x_min - x_range / 10, self._x_max + x_range / 10)
         ax.set_ylim(self._y_min - y_range / 10, self._y_max + y_range / 10)
 


### PR DESCRIPTION
Fixed bug with interactive scatter plot (tests didn't detect and I couldn't get the tests to detect it, the bug was happening on the caltech image _ang20171108t184227_corr_v2p13_subset_bil_)
and fixed bug with evaluator_bandmath tests not working in --test_mode.

Also made --test_mode take in CL arguments for specific files to test

Closes #269 

Closes #270