### PR TITLE
docs: Added tools menu plugin doc and updated others

### DIFF
--- a/doc/sphinx-extending-wiser/bandmath_plugins.rst
+++ b/doc/sphinx-extending-wiser/bandmath_plugins.rst
@@ -99,3 +99,12 @@ implemented to operate on NumPy ``ndarray`` objects for maximum generality,
 although it may also be useful to implement certain operations against
 :class:`wiser.raster.RasterDataSet` or :class:`wiser.raster.Spectrum` objects,
 where metadata is available for use.
+
+Example BandMath Plugin
+-----------------------
+
+Okay, lets get into an example plugin that lets you do a spectral angle calculation
+between a spectrum and a dataset.
+
+.. literalinclude:: ../../src/example_plugins/bandmath_plugin.py
+   :language: python

--- a/doc/sphinx-extending-wiser/conf.py
+++ b/doc/sphinx-extending-wiser/conf.py
@@ -32,6 +32,7 @@ author = "California Institute of Technology"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
+    "sphinx.ext.viewcode",
     "enum_tools.autoenum",
 ]
 

--- a/doc/sphinx-extending-wiser/ctxmenu_plugins.rst
+++ b/doc/sphinx-extending-wiser/ctxmenu_plugins.rst
@@ -28,3 +28,11 @@ with WISER.
 The ``ContextMenuType`` enumeration is as follows:
 
 .. autoenum:: wiser.plugins.ContextMenuType
+
+Example Context-Menu Plugin
+---------------------------
+
+Here is an example of a simple context menu plugin.
+
+.. literalinclude:: ../../src/example_plugins/ctxmenu_plugin.py
+   :language: python

--- a/doc/sphinx-extending-wiser/index.rst
+++ b/doc/sphinx-extending-wiser/index.rst
@@ -13,6 +13,7 @@ Extending WISER
 
     plugins
     ctxmenu_plugins
+    toolsmenu_plugins.rst
     ui_plugins
     bandmath_plugins
     plugin_dependencies

--- a/doc/sphinx-extending-wiser/supporting_types.rst
+++ b/doc/sphinx-extending-wiser/supporting_types.rst
@@ -53,3 +53,14 @@ A spectrum may be constructed from a NumPy array using the
 
 .. autoclass:: wiser.raster.NumPyArraySpectrum
     :members:
+
+
+Region Of Interest
+------------------
+
+A region of interest that is draw on the screen is represented by the ``Region Of Interest``
+class.
+
+.. autoclass:: wiser.raster.RegionOfInterest
+    :members:
+    :undoc-members:

--- a/doc/sphinx-extending-wiser/toolsmenu_plugins.rst
+++ b/doc/sphinx-extending-wiser/toolsmenu_plugins.rst
@@ -1,0 +1,20 @@
+Tools-Menu Plugins
+==================
+
+Tools-menu plugins allow you to add custom actions to the Tool Menu located in the top navigation bar.
+Each plugin appears using the name you provide, and selecting it triggers the function you have linked
+to that action.
+
+If you have actions that are used less frequently, consider organizing them into a submenu to keep the
+main Tool Menu concise and easy to navigate.
+
+.. autoclass:: wiser.plugins.ToolsMenuPlugin
+    :members:
+
+Example Tools-Menu Plugin
+-------------------------
+
+Okay, lets get into an example plugin.
+
+.. literalinclude:: ../../src/example_plugins/tool_plugin.py
+   :language: python


### PR DESCRIPTION
## What does this change do?
I added the tools menu plugin documentation, fixed the RegionOfInterest class not getting linked to and put into supporting types and I added example plugins to the tools menu, context menu, and bandmath plugin types. Closes #324 

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
We need more documentation for our plugins and how people can make plugins with **concrete** examples. A lot of users have told me they don't know where to get started on plugins. This is meant to help them a bit more.

## How did you implement the change?
<!-- High-level approach -->

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request (#324)
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->