### PR TITLE
hotfix: Fixing when a masked array doesn't have a mask

### DIFF
--- a/src/wiser/raster/utils.py
+++ b/src/wiser/raster/utils.py
@@ -246,11 +246,13 @@ def compute_PCA_on_image(
     coords = coords.reshape((coords.shape[0] * coords.shape[1], coords.shape[2]))
 
     if isinstance(image_arr, np.ma.MaskedArray):
-        mask_1d = ~np.all(image_arr.mask == True, axis=1)  # noqa: E712
-        image_arr = image_arr.data[mask_1d, :]
-        coords = coords[mask_1d, :]
-        if not np.isfinite(image_arr).all():
-            raise ValueError("Array contains a non-numeric value after cleaning!")
+        # It is possible for the masked array to not have a mask
+        if image_arr.mask:
+            mask_1d = ~np.all(image_arr.mask == True, axis=1)  # noqa: E712
+            image_arr = image_arr.data[mask_1d, :]
+            coords = coords[mask_1d, :]
+            if not np.isfinite(image_arr).all():
+                raise ValueError("Array contains a non-numeric value after cleaning!")
 
     pca = PCA(n_components=num_components)
 


### PR DESCRIPTION
## What does this change do?
Some np.ma.Masked_Arrays do not have masks on them. Their masks are None. We do not account for this in the code. If there is no mask in the np.ma.Masked_Array then we don't use it.

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [X] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
We need PCA to work on masked arrays that don't have a mask.

## How did you implement the change?
<!-- High-level approach -->

## Added tests?
- [ ] yes
- [ ] no, because they aren’t needed
- [X] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [ ] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->