### PR TITLE
devOps: Upgrade macos intel runner because macos-13 is deprecating

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # macos-15 should be Apple silicon
         # macos-13 should be Intel
-        os: [windows-latest, macos-15, macos-13]
+        os: [windows-latest, macos-15, macos-15-intel]
     runs-on: ${{matrix.os}}
     
     steps:


### PR DESCRIPTION
## What does this change do?
This updates our macos intel runner from macos-13 to macos-15-intel because the macos-13 github runner is getting deprecated. 
Closes #370

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [x] Build
- [x] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
So we can still run builds on macos intel github runners.

## How did you implement the change?
<!-- High-level approach -->

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request (#370)
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->