### PR TITLE
build: Fix Linux Build Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ Secret.sh
 
 src/wiser/bandmath/temp_output/
 src/wiser/profiling/output/*
+
+dev_config_dir_windows/

--- a/WISER-macOS.spec
+++ b/WISER-macOS.spec
@@ -87,7 +87,7 @@ existing_hidden_imports = _hidden
 # pyinstaller_hooks/pyi_rth_cv2.py is meant to help fix this as well.
 cv2_binaries = collect_dynamic_libs(
     "cv2",
-    search_patterns=["cv2*.so", "cv2*.dylib", "python-*/cv2*.so", "python-*/cv2*.dylib"]
+    search_patterns=["cv2*.so", "cv2*.dylib", "python-*/cv2*.so", "python-*/cv2*.dylib"],
 )
 
 existing_binaries += cv2_binaries

--- a/WISER-ubuntu.spec
+++ b/WISER-ubuntu.spec
@@ -104,7 +104,7 @@ existing_hidden_imports = _hidden
 # OpenCV dynamic libs fix: collect cv2 shared objects (.so only on Linux)
 cv2_binaries = collect_dynamic_libs(
     "cv2",
-    search_patterns=["cv2*.so", "python-*/cv2*.so"],
+    search_patterns=["cv2*.so", "cv2*.dylib", "python-*/cv2*.so", "python-*/cv2*.dylib"],
 )
 existing_binaries += cv2_binaries
 

--- a/install-linux/multistage/Dockerfile
+++ b/install-linux/multistage/Dockerfile
@@ -83,8 +83,8 @@ RUN micromamba run -n "${ENV_NAME}" make -C /work build-linux
 
 # Bundle ELF dependency scrub/verify:
 # Conda absolute paths can leak into DT_NEEDED/RUNPATH (notably GDAL -> sqlite),
-# which breaks portability on target Linux hosts. We do not force/overwrite
-# RPATH; we only scrub micromamba paths and adjust RUNPATH when required.
+# and some bundled libs carry hard-coded build paths in RPATH/RUNPATH.
+# We do not force-convert tags; we append $ORIGIN when those build paths appear.
 RUN set -euxo pipefail; \
     internal_dir="$(find /work/dist -type d -name _internal -print -quit)"; \
     test -n "$internal_dir"; \

--- a/install-linux/multistage/Dockerfile
+++ b/install-linux/multistage/Dockerfile
@@ -25,7 +25,7 @@ SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl wget git \
     build-essential pkg-config \
-    patchelf file \
+    patchelf file binutils \
     # Qt/OpenGL/EGL runtime deps (PySide2 common deps)
     libegl1 libgl1 \
     libgl1-mesa-dri \
@@ -81,46 +81,15 @@ RUN micromamba create -y -n "${ENV_NAME}" -f /work/prod-conda-lock.yml \
 # Run build (avoid bash -l; keep env PATH intact)
 RUN micromamba run -n "${ENV_NAME}" make -C /work build-linux
 
-# ---- Bundle fixups ----
+# Bundle ELF dependency scrub/verify:
+# Conda absolute paths can leak into DT_NEEDED/RUNPATH (notably GDAL -> sqlite),
+# which breaks portability on target Linux hosts.
 RUN set -euxo pipefail; \
-    internal_dir="$(find /work/dist -type d -name _internal -print -quit 2>/dev/null || true)"; \
-    if [ -z "$internal_dir" ]; then \
-      echo "No _internal directory found under /work/dist; skipping fixups."; \
-      exit 0; \
-    fi; \
-    absolute_internal_dir="$(cd "$internal_dir" && pwd)"; \
-    cd "$absolute_internal_dir"; \
-    pick_sqlite_target() { ls -1 libsqlite3.so.* 2>/dev/null | sort -V | tail -n 1; }; \
-    \
-    echo "== Step 1: sqlite SONAME/aliases =="; \
-    if ls -1 libsqlite3.so.* >/dev/null 2>&1 && [ ! -e libsqlite3.so ]; then \
-      target="$(pick_sqlite_target)"; \
-      ln -sf "$target" libsqlite3.so; \
-    fi; \
-    if [ -e libsqlite3.so ] && [ ! -e libsqlite3.so.3 ]; then \
-      ln -sf libsqlite3.so libsqlite3.so.3; \
-    fi; \
-    if ls -1 libsqlite3.so.* >/dev/null 2>&1 && [ ! -e libsqlite3.so.0 ]; then \
-      target="$(pick_sqlite_target)"; \
-      ln -sf "$target" libsqlite3.so.0; \
-    fi; \
-    \
-    echo "== Step 2: GDAL RPATH to \$ORIGIN =="; \
-    found_any=0; \
-    while IFS= read -r -d '' f; do \
-      found_any=1; \
-      patchelf --force-rpath --set-rpath '$ORIGIN' "$f"; \
-    done < <(find "$absolute_internal_dir" -type f \( -iname "*gdal*.so*" -o -iname "libgdal.so*" \) -print0); \
-    if [ "$found_any" -eq 0 ]; then echo "No GDAL libs found; skipping."; fi; \
-    \
-    echo "== Step 3: replace-needed (only if absolute DT_NEEDED present) =="; \
-    gdal_so="$(find "$absolute_internal_dir" -maxdepth 1 -type f -name 'libgdal.so*' -print -quit 2>/dev/null || true)"; \
-    if [ -z "$gdal_so" ]; then echo "No libgdal.so* found; skipping."; exit 0; fi; \
-    ABS_SQLITE="/opt/micromamba/envs/${ENV_NAME}/lib/libsqlite3.so"; \
-    if readelf -d "$gdal_so" | grep -Fq "$ABS_SQLITE"; then \
-      patchelf --replace-needed "$ABS_SQLITE" "libsqlite3.so.0" "$gdal_so"; \
-    fi; \
-    readelf -d "$gdal_so" | grep -i sqlite || true
+    internal_dir="$(find /work/dist -type d -name _internal -print -quit)"; \
+    test -n "$internal_dir"; \
+    sed -i 's/\r$//' /work/install-linux/scripts/patch_internal_elf_deps.sh /work/install-linux/scripts/verify_internal_elf_deps.sh; \
+    bash /work/install-linux/scripts/patch_internal_elf_deps.sh "$internal_dir" "${ENV_NAME}"; \
+    bash /work/install-linux/scripts/verify_internal_elf_deps.sh "$internal_dir"
 
 # Exportable output + tarball
 RUN set -euxo pipefail; \

--- a/install-linux/multistage/Dockerfile
+++ b/install-linux/multistage/Dockerfile
@@ -83,7 +83,8 @@ RUN micromamba run -n "${ENV_NAME}" make -C /work build-linux
 
 # Bundle ELF dependency scrub/verify:
 # Conda absolute paths can leak into DT_NEEDED/RUNPATH (notably GDAL -> sqlite),
-# which breaks portability on target Linux hosts.
+# which breaks portability on target Linux hosts. We do not force/overwrite
+# RPATH; we only scrub micromamba paths and adjust RUNPATH when required.
 RUN set -euxo pipefail; \
     internal_dir="$(find /work/dist -type d -name _internal -print -quit)"; \
     test -n "$internal_dir"; \

--- a/install-linux/multistage_fedora/Dockerfile
+++ b/install-linux/multistage_fedora/Dockerfile
@@ -31,7 +31,7 @@ RUN dnf -y update \
     ca-certificates curl wget git \
     gcc gcc-c++ make \
     pkgconf-pkg-config \
-    patchelf file \
+    patchelf file binutils \
     mesa-libEGL mesa-libGL mesa-dri-drivers \
     libglvnd-glx \
     glib2 dbus-libs \
@@ -109,104 +109,15 @@ RUN set -eux; \
   objdump -T "$internal_dir"/libcurl.so.* 2>/dev/null | grep -F OPENSSL_ | sort -u | head -n 10 || true; \
   readelf --version-info "$internal_dir"/libssl.so.* 2>/dev/null | grep -E "Name: OPENSSL_" | sort -u || true
 
-# -------------------------------------------------------------------
-# Bundle fixups: sqlite aliases + GDAL RPATH + (optional) replace-needed
-# -------------------------------------------------------------------
-
-# Ensure sqlite SONAME/aliases exist in the bundle (_internal)
+# Bundle ELF dependency scrub/verify:
+# Conda absolute paths can leak into DT_NEEDED/RUNPATH (notably GDAL -> sqlite),
+# which breaks portability on target Linux hosts.
 RUN set -euxo pipefail; \
-    internal_dir="$(find /work/dist -type d -name _internal -print -quit 2>/dev/null || true)"; \
-    if [ -z "$internal_dir" ]; then \
-      echo "No _internal directory found; skipping sqlite alias step."; \
-      exit 0; \
-    fi; \
-    absolute_internal_dir="$(cd "$internal_dir" && pwd)"; \
-    cd "$absolute_internal_dir"; \
-    pick_sqlite_target() { \
-      ls -1 libsqlite3.so.* 2>/dev/null | sort -V | tail -n 1; \
-    }; \
-    if ls -1 libsqlite3.so.* >/dev/null 2>&1 && [ ! -e libsqlite3.so ]; then \
-      target="$(pick_sqlite_target)"; \
-      echo "Creating symlink: libsqlite3.so -> $target"; \
-      ln -sf "$target" libsqlite3.so; \
-    fi; \
-    if [ -e libsqlite3.so ] && [ ! -e libsqlite3.so.3 ]; then \
-      echo "Creating symlink: libsqlite3.so.3 -> libsqlite3.so"; \
-      ln -sf libsqlite3.so libsqlite3.so.3; \
-    fi; \
-    if ls -1 libsqlite3.so.* >/dev/null 2>&1 && [ ! -e libsqlite3.so.0 ]; then \
-      target="$(pick_sqlite_target)"; \
-      echo "Creating symlink: libsqlite3.so.0 -> $target"; \
-      ln -sf "$target" libsqlite3.so.0; \
-    fi; \
-    echo "SQLite files now:"; \
-    ls -lah libsqlite3.so* 2>/dev/null || true
-
-# Patch GDAL extension + libgdal to look in PyInstaller _internal first
-RUN set -euxo pipefail; \
-    internal_dir="$(find /work/dist -type d -name _internal -print -quit 2>/dev/null || true)"; \
-    if [ -z "$internal_dir" ]; then \
-      echo "No _internal directory found; skipping GDAL rpath step."; \
-      exit 0; \
-    fi; \
-    absolute_internal_dir="$(cd "$internal_dir" && pwd)"; \
-    found_any=0; \
-    while IFS= read -r -d '' f; do \
-      found_any=1; \
-      echo "patchelf --set-rpath '\$ORIGIN' -> $f"; \
-      patchelf --force-rpath --set-rpath '$ORIGIN' "$f"; \
-    done < <(find "$absolute_internal_dir" -type f \( -iname "*gdal*.so*" -o -iname "libgdal.so*" \) -print0); \
-    if [ "$found_any" -eq 0 ]; then \
-      echo "No GDAL libs found in _internal; skipping rpath step."; \
-    fi
-
-# Patch libgdal.so.* to stop requiring sqlite via an absolute conda path (only if present)
-RUN set -euxo pipefail; \
-    internal_dir="$(find /work/dist -type d -name _internal -print -quit 2>/dev/null || true)"; \
-    if [ -z "$internal_dir" ]; then \
-      echo "No _internal directory found; skipping replace-needed step."; \
-      exit 0; \
-    fi; \
-    absolute_internal_dir="$(cd "$internal_dir" && pwd)"; \
-    gdal_so="$(find "$absolute_internal_dir" -maxdepth 1 -type f -name "libgdal.so*" -print -quit 2>/dev/null || true)"; \
-    if [ -z "$gdal_so" ]; then \
-      echo "No libgdal.so* found; skipping replace-needed step."; \
-      exit 0; \
-    fi; \
-    ABS_SQLITE="/opt/micromamba/envs/${ENV_NAME}/lib/libsqlite3.so"; \
-    echo "Checking DT_NEEDED entries for sqlite in: $gdal_so"; \
-    echo "Looking for absolute path: $ABS_SQLITE"; \
-    out=$(readelf -d "$gdal_so" | grep -F "$ABS_SQLITE"); \
-    echo "$out"; \
-    if command -v readelf >/dev/null 2>&1; then \
-      if (readelf -d "$gdal_so" 2>/dev/null || true) | grep -Fq "$ABS_SQLITE"; then \
-        echo "Found absolute sqlite DT_NEEDED; rewriting to libsqlite3.so.0"; \
-        cd "$absolute_internal_dir"; \
-        pick_sqlite_target() { \
-            ls -1 libsqlite3.so.* 2>/dev/null | sort -V | tail -n 1; \
-        }; \
-        if [ ! -e libsqlite3.so.0 ]; then \
-            if ls -1 libsqlite3.so.* >/dev/null 2>&1; then \
-            target="$(pick_sqlite_target)"; \
-            echo "Creating symlink: libsqlite3.so.0 -> $target"; \
-            ln -sf "$target" libsqlite3.so.0; \
-            else \
-            echo "ERROR: No libsqlite3.so.* files found to link from."; \
-            exit 1; \
-            fi; \
-        fi; \
-        patchelf --replace-needed "$ABS_SQLITE" "libsqlite3.so.0" "$gdal_so"; \
-        echo "After patch, sqlite-related entries:"; \
-        readelf -d "$gdal_so" | grep -i sqlite || true; \
-      fi; \
-    else \
-      echo "No absolute sqlite DT_NEEDED found; leaving libgdal as-is."; \
-      if command -v readelf >/dev/null 2>&1; then \
-        readelf -d "$gdal_so" | grep -i sqlite || true; \
-      else \
-        echo "readelf not found."; \
-      fi; \
-    fi
+    internal_dir="$(find /work/dist -type d -name _internal -print -quit)"; \
+    test -n "$internal_dir"; \
+    sed -i 's/\r$//' /work/install-linux/scripts/patch_internal_elf_deps.sh /work/install-linux/scripts/verify_internal_elf_deps.sh; \
+    bash /work/install-linux/scripts/patch_internal_elf_deps.sh "$internal_dir" "${ENV_NAME}"; \
+    bash /work/install-linux/scripts/verify_internal_elf_deps.sh "$internal_dir"
 
 # Exportable output + tarball
 RUN set -euxo pipefail; \

--- a/install-linux/multistage_fedora/Dockerfile
+++ b/install-linux/multistage_fedora/Dockerfile
@@ -111,8 +111,8 @@ RUN set -eux; \
 
 # Bundle ELF dependency scrub/verify:
 # Conda absolute paths can leak into DT_NEEDED/RUNPATH (notably GDAL -> sqlite),
-# which breaks portability on target Linux hosts. We do not force/overwrite
-# RPATH; we only scrub micromamba paths and adjust RUNPATH when required.
+# and some bundled libs carry hard-coded build paths in RPATH/RUNPATH.
+# We do not force-convert tags; we append $ORIGIN when those build paths appear.
 RUN set -euxo pipefail; \
     internal_dir="$(find /work/dist -type d -name _internal -print -quit)"; \
     test -n "$internal_dir"; \

--- a/install-linux/multistage_fedora/Dockerfile
+++ b/install-linux/multistage_fedora/Dockerfile
@@ -111,7 +111,8 @@ RUN set -eux; \
 
 # Bundle ELF dependency scrub/verify:
 # Conda absolute paths can leak into DT_NEEDED/RUNPATH (notably GDAL -> sqlite),
-# which breaks portability on target Linux hosts.
+# which breaks portability on target Linux hosts. We do not force/overwrite
+# RPATH; we only scrub micromamba paths and adjust RUNPATH when required.
 RUN set -euxo pipefail; \
     internal_dir="$(find /work/dist -type d -name _internal -print -quit)"; \
     test -n "$internal_dir"; \

--- a/install-linux/scripts/patch_internal_elf_deps.sh
+++ b/install-linux/scripts/patch_internal_elf_deps.sh
@@ -10,18 +10,22 @@ Arguments:
   internal_dir  Path to PyInstaller _internal directory
   env_name      Optional conda env name (default: wiser-prod)
   abs_prefix    Optional absolute build prefix to scrub
-                (default: /opt/micromamba/envs)
+                (default: /opt/micromamba)
   abs_sqlite    Optional absolute sqlite path to rewrite
-                (default: <abs_prefix>/<env_name>/lib/libsqlite3.so)
+                (default: /opt/micromamba/envs/<env_name>/lib/libsqlite3.so)
 
 Behavior:
   - Scans all ELF files under _internal (shared libs and extension modules)
-  - Rewrites absolute DT_NEEDED entries to sonames via patchelf --replace-needed
-  - Ensures local lookup with patchelf --force-rpath --set-rpath '$ORIGIN'
+  - Rewrites only /opt/micromamba* DT_NEEDED entries via patchelf --replace-needed
+  - Updates RUNPATH safely:
+      * strips /opt/micromamba* entries
+      * preserves existing entries
+      * ensures $ORIGIN is present when RUNPATH exists, or for files modified by replace-needed
+      * leaves RPATH-only files untouched
   - Creates sqlite aliases:
       libsqlite3.so -> latest libsqlite3.so.*
       libsqlite3.so.0 -> latest libsqlite3.so.*
-      libsqlite3.so.3 -> latest libsqlite3.so.* (best-effort compatibility)
+      libsqlite3.so.3 -> latest libsqlite3.so.* (only when bundle actually needs it)
 EOF
 }
 
@@ -37,8 +41,8 @@ fi
 
 internal_dir="$1"
 env_name="${2:-wiser-prod}"
-abs_prefix="${3:-/opt/micromamba/envs}"
-abs_sqlite="${4:-${abs_prefix}/${env_name}/lib/libsqlite3.so}"
+abs_prefix="${3:-/opt/micromamba}"
+abs_sqlite="${4:-/opt/micromamba/envs/${env_name}/lib/libsqlite3.so}"
 
 if [[ ! -d "$internal_dir" ]]; then
   echo "ERROR: _internal directory not found: $internal_dir" >&2
@@ -75,7 +79,6 @@ ensure_sqlite_aliases() {
     cd "$internal_dir"
     ln -sfn "$latest" libsqlite3.so
     ln -sfn "$latest" libsqlite3.so.0
-    ln -sfn "$latest" libsqlite3.so.3
     echo "SQLite aliases:"
     ls -lah libsqlite3.so*
   )
@@ -92,30 +95,139 @@ extract_needed() {
     | sed -n "s/.*(NEEDED).*Shared library: \[\(.*\)\].*/\1/p"
 }
 
+extract_runpath() {
+  local f="$1"
+  readelf -d "$f" 2>/dev/null \
+    | sed -n "s/.*(RUNPATH).*Library runpath: \[\(.*\)\].*/\1/p"
+}
+
+extract_rpath() {
+  local f="$1"
+  readelf -d "$f" 2>/dev/null \
+    | sed -n "s/.*(RPATH).*Library rpath: \[\(.*\)\].*/\1/p"
+}
+
+bundle_needs_sqlite3_so3() {
+  local f needed
+  while IFS= read -r -d '' f; do
+    if ! is_elf "$f"; then
+      continue
+    fi
+    while IFS= read -r needed; do
+      [[ -n "$needed" ]] || continue
+      case "$needed" in
+        libsqlite3.so.3|*/libsqlite3.so.3) return 0 ;;
+      esac
+    done < <(extract_needed "$f")
+  done < <(find "$internal_dir" -type f -print0)
+  return 1
+}
+
+rebuild_runpath_with_origin() {
+  local old_runpath="$1"
+  local entries=()
+  local new_entries=()
+  local entry existing
+  local has_origin=0
+  local seen
+
+  IFS=':' read -r -a entries <<< "$old_runpath"
+  for entry in "${entries[@]}"; do
+    [[ -n "$entry" ]] || continue
+    if [[ "$entry" == "$abs_prefix"* ]]; then
+      continue
+    fi
+    if [[ "$entry" == "\$ORIGIN" ]]; then
+      has_origin=1
+    fi
+    # Preserve order; de-duplicate only exact repeats.
+    seen=0
+    for existing in "${new_entries[@]}"; do
+      if [[ "$existing" == "$entry" ]]; then
+        seen=1
+        break
+      fi
+    done
+    if [[ $seen -eq 0 ]]; then
+      new_entries+=("$entry")
+    fi
+  done
+
+  if [[ $has_origin -eq 0 ]]; then
+    new_entries=("\$ORIGIN" "${new_entries[@]}")
+  fi
+
+  local out=""
+  for entry in "${new_entries[@]}"; do
+    if [[ -z "$out" ]]; then
+      out="$entry"
+    else
+      out="${out}:$entry"
+    fi
+  done
+  printf '%s' "$out"
+}
+
+update_runpath_if_needed() {
+  local f="$1"
+  local replaced_needed="$2"
+  local runpath rpath new_runpath
+
+  runpath="$(extract_runpath "$f")"
+  rpath="$(extract_rpath "$f")"
+
+  if [[ -n "$runpath" ]]; then
+    new_runpath="$(rebuild_runpath_with_origin "$runpath")"
+    if [[ "$new_runpath" != "$runpath" ]]; then
+      echo "set-runpath: $f"
+      echo "  old: ${runpath}"
+      echo "  new: ${new_runpath}"
+      patchelf --set-rpath "$new_runpath" "$f"
+    fi
+    return 0
+  fi
+
+  # No RUNPATH present:
+  # - If file was patched and has no RPATH either, create RUNPATH=$ORIGIN.
+  # - If it has RPATH only, leave it untouched.
+  if [[ "$replaced_needed" -eq 1 && -z "$rpath" ]]; then
+    echo "set-runpath: $f"
+    echo "  old: <none>"
+    echo "  new: \$ORIGIN"
+    patchelf --set-rpath '$ORIGIN' "$f"
+  fi
+}
+
 patch_one() {
   local f="$1"
   local needed old base
+  local replaced_needed=0
   while IFS= read -r needed; do
     [[ -n "$needed" ]] || continue
-    if [[ "$needed" == /* ]]; then
+    if [[ "$needed" == "$abs_prefix"* ]]; then
       old="$needed"
-      base="$(basename "$old")"
-      if [[ "$old" == "$abs_sqlite" ]]; then
+      if [[ "$old" == "$abs_sqlite" || "$old" == */libsqlite3.so ]]; then
         base="libsqlite3.so.0"
+      else
+        base="$(basename "$old")"
       fi
       if [[ "$old" != "$base" ]]; then
         echo "replace-needed: $f"
         echo "  $old -> $base"
         patchelf --replace-needed "$old" "$base" "$f"
+        replaced_needed=1
       fi
     fi
   done < <(extract_needed "$f")
 
-  # Ensure bundle-local lookup; this avoids accidental build-host library resolution.
-  patchelf --force-rpath --set-rpath '$ORIGIN' "$f"
+  update_runpath_if_needed "$f" "$replaced_needed"
 }
 
 ensure_sqlite_aliases
+need_sqlite3_so3=0
+if bundle_needs_sqlite3_so3; then
+  need_sqlite3_so3=1
+fi
 
 patched_count=0
 while IFS= read -r -d '' f; do
@@ -138,5 +250,23 @@ while IFS= read -r -d '' f; do
   patch_one "$f"
   patched_count=$((patched_count + 1))
 done < <(find "$internal_dir" -type f -print0)
+
+if [[ $need_sqlite3_so3 -eq 1 ]]; then
+  latest_sqlite="$(
+    ls -1 "$internal_dir"/libsqlite3.so.* 2>/dev/null \
+      | sed 's#^.*/##' \
+      | sort -V \
+      | tail -n 1 || true
+  )"
+  if [[ -n "$latest_sqlite" ]]; then
+    (
+      cd "$internal_dir"
+      ln -sfn "$latest_sqlite" libsqlite3.so.3
+      echo "Created sqlite compatibility alias: libsqlite3.so.3 -> $latest_sqlite"
+    )
+  fi
+else
+  echo "No DT_NEEDED requires libsqlite3.so.3; not creating that alias."
+fi
 
 echo "Patched ELF file count: $patched_count"

--- a/install-linux/scripts/patch_internal_elf_deps.sh
+++ b/install-linux/scripts/patch_internal_elf_deps.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  patch_internal_elf_deps.sh <internal_dir> [env_name] [abs_prefix] [abs_sqlite]
+
+Arguments:
+  internal_dir  Path to PyInstaller _internal directory
+  env_name      Optional conda env name (default: wiser-prod)
+  abs_prefix    Optional absolute build prefix to scrub
+                (default: /opt/micromamba/envs)
+  abs_sqlite    Optional absolute sqlite path to rewrite
+                (default: <abs_prefix>/<env_name>/lib/libsqlite3.so)
+
+Behavior:
+  - Scans all ELF files under _internal (shared libs and extension modules)
+  - Rewrites absolute DT_NEEDED entries to sonames via patchelf --replace-needed
+  - Ensures local lookup with patchelf --force-rpath --set-rpath '$ORIGIN'
+  - Creates sqlite aliases:
+      libsqlite3.so -> latest libsqlite3.so.*
+      libsqlite3.so.0 -> latest libsqlite3.so.*
+      libsqlite3.so.3 -> latest libsqlite3.so.* (best-effort compatibility)
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+internal_dir="$1"
+env_name="${2:-wiser-prod}"
+abs_prefix="${3:-/opt/micromamba/envs}"
+abs_sqlite="${4:-${abs_prefix}/${env_name}/lib/libsqlite3.so}"
+
+if [[ ! -d "$internal_dir" ]]; then
+  echo "ERROR: _internal directory not found: $internal_dir" >&2
+  exit 1
+fi
+
+if ! command -v readelf >/dev/null 2>&1; then
+  echo "ERROR: readelf is required (install binutils)." >&2
+  exit 1
+fi
+if ! command -v patchelf >/dev/null 2>&1; then
+  echo "ERROR: patchelf is required." >&2
+  exit 1
+fi
+
+echo "Patching ELF deps under: $internal_dir"
+echo "Absolute prefix scrub target: $abs_prefix"
+echo "Absolute sqlite target: $abs_sqlite"
+
+ensure_sqlite_aliases() {
+  local latest
+  latest="$(
+    ls -1 "$internal_dir"/libsqlite3.so.* 2>/dev/null \
+      | sed 's#^.*/##' \
+      | sort -V \
+      | tail -n 1 || true
+  )"
+  if [[ -z "$latest" ]]; then
+    echo "No bundled libsqlite3.so.* found in _internal; skipping alias creation."
+    return 0
+  fi
+
+  (
+    cd "$internal_dir"
+    ln -sfn "$latest" libsqlite3.so
+    ln -sfn "$latest" libsqlite3.so.0
+    ln -sfn "$latest" libsqlite3.so.3
+    echo "SQLite aliases:"
+    ls -lah libsqlite3.so*
+  )
+}
+
+is_elf() {
+  local f="$1"
+  readelf -h "$f" >/dev/null 2>&1
+}
+
+extract_needed() {
+  local f="$1"
+  readelf -d "$f" 2>/dev/null \
+    | sed -n "s/.*(NEEDED).*Shared library: \[\(.*\)\].*/\1/p"
+}
+
+patch_one() {
+  local f="$1"
+  local needed old base
+  while IFS= read -r needed; do
+    [[ -n "$needed" ]] || continue
+    if [[ "$needed" == /* ]]; then
+      old="$needed"
+      base="$(basename "$old")"
+      if [[ "$old" == "$abs_sqlite" ]]; then
+        base="libsqlite3.so.0"
+      fi
+      if [[ "$old" != "$base" ]]; then
+        echo "replace-needed: $f"
+        echo "  $old -> $base"
+        patchelf --replace-needed "$old" "$base" "$f"
+      fi
+    fi
+  done < <(extract_needed "$f")
+
+  # Ensure bundle-local lookup; this avoids accidental build-host library resolution.
+  patchelf --force-rpath --set-rpath '$ORIGIN' "$f"
+}
+
+ensure_sqlite_aliases
+
+patched_count=0
+while IFS= read -r -d '' f; do
+  if ! is_elf "$f"; then
+    continue
+  fi
+  patch_one "$f"
+  patched_count=$((patched_count + 1))
+done < <(find "$internal_dir" -type f \( -name "*.so" -o -name "*.so.*" -o -name "*.pyd" \) -print0)
+
+# Catch extension modules without a typical suffix (e.g. *_gdal*.so already covered,
+# but this loop also includes executables/other ELF files not matched above).
+while IFS= read -r -d '' f; do
+  if ! is_elf "$f"; then
+    continue
+  fi
+  case "$f" in
+    *.so|*.so.*|*.pyd) continue ;;
+  esac
+  patch_one "$f"
+  patched_count=$((patched_count + 1))
+done < <(find "$internal_dir" -type f -print0)
+
+echo "Patched ELF file count: $patched_count"

--- a/install-linux/scripts/patch_internal_elf_deps.sh
+++ b/install-linux/scripts/patch_internal_elf_deps.sh
@@ -17,11 +17,9 @@ Arguments:
 Behavior:
   - Scans all ELF files under _internal (shared libs and extension modules)
   - Rewrites only /opt/micromamba* DT_NEEDED entries via patchelf --replace-needed
-  - Updates RUNPATH safely:
-      * strips /opt/micromamba* entries
-      * preserves existing entries
-      * ensures $ORIGIN is present when RUNPATH exists, or for files modified by replace-needed
-      * leaves RPATH-only files untouched
+  - If RPATH/RUNPATH contains hard-coded build paths (/opt/micromamba, /home/conda),
+    appends $ORIGIN as the final path element (without removing existing entries)
+  - Does not force-convert RPATH<->RUNPATH and does not overwrite to only $ORIGIN
   - Creates sqlite aliases:
       libsqlite3.so -> latest libsqlite3.so.*
       libsqlite3.so.0 -> latest libsqlite3.so.*
@@ -43,6 +41,8 @@ internal_dir="$1"
 env_name="${2:-wiser-prod}"
 abs_prefix="${3:-/opt/micromamba}"
 abs_sqlite="${4:-/opt/micromamba/envs/${env_name}/lib/libsqlite3.so}"
+readonly build_prefix_a="/opt/micromamba"
+readonly build_prefix_b="/home/conda"
 
 if [[ ! -d "$internal_dir" ]]; then
   echo "ERROR: _internal directory not found: $internal_dir" >&2
@@ -123,85 +123,71 @@ bundle_needs_sqlite3_so3() {
   return 1
 }
 
-rebuild_runpath_with_origin() {
-  local old_runpath="$1"
+value_has_hardcoded_build_path() {
+  local path_value="$1"
+  local entry
   local entries=()
-  local new_entries=()
-  local entry existing
-  local has_origin=0
-  local seen
-
-  IFS=':' read -r -a entries <<< "$old_runpath"
+  IFS=':' read -r -a entries <<< "$path_value"
   for entry in "${entries[@]}"; do
     [[ -n "$entry" ]] || continue
-    if [[ "$entry" == "$abs_prefix"* ]]; then
-      continue
-    fi
-    if [[ "$entry" == "\$ORIGIN" ]]; then
-      has_origin=1
-    fi
-    # Preserve order; de-duplicate only exact repeats.
-    seen=0
-    for existing in "${new_entries[@]}"; do
-      if [[ "$existing" == "$entry" ]]; then
-        seen=1
-        break
-      fi
-    done
-    if [[ $seen -eq 0 ]]; then
-      new_entries+=("$entry")
+    if [[ "$entry" == *"$build_prefix_a"* || "$entry" == *"$build_prefix_b"* ]]; then
+      return 0
     fi
   done
-
-  if [[ $has_origin -eq 0 ]]; then
-    new_entries=("\$ORIGIN" "${new_entries[@]}")
-  fi
-
-  local out=""
-  for entry in "${new_entries[@]}"; do
-    if [[ -z "$out" ]]; then
-      out="$entry"
-    else
-      out="${out}:$entry"
-    fi
-  done
-  printf '%s' "$out"
+  return 1
 }
 
-update_runpath_if_needed() {
+path_ends_with_origin() {
+  local path_value="$1"
+  [[ "$path_value" == "\$ORIGIN" || "$path_value" == *":\$ORIGIN" ]]
+}
+
+append_origin_suffix_if_needed() {
+  local path_value="$1"
+  local updated="$path_value"
+  if ! value_has_hardcoded_build_path "$path_value"; then
+    printf '%s' "$updated"
+    return 0
+  fi
+
+  if ! path_ends_with_origin "$path_value"; then
+    updated="${path_value}:\$ORIGIN"
+  fi
+  printf '%s' "$updated"
+}
+
+update_runtime_path_if_needed() {
   local f="$1"
-  local replaced_needed="$2"
-  local runpath rpath new_runpath
+  local runpath rpath new_path
 
   runpath="$(extract_runpath "$f")"
   rpath="$(extract_rpath "$f")"
 
   if [[ -n "$runpath" ]]; then
-    new_runpath="$(rebuild_runpath_with_origin "$runpath")"
-    if [[ "$new_runpath" != "$runpath" ]]; then
+    new_path="$(append_origin_suffix_if_needed "$runpath")"
+    if [[ "$new_path" != "$runpath" ]]; then
       echo "set-runpath: $f"
-      echo "  old: ${runpath}"
-      echo "  new: ${new_runpath}"
-      patchelf --set-rpath "$new_runpath" "$f"
+      echo "  old RUNPATH: ${runpath}"
+      echo "  new RUNPATH: ${new_path}"
+      patchelf --set-rpath "$new_path" "$f"
     fi
     return 0
   fi
 
-  # No RUNPATH present:
-  # - If file was patched and has no RPATH either, create RUNPATH=$ORIGIN.
-  # - If it has RPATH only, leave it untouched.
-  if [[ "$replaced_needed" -eq 1 && -z "$rpath" ]]; then
-    echo "set-runpath: $f"
-    echo "  old: <none>"
-    echo "  new: \$ORIGIN"
-    patchelf --set-rpath '$ORIGIN' "$f"
+  if [[ -n "$rpath" ]]; then
+    new_path="$(append_origin_suffix_if_needed "$rpath")"
+    if [[ "$new_path" != "$rpath" ]]; then
+      echo "set-rpath: $f"
+      echo "  old RPATH: ${rpath}"
+      echo "  new RPATH: ${new_path}"
+      patchelf --set-rpath "$new_path" "$f"
+    fi
   fi
 }
 
 patch_one() {
   local f="$1"
   local needed old base
-  local replaced_needed=0
   while IFS= read -r needed; do
     [[ -n "$needed" ]] || continue
     if [[ "$needed" == "$abs_prefix"* ]]; then
@@ -215,12 +201,11 @@ patch_one() {
         echo "replace-needed: $f"
         echo "  $old -> $base"
         patchelf --replace-needed "$old" "$base" "$f"
-        replaced_needed=1
       fi
     fi
   done < <(extract_needed "$f")
 
-  update_runpath_if_needed "$f" "$replaced_needed"
+  update_runtime_path_if_needed "$f"
 }
 
 ensure_sqlite_aliases

--- a/install-linux/scripts/verify_internal_elf_deps.sh
+++ b/install-linux/scripts/verify_internal_elf_deps.sh
@@ -4,16 +4,14 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  verify_internal_elf_deps.sh <internal_dir> [abs_prefix]
+  verify_internal_elf_deps.sh <internal_dir>
 
 Arguments:
   internal_dir  Path to PyInstaller _internal directory
-  abs_prefix    Absolute build prefix that must not appear in dynamic entries
-                (default: /opt/micromamba)
 
 Checks:
-  - Fails if any DT_NEEDED entry starts with abs_prefix
-  - Fails if any RPATH/RUNPATH entry starts with abs_prefix
+  - For any RPATH/RUNPATH containing /opt/micromamba or /home/conda,
+    fails unless the last path element is exactly $ORIGIN
 EOF
 }
 
@@ -28,7 +26,8 @@ if [[ $# -lt 1 ]]; then
 fi
 
 internal_dir="$1"
-abs_prefix="${2:-/opt/micromamba}"
+readonly build_prefix_a="/opt/micromamba"
+readonly build_prefix_b="/home/conda"
 
 if [[ ! -d "$internal_dir" ]]; then
   echo "ERROR: _internal directory not found: $internal_dir" >&2
@@ -44,16 +43,29 @@ is_elf() {
   readelf -h "$f" >/dev/null 2>&1
 }
 
-extract_needed() {
-  local f="$1"
-  readelf -d "$f" 2>/dev/null \
-    | sed -n "s/.*(NEEDED).*Shared library: \[\(.*\)\].*/\1/p"
-}
-
 extract_rpath_like() {
   local f="$1"
   readelf -d "$f" 2>/dev/null \
     | sed -n "s/.*(RPATH).*Library rpath: \[\(.*\)\].*/RPATH:\1/p; s/.*(RUNPATH).*Library runpath: \[\(.*\)\].*/RUNPATH:\1/p"
+}
+
+value_has_hardcoded_build_path() {
+  local path_value="$1"
+  local entry
+  local entries=()
+  IFS=':' read -r -a entries <<< "$path_value"
+  for entry in "${entries[@]}"; do
+    [[ -n "$entry" ]] || continue
+    if [[ "$entry" == *"$build_prefix_a"* || "$entry" == *"$build_prefix_b"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+path_ends_with_origin() {
+  local path_value="$1"
+  [[ "$path_value" == "\$ORIGIN" || "$path_value" == *":\$ORIGIN" ]]
 }
 
 offenders=0
@@ -61,36 +73,21 @@ scanned=0
 
 check_one() {
   local f="$1"
-  local needed rp_line rp_value had_problem entry
-  local entries=()
+  local rp_line rp_value had_problem
   had_problem=0
   scanned=$((scanned + 1))
-
-  while IFS= read -r needed; do
-    [[ -n "$needed" ]] || continue
-    if [[ "$needed" == "$abs_prefix"* ]]; then
-      if [[ $had_problem -eq 0 ]]; then
-        echo "ELF offender: $f"
-        had_problem=1
-      fi
-      echo "  forbidden DT_NEEDED: $needed"
-    fi
-  done < <(extract_needed "$f")
 
   while IFS= read -r rp_line; do
     [[ -n "$rp_line" ]] || continue
     rp_value="${rp_line#*:}"
-    IFS=':' read -r -a entries <<< "$rp_value"
-    for entry in "${entries[@]}"; do
-      [[ -n "$entry" ]] || continue
-      if [[ "$entry" == "$abs_prefix"* ]]; then
-        if [[ $had_problem -eq 0 ]]; then
-          echo "ELF offender: $f"
-          had_problem=1
-        fi
-        echo "  forbidden ${rp_line%%:*} entry: $entry"
+    if value_has_hardcoded_build_path "$rp_value" && ! path_ends_with_origin "$rp_value"; then
+      if [[ $had_problem -eq 0 ]]; then
+        echo "ELF offender: $f"
+        had_problem=1
       fi
-    done
+      echo "  ${rp_line%%:*} contains build paths but does not end with \$ORIGIN"
+      echo "  ${rp_line%%:*} value: $rp_value"
+    fi
   done < <(extract_rpath_like "$f")
 
   if [[ $had_problem -eq 1 ]]; then
@@ -111,4 +108,4 @@ if [[ $offenders -gt 0 ]]; then
   exit 1
 fi
 
-echo "Verification passed: scanned $scanned ELF file(s); no /opt/micromamba leakage in DT_NEEDED/RPATH/RUNPATH."
+echo "Verification passed: scanned $scanned ELF file(s); build-path RPATH/RUNPATH entries are origin-safe."

--- a/install-linux/scripts/verify_internal_elf_deps.sh
+++ b/install-linux/scripts/verify_internal_elf_deps.sh
@@ -9,11 +9,11 @@ Usage:
 Arguments:
   internal_dir  Path to PyInstaller _internal directory
   abs_prefix    Absolute build prefix that must not appear in dynamic entries
-                (default: /opt/micromamba/envs)
+                (default: /opt/micromamba)
 
 Checks:
-  - Fails if any DT_NEEDED entry is absolute (/...)
-  - Fails if any RPATH/RUNPATH contains absolute build-time paths (abs_prefix)
+  - Fails if any DT_NEEDED entry starts with abs_prefix
+  - Fails if any RPATH/RUNPATH entry starts with abs_prefix
 EOF
 }
 
@@ -28,7 +28,7 @@ if [[ $# -lt 1 ]]; then
 fi
 
 internal_dir="$1"
-abs_prefix="${2:-/opt/micromamba/envs}"
+abs_prefix="${2:-/opt/micromamba}"
 
 if [[ ! -d "$internal_dir" ]]; then
   echo "ERROR: _internal directory not found: $internal_dir" >&2
@@ -61,31 +61,36 @@ scanned=0
 
 check_one() {
   local f="$1"
-  local needed rp_line rp_value had_problem
+  local needed rp_line rp_value had_problem entry
+  local entries=()
   had_problem=0
   scanned=$((scanned + 1))
 
   while IFS= read -r needed; do
     [[ -n "$needed" ]] || continue
-    if [[ "$needed" == /* ]]; then
+    if [[ "$needed" == "$abs_prefix"* ]]; then
       if [[ $had_problem -eq 0 ]]; then
         echo "ELF offender: $f"
         had_problem=1
       fi
-      echo "  absolute DT_NEEDED: $needed"
+      echo "  forbidden DT_NEEDED: $needed"
     fi
   done < <(extract_needed "$f")
 
   while IFS= read -r rp_line; do
     [[ -n "$rp_line" ]] || continue
     rp_value="${rp_line#*:}"
-    if [[ "$rp_value" == *"$abs_prefix"* ]]; then
-      if [[ $had_problem -eq 0 ]]; then
-        echo "ELF offender: $f"
-        had_problem=1
+    IFS=':' read -r -a entries <<< "$rp_value"
+    for entry in "${entries[@]}"; do
+      [[ -n "$entry" ]] || continue
+      if [[ "$entry" == "$abs_prefix"* ]]; then
+        if [[ $had_problem -eq 0 ]]; then
+          echo "ELF offender: $f"
+          had_problem=1
+        fi
+        echo "  forbidden ${rp_line%%:*} entry: $entry"
       fi
-      echo "  absolute ${rp_line%%:*}: $rp_value"
-    fi
+    done
   done < <(extract_rpath_like "$f")
 
   if [[ $had_problem -eq 1 ]]; then
@@ -106,4 +111,4 @@ if [[ $offenders -gt 0 ]]; then
   exit 1
 fi
 
-echo "Verification passed: scanned $scanned ELF file(s); no absolute DT_NEEDED or build-path RUNPATH/RPATH found."
+echo "Verification passed: scanned $scanned ELF file(s); no /opt/micromamba leakage in DT_NEEDED/RPATH/RUNPATH."

--- a/install-linux/scripts/verify_internal_elf_deps.sh
+++ b/install-linux/scripts/verify_internal_elf_deps.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  verify_internal_elf_deps.sh <internal_dir> [abs_prefix]
+
+Arguments:
+  internal_dir  Path to PyInstaller _internal directory
+  abs_prefix    Absolute build prefix that must not appear in dynamic entries
+                (default: /opt/micromamba/envs)
+
+Checks:
+  - Fails if any DT_NEEDED entry is absolute (/...)
+  - Fails if any RPATH/RUNPATH contains absolute build-time paths (abs_prefix)
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+internal_dir="$1"
+abs_prefix="${2:-/opt/micromamba/envs}"
+
+if [[ ! -d "$internal_dir" ]]; then
+  echo "ERROR: _internal directory not found: $internal_dir" >&2
+  exit 1
+fi
+if ! command -v readelf >/dev/null 2>&1; then
+  echo "ERROR: readelf is required (install binutils)." >&2
+  exit 1
+fi
+
+is_elf() {
+  local f="$1"
+  readelf -h "$f" >/dev/null 2>&1
+}
+
+extract_needed() {
+  local f="$1"
+  readelf -d "$f" 2>/dev/null \
+    | sed -n "s/.*(NEEDED).*Shared library: \[\(.*\)\].*/\1/p"
+}
+
+extract_rpath_like() {
+  local f="$1"
+  readelf -d "$f" 2>/dev/null \
+    | sed -n "s/.*(RPATH).*Library rpath: \[\(.*\)\].*/RPATH:\1/p; s/.*(RUNPATH).*Library runpath: \[\(.*\)\].*/RUNPATH:\1/p"
+}
+
+offenders=0
+scanned=0
+
+check_one() {
+  local f="$1"
+  local needed rp_line rp_value had_problem
+  had_problem=0
+  scanned=$((scanned + 1))
+
+  while IFS= read -r needed; do
+    [[ -n "$needed" ]] || continue
+    if [[ "$needed" == /* ]]; then
+      if [[ $had_problem -eq 0 ]]; then
+        echo "ELF offender: $f"
+        had_problem=1
+      fi
+      echo "  absolute DT_NEEDED: $needed"
+    fi
+  done < <(extract_needed "$f")
+
+  while IFS= read -r rp_line; do
+    [[ -n "$rp_line" ]] || continue
+    rp_value="${rp_line#*:}"
+    if [[ "$rp_value" == *"$abs_prefix"* ]]; then
+      if [[ $had_problem -eq 0 ]]; then
+        echo "ELF offender: $f"
+        had_problem=1
+      fi
+      echo "  absolute ${rp_line%%:*}: $rp_value"
+    fi
+  done < <(extract_rpath_like "$f")
+
+  if [[ $had_problem -eq 1 ]]; then
+    offenders=$((offenders + 1))
+    echo "  readelf -d excerpt:"
+    readelf -d "$f" | sed -n '/NEEDED\|RPATH\|RUNPATH/p' | sed 's/^/    /'
+  fi
+}
+
+while IFS= read -r -d '' f; do
+  if is_elf "$f"; then
+    check_one "$f"
+  fi
+done < <(find "$internal_dir" -type f -print0)
+
+if [[ $offenders -gt 0 ]]; then
+  echo "Verification failed: $offenders offending ELF file(s) under $internal_dir" >&2
+  exit 1
+fi
+
+echo "Verification passed: scanned $scanned ELF file(s); no absolute DT_NEEDED or build-path RUNPATH/RPATH found."

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -3,3 +3,5 @@ wiser.log
 wiser/Cache
 
 !data/
+
+numba_wiser_cache

--- a/src/wiser/__main__.py
+++ b/src/wiser/__main__.py
@@ -32,17 +32,16 @@ faulthandler.enable()
 from wiser.gui.app_config import (
     get_wiser_config_dir,
     check_create_wiser_config_dir,
-    resource_path,
     ApplicationConfig,
 )
 
 if getattr(sys, "frozen", False):
     # We are in a PyInstaller bundle
-    app_data_dir = get_wiser_config_dir()
+    exe_dir = get_wiser_config_dir()
 else:
     # Running as a script
-    app_data_dir = os.path.dirname(os.path.abspath(__file__))
-numba_cache_dir = os.path.join(app_data_dir, "Cache", "numba_jit")
+    exe_dir = os.path.dirname(os.path.abspath(__file__))
+numba_cache_dir = os.path.join(exe_dir, "numba_wiser_cache")
 os.makedirs(numba_cache_dir, exist_ok=True)
 
 os.environ["NUMBA_CACHE_DIR"] = numba_cache_dir
@@ -120,7 +119,9 @@ from PySide2.QtWidgets import *
 
 import matplotlib
 
-# Use absolute paths
+# Use absolute imports in __main__.py so that we can pass the file to
+# pyinstaller.
+from wiser.gui.app import DataVisualizerApp
 from wiser.gui import bug_reporting
 
 
@@ -253,39 +254,16 @@ def main():
     else:
         # TODO(donnie):  Pass Qt arguments
         app = QApplication([])
-        icon_path = resource_path("icons", "wiser.iconset", "icon_256x256.png")
-        icon = QIcon(icon_path)
-        pixmap = icon.pixmap(256, 256)
-        flags = Qt.WindowDoesNotAcceptFocus | Qt.FramelessWindowHint
-        splash = QSplashScreen(pixmap, flags)
-        splash.show()
-        splash.showMessage(
-            "WISER may take longer to load the\nfirst time after a fresh intsall.",
-            Qt.AlignHCenter | Qt.AlignBottom,
-            QColor("black"),
-        )
-        app.processEvents()
-
-        def load_app() -> QMainWindow:
-            # Use absolute imports in __main__.py so that we can pass the file to
-            # pyinstaller. Also this has heavy imports
-            # heavy imports
-            from wiser.gui.app import DataVisualizerApp
-
-            wiser_ui = DataVisualizerApp(config_path=config_path, config=config)
-            # Set the initial window size to be 70% of the screen size.
-            screen_size = app.screens()[0].size()
-            wiser_ui.resize(screen_size * 0.7)
-            splash.finish(wiser_ui)
-            wiser_ui.show()
-
-            return wiser_ui
-
-        # Run load_app when event loop starts
-        QTimer.singleShot(0, load_app)
 
         # ========================================================================
         # WISER Application Initialization
+
+        wiser_ui = DataVisualizerApp(config_path=config_path, config=config)
+
+        # Set the initial window size to be 70% of the screen size.
+        screen_size = app.screens()[0].size()
+        wiser_ui.resize(screen_size * 0.7)
+        wiser_ui.show()
 
         # If the WISER config file was created for the first time, ask the user if
         # they would like to opt in to online bug reporting.

--- a/src/wiser/__main__.py
+++ b/src/wiser/__main__.py
@@ -30,13 +30,13 @@ LOG_CONF_FILE = "logging.conf"
 faulthandler.enable()
 
 from wiser.gui.app_config import (
-    get_wiser_app_dir,
+    get_numba_cache_dir,
     get_wiser_config_dir,
     check_create_wiser_config_dir,
     ApplicationConfig,
 )
 
-numba_cache_dir = os.path.join(get_wiser_app_dir(), "numba_wiser_cache")
+numba_cache_dir = get_numba_cache_dir()
 os.makedirs(numba_cache_dir, exist_ok=True)
 
 os.environ["NUMBA_CACHE_DIR"] = numba_cache_dir

--- a/src/wiser/__main__.py
+++ b/src/wiser/__main__.py
@@ -30,18 +30,13 @@ LOG_CONF_FILE = "logging.conf"
 faulthandler.enable()
 
 from wiser.gui.app_config import (
+    get_wiser_app_dir,
     get_wiser_config_dir,
     check_create_wiser_config_dir,
     ApplicationConfig,
 )
 
-if getattr(sys, "frozen", False):
-    # We are in a PyInstaller bundle
-    exe_dir = get_wiser_config_dir()
-else:
-    # Running as a script
-    exe_dir = os.path.dirname(os.path.abspath(__file__))
-numba_cache_dir = os.path.join(exe_dir, "numba_wiser_cache")
+numba_cache_dir = os.path.join(get_wiser_app_dir(), "numba_wiser_cache")
 os.makedirs(numba_cache_dir, exist_ok=True)
 
 os.environ["NUMBA_CACHE_DIR"] = numba_cache_dir

--- a/src/wiser/gui/app_config.py
+++ b/src/wiser/gui/app_config.py
@@ -85,6 +85,30 @@ def get_wiser_app_dir() -> str:
     return str(Path(__file__).resolve().parents[2])
 
 
+def get_app_data_dir() -> str:
+    """
+    Return the per-version directory WISER should use for writable app data.
+    """
+    sys_name = platform.system()
+    if sys_name == "Windows":
+        return os.path.join(os.path.expandvars(r"%LOCALAPPDATA%\WISER"), version.VERSION)
+
+    if sys_name == "Darwin":
+        return os.path.expanduser(f"~/Library/WISER/{version.VERSION}")
+
+    if sys_name != "Linux":
+        warnings.warn(f'Unrecognized platform name "{sys_name}"')
+
+    return os.path.expanduser(f"~/.wiser/{version.VERSION}")
+
+
+def get_numba_cache_dir() -> str:
+    """
+    Return the directory to use for WISER's numba cache.
+    """
+    return os.path.join(get_app_data_dir(), "numba_wiser_cache")
+
+
 def get_wiser_config_dir() -> str:
     """
     Determine the WISER config directory based on the platform/OS.  The config
@@ -96,28 +120,7 @@ def get_wiser_config_dir() -> str:
     *   All other platforms are assumed to be Linux/*NIX, and `~/.wiser` is
         used.  Note that a warning is output if the platform is not Linux.
     """
-    sys_name = platform.system()
-    if sys_name == "Windows":
-        # If our app is built, we need to put WISER's config into wherever the
-        # user decided to place WISER into
-        if getattr(sys, "frozen", False):
-            wiser_dir = str(Path(sys.executable).resolve().parent)
-        else:
-            wiser_dir = os.path.join(Path(__file__).resolve().parents[3], "dev_config_dir_windows")
-
-    elif sys_name == "Darwin":
-        # Put WISER config in the user's Library directory
-        wiser_dir = os.path.expanduser("~/Library/WISER")
-
-    else:
-        # Use the standard UNIX/Linux approach of a dot-filename in the user's
-        # home directory.
-        if sys_name != "Linux":
-            warnings.warn(f'Unrecognized platform name "{sys_name}"')
-
-        wiser_dir = os.path.expanduser("~/.wiser")
-
-    return wiser_dir
+    return get_app_data_dir()
 
 
 def check_create_wiser_config_dir():

--- a/src/wiser/gui/app_config.py
+++ b/src/wiser/gui/app_config.py
@@ -72,6 +72,19 @@ def resource_path(*parts: str) -> str:
     return str(base.joinpath(*parts))
 
 
+def get_wiser_app_dir() -> str:
+    """
+    Return the directory containing the running WISER application.
+
+    In a frozen PyInstaller build, this is the directory containing WISER.exe.
+    In development, this resolves to the ``src`` directory.
+    """
+    if getattr(sys, "frozen", False):
+        return str(Path(sys.executable).resolve().parent)
+
+    return str(Path(__file__).resolve().parents[2])
+
+
 def get_wiser_config_dir() -> str:
     """
     Determine the WISER config directory based on the platform/OS.  The config
@@ -88,9 +101,9 @@ def get_wiser_config_dir() -> str:
         # If our app is built, we need to put WISER's config into wherever the
         # user decided to place WISER into
         if getattr(sys, "frozen", False):
-            wiser_dir = os.path.dirname(sys.executable)
+            wiser_dir = str(Path(sys.executable).resolve().parent)
         else:
-            wiser_dir = Path(__file__).resolve().parents[2]
+            wiser_dir = os.path.join(Path(__file__).resolve().parents[3], "dev_config_dir_windows")
 
     elif sys_name == "Darwin":
         # Put WISER config in the user's Library directory

--- a/src/wiser/gui/app_config.py
+++ b/src/wiser/gui/app_config.py
@@ -77,15 +77,20 @@ def get_wiser_config_dir() -> str:
     Determine the WISER config directory based on the platform/OS.  The config
     directory is as follows:
 
-    *   On Windows, the user's `AppData\Local\WISER` directory is used.
+    *   On Windows, whichever directory the user decided to install this wiser
+        build into.
     *   On macOS, the user's `~/Library/WISER` directory is used.
     *   All other platforms are assumed to be Linux/*NIX, and `~/.wiser` is
         used.  Note that a warning is output if the platform is not Linux.
     """
     sys_name = platform.system()
     if sys_name == "Windows":
-        # Put WISER config in the user's local application data directory
-        wiser_dir = os.path.expandvars(r"%LOCALAPPDATA%\WISER")
+        # If our app is built, we need to put WISER's config into wherever the
+        # user decided to place WISER into
+        if getattr(sys, "frozen", False):
+            wiser_dir = os.path.dirname(sys.executable)
+        else:
+            wiser_dir = Path(__file__).resolve().parents[2]
 
     elif sys_name == "Darwin":
         # Put WISER config in the user's Library directory


### PR DESCRIPTION
## What does this change do?
We are getting the opencv recursion error again but only on linux builds (Closes #411). To fix, I am trying to:
1. Make sure the .spec between `WISER-ubuntu.spec` and `WISER-macOS.spec` match perfectly. 
2. Compare the differences between the commits where it did work and where it stopped working. It seems that the difference was adding the splash screen.

We are also getting the libsqlite error (Closes #412). I think the solution I need for this is to search every `*.so`'s dependency list in their dynamic section and ensure none of the DT_NEEDED names are paths on the build machine. Also previously we overwrote DT_RPATH. Both overwriting it and using it in the first place is bad practice. Using DT_RPATH treats dependencies as transitive (which means if `A` depends on `B` and `B` depends on `C`, then when `C` is imported, `A` and `B`'s RPATH will still be used), using DT_RUNPATH means `A`'s RPATH will not be used when importing `C`, only `B`'s will). We will also need to make sure that no RPATH is hard coded to a path on the build machine. If it is, then we add $ORIGIN to that RPATH.

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [x] Build
- [x] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
This changed is needed so Linux builds work.

## How did you implement the change?
1. The open cv error was fixed by removing the splash screen code.
2. The libsqlite3 error was fixed by implementing a more general solution for removing built-time path's from a `.so`'s DT_NEEDED list.
    1. Previously we just patched libgdal.so's DT_NEEDED filename (patched from /opt/micromamba/.../libsqlite3.so.0 to libsqlite3.so.0 with symlink). Now the solution looks through all `*.so`s in the `_internal` folder in each of their dynamic sections in their ELF and ensures that there are no DT_NEEDED's with a build path to them and if their are it rewrites the build-time path to the correct soname (e.g. libsqlite3.so.0). This does assume there is a `.so` with a name that matches the build-time path, which most of the time there is. A future PR can update the code to look for a `.so` that matches the base name (without the .so.X).
    2. It also explicitly targets libsqlite3.so.* to make sure its symlinks exist. We also make sure the RPATH and RUNPATH has $ORIGIN appended to it if the path only has build-time paths. 

## Added tests?
- [ ] yes
- [X] no, because they aren’t needed (the test is the build step)
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->