### PR TITLE
docs: Normalized the markdown structure of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,29 +7,29 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Describe the bug
+_A clear and concise description of what the bug is._
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+## To Reproduce
+_Steps to reproduce the behavior:_
+1. _Go to '...'_
+2. _Click on '....'_
+3. _Scroll down to '....'_
+4. _See error_
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Expected behavior
+_A clear and concise description of what you expected to happen._
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+## Screenshots
+_If applicable, add screenshots to help explain your problem._
 
-**Desktop (please complete the following information):**
- - OS: [e.g. Windows, MacOSx]
-- CPU architecture: [e.g. x86_64, arm]
- - Version [e.g. 1.3b1]
+## Desktop (please complete the following information):
+ - _OS: [e.g. Windows, MacOSx]_
+- _CPU architecture: [e.g. x86_64, arm]_
+ - _Version [e.g. 1.3b1]_
 
-**[Optional] Error Message**
-The error message in the console if there is one.
+## [Optional] Error Message
+_The error message in the console if there is one._
 
-**Additional context**
-Add any other context about the problem here.
+## Additional context
+_Add any other context about the problem here._

--- a/.github/ISSUE_TEMPLATE/documentation-update.md
+++ b/.github/ISSUE_TEMPLATE/documentation-update.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-### Summary
+## Summary
 _Describe the documentation update needed._
 
-### Location
+## Location
 _Link to the page or file that needs updating._
 
-### Details
+## Details
 _Explain what should be added, removed, or changed._
 
-### Additional Context
+## Additional Context
 _Optional: Include screenshots, references, or related issues._

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,17 +7,17 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Is your feature request related to a problem? Please describe.
+_A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]_
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+## Describe the solution you'd like
+_A clear and concise description of what you want to happen._
 
-**Describe how solution fits WISER's mission**
-A clear and concise description of how this solution fits into WISER's mission
+## Describe how solution fits WISER's mission
+_A clear and concise description of how this solution fits into WISER's mission_
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Describe alternatives you've considered
+_A clear and concise description of any alternative solutions or features you've considered._
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+## Additional context
+_Add any other context or screenshots about the feature request here._

--- a/.github/ISSUE_TEMPLATE/improvement---refactor.md
+++ b/.github/ISSUE_TEMPLATE/improvement---refactor.md
@@ -7,17 +7,17 @@ assignees: ''
 
 ---
 
-### Summary
+## Summary
 _Describe the improvement or refactor you'd like to see._
 
-### Current Behavior
+## Current Behavior
 _Explain what currently exists and why it could be improved._
 
-### Proposed Changes
+## Proposed Changes
 _Outline your suggested changes or refactoring approach._
 
-### Benefits
+## Benefits
 _Describe how this change will improve performance, readability, maintainability, etc._
 
-### Additional Context
+## Additional Context
 _Optional: Include related issues, code references, or benchmarks._


### PR DESCRIPTION
## What does this change do?
Now the markdown structure of issue templates is the same across issue templates. It also is easier for people to see the different sections of the issue templates. Closes #325 

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
The issue templates weren't the same across different templates and some issue templates were harder to see the titles than others.

## How did you implement the change?
<!-- High-level approach -->

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request (#325)
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->