### PR TITLE
docs: Added bug submitting guide to sphinx docs

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/contributing.rst
+++ b/doc/sphinx-general-wiser-docs/source/contributing.rst
@@ -10,3 +10,5 @@ what you have found.
     :caption: Contents
 
     general-content/feature-submitting-guide.md
+
+    general-content/bug-submitting-guide.md

--- a/doc/sphinx-general-wiser-docs/source/general-content/bug-submitting-guide.md
+++ b/doc/sphinx-general-wiser-docs/source/general-content/bug-submitting-guide.md
@@ -1,0 +1,29 @@
+# Bug Submitting Guide
+
+Thank you for helping make **WISER** better!  
+If you find a problem or unexpected behavior, please **submit it as a GitHub issue** using the **Bug report** template.
+
+## How to Submit a Bug Report
+You can submit a new bug report here:  
+👉 [**Submit a Bug Report**](https://github.com/Ehlmann-research-group/WISER/issues/new/choose)
+
+When filling out the issue form:
+- Clearly **describe the bug** — what went wrong and where.  
+- Include **steps to reproduce** the problem (numbered if possible).  
+- State what you **expected to happen** versus what actually occurred.  
+- Add **screenshots or console messages** if they help explain the issue.  
+- Include details about your **system setup**:
+  - Operating System (e.g., Windows, macOS, Linux)  
+  - CPU architecture (x86_64, ARM, etc.)  
+  - WISER version (e.g., `1.4b1`)
+
+If there’s an error message, paste it under **Error Message**, and add any **additional context** that might help reproduce or understand the bug.
+
+## Review Process
+Once submitted, maintainers or contributors will review your report.  
+They may ask for clarification or logs to help pinpoint the issue.  
+Please be patient and responsive — this helps get your bug fixed faster!
+
+---
+
+Thank you for contributing to WISER’s stability and improvement!


### PR DESCRIPTION
## What does this change do?
Adds a guide on how to submit bugs to sphinx docs. Closes #288 

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
We want bug reporters to see how to submit bugs on our wiser documentation page and not have to sift through the github to find it.

## How did you implement the change?
<!-- High-level approach -->

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request (#288)
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->