### PR TITLE
fix: load_from_file used logger.debug wrong, causing user-facing console error

### DIFF
--- a/src/wiser/raster/loader.py
+++ b/src/wiser/raster/loader.py
@@ -104,8 +104,10 @@ class RasterDataLoader:
                     impl_list = impl_type.try_load_file(path, interactive=interactive)
             except Exception as e:
                 logger.debug(
-                    f"Couldn't load file {path} with driver "
-                    + f"{driver_name} and implementation {impl_type}.",
+                    "Couldn't load file %s with driver %s and implementation %s. Error: %s",
+                    path,
+                    driver_name,
+                    impl_type,
                     e,
                 )
 


### PR DESCRIPTION
## What does this change do?
Fixes how parameters are passed into logger.debug in RasterDataLoader.load_from_file. The way parameters
were passed in before caused an error. This error didn't affect functionality but would show up in console. It 
shows every file that was tried previously and failed because each of these creates a non stopping logging error. Closes #339 

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
We do not want the user to be confused by errors that occur but do not mean anything.

## How did you implement the change?
Changed how parameters were passed into logger.debug.

## Added tests?
- [ ] yes
- [X] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [X] There is an issue associated with this pull request #339 
- [X] Code compiles/builds without errors
- [X] No new lint/style issues introduced
- [X] Branch is up-to-date with main/master
- [X] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->