### PR TITLE
feat: Adding better user feedback to plugin adding

### DIFF
--- a/src/wiser/gui/app_config_dialog.py
+++ b/src/wiser/gui/app_config_dialog.py
@@ -338,13 +338,21 @@ class AppConfigDialog(QDialog):
             if not file_path:
                 return
 
-            self._load_plugin_from_file(file_path)
-            QMessageBox.information(
-                self,
-                self.tr("Plugin Added"),
-                self.tr("Your plugin was successfully added!"),
-            )
-        except RuntimeError as e:
+            plugins, _ = self._load_plugin_from_file(file_path)
+            if len(plugins) == 0:
+                QMessageBox.warning(
+                    self,
+                    self.tr("No Plugin Found"),
+                    self.tr("No plugin was found in your file!"),
+                )
+            else:
+                QMessageBox.information(
+                    self,
+                    self.tr("Plugin Added"),
+                    self.tr("Your plugin was successfully added!"),
+                )
+
+        except (RuntimeError, ModuleNotFoundError) as e:
             QMessageBox.warning(
                 self,
                 self.tr("Failed To Add Plugin"),
@@ -368,6 +376,10 @@ class AppConfigDialog(QDialog):
         """
         plugins_dict = self._discover_plugin_classes(file_path)
 
+        plugins: List[Dict] = plugins_dict["plugins"]
+        if len(plugins) == 0:
+            return [], ""
+
         base_dir_abs: str = plugins_dict["base_dir_abs"]
         base_dir_duplicate = False
         if base_dir_abs not in qlistwidget_to_list(self._ui.list_plugin_paths):
@@ -377,8 +389,6 @@ class AppConfigDialog(QDialog):
             self._ui.list_plugin_paths.addItem(item)
         else:
             base_dir_duplicate = True
-
-        plugins: List[Dict] = plugins_dict["plugins"]
 
         plugin_duplicates: List[str] = []
         for plugin in plugins:


### PR DESCRIPTION
## What does this change do?
This adds better user feedback when a user adds a plugin. If the plugin was successfully added, it says so. If no plugin was added, it says so. If there was an error adding the plugin, it says so. Closes #329 

## What type of PR is this? (check all applicable) 
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
This is needed so people do not need to worry about if their plugin was added correctly.

## How did you implement the change?
I added QMessageBoxes to tell the user if their plugin was added.

## Added tests?
- [ ] yes
- [X] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request (#329)
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->