### PR TITLE
fix: Fixing bandmath issues with selecting variable types

### DIFF
--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -59,6 +59,9 @@ from wiser.gui.ui_library import (
     ROIChooserDialog,
     BandChooserDialog,
 )
+from wiser.gui.bandmath_dialog import BandMathDialog
+
+from wiser.bandmath import VariableType
 
 from wiser.raster.loader import RasterDataLoader
 from wiser.raster.dataset import RasterDataSet, RasterDataBand
@@ -120,6 +123,8 @@ class WiserTestModel:
         self._set_up()
 
         self.raster_data_loader = RasterDataLoader()
+
+        self._bandmath_regression_dialog: Optional[BandMathDialog] = None
 
     def _tear_down_windows(self):
         """Closes all open windows and processes pending events."""
@@ -2096,6 +2101,65 @@ class WiserTestModel:
         # We expect this to be none here
         none_ = self.app_state._plugin_band_chooser_dialog.get_chosen_object()
         return none_
+
+    # ==========================================
+    # region Band Math dialog
+    # ==========================================
+
+    def _bandmath_apply_variable_type_combo(self, type_combo: QComboBox, target_type: VariableType) -> bool:
+        idx = type_combo.findData(target_type)
+        if idx < 0:
+            return False
+        type_combo.setCurrentIndex(idx)
+        type_combo.activated.emit(idx)
+        QApplication.processEvents()
+        return True
+
+    def close_bandmath_regression_dialog(self) -> None:
+        """Close the Band Math dialog opened for regression tests and clear the reference."""
+        if self._bandmath_regression_dialog is not None:
+            self._bandmath_regression_dialog.close()
+            self._bandmath_regression_dialog.deleteLater()
+            self._bandmath_regression_dialog = None
+            QApplication.processEvents()
+
+    @run_in_wiser_decorator
+    def bandmath_dialog_variable_type_change_empty_app(self, target_type: VariableType) -> None:
+        """
+        Open Band Math with expression ``a+0``, change variable ``a`` to ``target_type``,
+        and leave the dialog open on ``self._bandmath_regression_dialog``.
+
+        Tests must read **live** widget state from that dialog **after** this method
+        returns (do not snapshot values inside this function for assertions). Call
+        :meth:`close_bandmath_regression_dialog` when finished.
+
+        Runs inside the Qt event loop via :func:`run_in_wiser_decorator`. Parent is the
+        main window, like ``DataVisualizerApp.show_bandmath_dialog``.
+
+        For Image Band, first switches to Image (cube) then to Image Band so switching
+        *to* Image Band is exercised (default name guess for ``a`` is already Image Band).
+        """
+        self.close_bandmath_regression_dialog()
+
+        dialog = BandMathDialog(self.app_state, parent=self.main_window)
+        self._bandmath_regression_dialog = dialog
+
+        dialog.setAttribute(Qt.WA_DontShowOnScreen, True)
+        dialog.show()
+        QApplication.processEvents()
+
+        dialog._ui.ledit_expression.setText("a+0")
+        dialog._analyze_expr()
+        QApplication.processEvents()
+
+        type_combo = dialog._ui.tbl_variables.cellWidget(0, 1)
+        if not isinstance(type_combo, QComboBox):
+            return
+
+        if target_type == VariableType.IMAGE_BAND:
+            self._bandmath_apply_variable_type_combo(type_combo, VariableType.IMAGE_CUBE)
+
+        self._bandmath_apply_variable_type_combo(type_combo, target_type)
 
     # ==========================================
     # region General

--- a/src/tests/test_bandmath_evaluator.py
+++ b/src/tests/test_bandmath_evaluator.py
@@ -32,6 +32,8 @@ from wiser.raster.serializable import BasicValueSerialized, SerializedForm
 
 from test_utils.test_model import WiserTestModel
 
+from PySide2.QtWidgets import QComboBox
+
 from wiser.bandmath.utils import (
     load_image_from_bandmath_result,
     load_band_from_bandmath_result,
@@ -1864,6 +1866,45 @@ class TestBandmathEvaluator(unittest.TestCase):
 
     def test_bandmath_builtin_func_async(self):
         self.bandmath_test_builtin_func_helper(run_sync=False)
+
+    # Band Math dialog: variable type changes with empty app state (regression)
+
+    def _assert_bandmath_dialog_variable_type_result(self, target_type: VariableType):
+        dialog = self.test_model._bandmath_regression_dialog
+        self.assertIsNotNone(dialog, "Band Math dialog should be open on the test model")
+        tbl = dialog._ui.tbl_variables
+        self.assertEqual(tbl.rowCount(), 1)
+        item0 = tbl.item(0, 0)
+        self.assertIsNotNone(item0)
+        self.assertEqual(item0.text(), "a")
+        type_combo = tbl.cellWidget(0, 1)
+        self.assertIsInstance(type_combo, QComboBox)
+        self.assertEqual(type_combo.currentData(), target_type)
+        self.assertEqual(type_combo.currentText(), dialog._variable_types_text[target_type])
+        info_text = dialog._ui.lbl_result_info.text()
+        self.assertNotIn(
+            "Error:",
+            info_text,
+            msg=f"Band-math result label should not show an exception error: {info_text!r}",
+        )
+        stylesheet = dialog._ui.lbl_result_info.styleSheet() or ""
+        self.assertNotIn(
+            "color: red",
+            stylesheet.lower(),
+            msg="Result label should not use red error styling after type change",
+        )
+
+    def test_bandmath_dialog_variable_type_spectrum_empty_app(self):
+        """Regression: switch ``a`` to Spectrum with no spectra loaded; type must stick."""
+        self.addCleanup(self.test_model.close_bandmath_regression_dialog)
+        self.test_model.bandmath_dialog_variable_type_change_empty_app(VariableType.SPECTRUM)
+        self._assert_bandmath_dialog_variable_type_result(VariableType.SPECTRUM)
+
+    def test_bandmath_dialog_variable_type_image_cube_empty_app(self):
+        """Regression: switch ``a`` to Image (cube) with no data loaded; type must stick."""
+        self.addCleanup(self.test_model.close_bandmath_regression_dialog)
+        self.test_model.bandmath_dialog_variable_type_change_empty_app(VariableType.IMAGE_CUBE)
+        self._assert_bandmath_dialog_variable_type_result(VariableType.IMAGE_CUBE)
 
 
 if __name__ == "__main__":

--- a/src/wiser/gui/bandmath_dialog.py
+++ b/src/wiser/gui/bandmath_dialog.py
@@ -2103,14 +2103,18 @@ class BandMathDialog(QDialog):
         if var_type == bandmath.VariableType.IMAGE_CUBE:
             if isinstance(value_widget, QComboBox):
                 ds_id = value_widget.currentData()
-                return ds_id is None or self._app_state.has_dataset(ds_id)
+                if ds_id is None:
+                    return True
+                return self._app_state.has_dataset(ds_id)
             return False
 
         # IMAGE_BAND -> dataset ID from DatasetBandChooserWidget
         if var_type == bandmath.VariableType.IMAGE_BAND:
             if isinstance(value_widget, DatasetBandChooserWidget):
-                ds_id, _band_idx = value_widget.get_ds_band()
-                return ds_id is not None and self._app_state.has_dataset(ds_id)
+                ds_id, band_idx = value_widget.get_ds_band()
+                if ds_id is None or band_idx is None:
+                    return True
+                return self._app_state.has_dataset(ds_id)
             return False
 
         # SPECTRUM -> either spectrum ID (int) or (lib_id, spectrum_index) tuple

--- a/src/wiser/gui/bandmath_dialog.py
+++ b/src/wiser/gui/bandmath_dialog.py
@@ -1687,7 +1687,7 @@ class BandMathDialog(QDialog):
             # If there is a row for batch processing and batch processing is disabled, remove the row
             # If there is no row for batch processing and batch processing is enabled, add a new row
             batch_proc_mismatch = self._is_batch_var_row(index) != self.is_batch_processing_enabled()
-            # If the current row's dataset got deleted, we need to readd the row
+            # If the current row's dataset got deleted, we need to read the row
             row_state_changed = not self.is_row_state_unchanged(index)
             if index == -1 or batch_proc_mismatch or row_state_changed:
                 if (batch_proc_mismatch and index != -1) or row_state_changed:
@@ -2103,7 +2103,7 @@ class BandMathDialog(QDialog):
         if var_type == bandmath.VariableType.IMAGE_CUBE:
             if isinstance(value_widget, QComboBox):
                 ds_id = value_widget.currentData()
-                return ds_id is not None and self._app_state.has_dataset(ds_id)
+                return ds_id is None or self._app_state.has_dataset(ds_id)
             return False
 
         # IMAGE_BAND -> dataset ID from DatasetBandChooserWidget
@@ -2117,6 +2117,9 @@ class BandMathDialog(QDialog):
         if var_type == bandmath.VariableType.SPECTRUM:
             if isinstance(value_widget, QComboBox):
                 info = value_widget.currentData()
+                # If there is no data in the widget, then it couldn't have been changed
+                if info is None:
+                    return True
                 if isinstance(info, int):
                     return self._app_state.has_spectrum(info)
                 if isinstance(info, tuple) and len(info) == 2:
@@ -2186,7 +2189,7 @@ class BandMathDialog(QDialog):
                         lib = self._app_state.get_spectral_library(lib_id)
                         value = lib.get_spectrum(spectrum_index)
 
-                else:
+                elif not isinstance(spectrum_info, type(None)):
                     raise TypeError(f"Unrecognized type of spectrum info:  {spectrum_info}")
             elif var_type == bandmath.VariableType.IMAGE_CUBE_BATCH:
                 # If value is None, then the bandmath dialog will raise the not all bindings specified error
@@ -2219,7 +2222,7 @@ class BandMathDialog(QDialog):
                 raise AssertionError(f"Unrecognized binding type {var_type} for variable {var}")
 
             assert isinstance(
-                value, Serializable
+                value, (Serializable, type(None))
             ), f"value from get_variable_bindings is not Serializable, instead it's {type(value)}"
             variables[var] = (var_type, value)
 


### PR DESCRIPTION
## What does this change do?
In bandmath if there is not a variable available of that variable type, errors happen that shouldn't. For example, if a variable type of spectrum is selected but there are no spectra in the spectrum plot, the variable type looks like it stays as Image Band. In reality what happens is that variable is removed and re-added as image band. Also, selecting a variable type with no values loaded into wiser caused some errors to display that shouldn't have.

Closes #483 

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert


## Added tests?
- [X] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->