### PR TITLE
feat: Creating median, mean, and gaussian filter

### DIFF
--- a/src/tests/test_smooth_filter_semantic_task.py
+++ b/src/tests/test_smooth_filter_semantic_task.py
@@ -1,0 +1,292 @@
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy import ndimage
+
+import tests.context
+
+from test_utils.test_model import WiserTestModel
+from wiser.gui.smooth_filter import (
+    SmoothingDomain,
+    SmoothingFilterKind,
+    SmoothingFilterSemanticTask,
+)
+from wiser.utils.primitives import ExternalRasterHandle
+from wiser.utils.task_stage_utils import build_smoothing_exclusion_mask
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+_JPL_HDR = Path(__file__).resolve().parent / ".." / "test_utils" / "test_datasets" / "jpl_425_7_7.hdr"
+
+
+class TestSmoothingFilterSemanticTask(unittest.TestCase):
+    def setUp(self):
+        self.test_model = WiserTestModel()
+
+    def tearDown(self):
+        self.test_model.close_app()
+        del self.test_model
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _submit_task(
+        self,
+        dataset,
+        *,
+        domain: SmoothingDomain,
+        filter_kind: SmoothingFilterKind,
+        mode: str,
+        cval: float = 0.0,
+        size=None,
+        sigma=None,
+        radius=None,
+        output_ref_name: str = "smooth_out",
+    ):
+        app_state = self.test_model.app_state
+        app_services = self.test_model.app_services
+
+        dataset_ref = app_services.storage_service.register_external(
+            ExternalRasterHandle(dataset_obj=dataset)
+        )
+        task = SmoothingFilterSemanticTask(
+            app_state=app_state,
+            source_dataset=dataset,
+            input_ref=dataset_ref,
+            domain=domain,
+            filter_kind=filter_kind,
+            mode=mode,
+            cval=cval,
+            size=size,
+            sigma=sigma,
+            radius=radius,
+            output_ref_name=output_ref_name,
+        )
+        task_plan = app_services.task_planner.plan_semantic_task(task)
+        future = app_services.task_manager.register_and_submit_task_plan(app_services.scheduler, task_plan)
+        future.result(timeout=180)
+        self.test_model.app.processEvents()
+
+        datasets = app_state.get_datasets()
+        self.assertGreaterEqual(len(datasets), 1, "No dataset was added after task completion")
+        return datasets[-1]
+
+    def _expected_input(self, dataset) -> np.ndarray:
+        """
+        Float32 [y][x][b] array with nodata / bad-band positions and remaining
+        non-finite values set to NaN — mirrors what the tile runner does before scipy.
+        """
+        arr = np.asarray(dataset.get_image_data(filter_data_ignore_value=False), dtype=np.float32).transpose(
+            1, 2, 0
+        )
+
+        exclusion = build_smoothing_exclusion_mask(
+            arr,
+            nodata=dataset.get_data_ignore_value(),
+            bad_bands=dataset.get_bad_bands(),
+        )
+        arr = arr.copy()
+        arr[exclusion] = np.nan
+        arr[~np.isfinite(arr)] = np.nan
+        return arr
+
+    def _result_array(self, result_dataset) -> np.ndarray:
+        """Return result dataset as float32 [y][x][b]."""
+        return np.asarray(
+            result_dataset.get_image_data(filter_data_ignore_value=False), dtype=np.float32
+        ).transpose(1, 2, 0)
+
+    def _check_metadata(self, result_dataset, source_dataset) -> None:
+        source_bad_bands = source_dataset.get_bad_bands()
+        if source_bad_bands is None:
+            self.assertIsNone(result_dataset.get_bad_bands())
+        else:
+            self.assertTrue(
+                np.array_equal(
+                    np.asarray(result_dataset.get_bad_bands()),
+                    np.asarray(source_bad_bands),
+                )
+            )
+        self.assertEqual(
+            result_dataset.get_data_ignore_value(),
+            source_dataset.get_data_ignore_value(),
+        )
+        if source_dataset.has_wavelengths():
+            self.assertTrue(result_dataset.has_wavelengths())
+
+    # ------------------------------------------------------------------
+    # Spatial: mean (uniform_filter)
+    # ------------------------------------------------------------------
+
+    def test_semantic_task_spatial_mean_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        result_dataset = self._submit_task(
+            dataset,
+            domain=SmoothingDomain.SPATIAL,
+            filter_kind=SmoothingFilterKind.MEAN,
+            mode="reflect",
+            size=3,
+            output_ref_name="sem_spatial_mean",
+        )
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.uniform_filter(work, size=(3, 3), axes=(0, 1), mode="reflect"),
+            dtype=np.float32,
+        )
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+
+        actual = self._result_array(result_dataset)
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_metadata(result_dataset, dataset)
+
+    # ------------------------------------------------------------------
+    # Spatial: median (median_filter)
+    # ------------------------------------------------------------------
+
+    def test_semantic_task_spatial_median_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        result_dataset = self._submit_task(
+            dataset,
+            domain=SmoothingDomain.SPATIAL,
+            filter_kind=SmoothingFilterKind.MEDIAN,
+            mode="reflect",
+            size=3,
+            output_ref_name="sem_spatial_median",
+        )
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.median_filter(work, size=(3, 3), axes=(0, 1), mode="reflect"),
+            dtype=np.float32,
+        )
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+
+        actual = self._result_array(result_dataset)
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_metadata(result_dataset, dataset)
+
+    # ------------------------------------------------------------------
+    # Spatial: gaussian (gaussian_filter)
+    # ------------------------------------------------------------------
+
+    def test_semantic_task_spatial_gaussian_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        result_dataset = self._submit_task(
+            dataset,
+            domain=SmoothingDomain.SPATIAL,
+            filter_kind=SmoothingFilterKind.GAUSSIAN,
+            mode="reflect",
+            sigma=1.0,
+            output_ref_name="sem_spatial_gaussian",
+        )
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.gaussian_filter(work, sigma=(1.0, 1.0), axes=(0, 1), mode="reflect", truncate=4.0),
+            dtype=np.float32,
+        )
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+
+        actual = self._result_array(result_dataset)
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_metadata(result_dataset, dataset)
+
+    # ------------------------------------------------------------------
+    # Spectral: mean (uniform_filter)
+    # ------------------------------------------------------------------
+
+    def test_semantic_task_spectral_mean_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        result_dataset = self._submit_task(
+            dataset,
+            domain=SmoothingDomain.SPECTRAL,
+            filter_kind=SmoothingFilterKind.MEAN,
+            mode="reflect",
+            size=5,
+            output_ref_name="sem_spectral_mean",
+        )
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.uniform_filter(work, size=5, axes=(2,), mode="reflect"),
+            dtype=np.float32,
+        )
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+
+        actual = self._result_array(result_dataset)
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_metadata(result_dataset, dataset)
+
+    # ------------------------------------------------------------------
+    # Spectral: median (median_filter)
+    # ------------------------------------------------------------------
+
+    def test_semantic_task_spectral_median_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        result_dataset = self._submit_task(
+            dataset,
+            domain=SmoothingDomain.SPECTRAL,
+            filter_kind=SmoothingFilterKind.MEDIAN,
+            mode="reflect",
+            size=5,
+            output_ref_name="sem_spectral_median",
+        )
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.median_filter(work, size=5, axes=(2,), mode="reflect"),
+            dtype=np.float32,
+        )
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+
+        actual = self._result_array(result_dataset)
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_metadata(result_dataset, dataset)
+
+    # ------------------------------------------------------------------
+    # Spectral: gaussian (gaussian_filter)
+    # ------------------------------------------------------------------
+
+    def test_semantic_task_spectral_gaussian_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        result_dataset = self._submit_task(
+            dataset,
+            domain=SmoothingDomain.SPECTRAL,
+            filter_kind=SmoothingFilterKind.GAUSSIAN,
+            mode="reflect",
+            sigma=2.0,
+            output_ref_name="sem_spectral_gaussian",
+        )
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.gaussian_filter(work, sigma=2.0, axes=(2,), mode="reflect", truncate=4.0),
+            dtype=np.float32,
+        )
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+
+        actual = self._result_array(result_dataset)
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_metadata(result_dataset, dataset)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_smooth_filter_semantic_task.py
+++ b/src/tests/test_smooth_filter_semantic_task.py
@@ -14,7 +14,10 @@ from wiser.gui.smooth_filter import (
     SmoothingFilterSemanticTask,
 )
 from wiser.utils.primitives import ExternalRasterHandle
-from wiser.utils.task_stage_utils import build_smoothing_exclusion_mask
+from wiser.utils.task_stage_utils import (
+    _nan_aware_linear_ndimage_filtered_output,
+    build_smoothing_exclusion_mask,
+)
 
 pytestmark = [
     pytest.mark.integration,
@@ -191,9 +194,10 @@ class TestSmoothingFilterSemanticTask(unittest.TestCase):
         )
 
         work = self._expected_input(dataset)
-        expected = np.asarray(
-            ndimage.gaussian_filter(work, sigma=(1.0, 1.0), axes=(0, 1), mode="reflect", truncate=4.0),
-            dtype=np.float32,
+        expected = _nan_aware_linear_ndimage_filtered_output(
+            work,
+            ndimage.gaussian_filter,
+            {"sigma": (1.0, 1.0), "axes": (0, 1), "mode": "reflect", "truncate": 4.0},
         )
         mask = ~np.isfinite(work)
         expected[mask] = work[mask]
@@ -275,9 +279,10 @@ class TestSmoothingFilterSemanticTask(unittest.TestCase):
         )
 
         work = self._expected_input(dataset)
-        expected = np.asarray(
-            ndimage.gaussian_filter(work, sigma=2.0, axes=(2,), mode="reflect", truncate=4.0),
-            dtype=np.float32,
+        expected = _nan_aware_linear_ndimage_filtered_output(
+            work,
+            ndimage.gaussian_filter,
+            {"sigma": 2.0, "axes": (2,), "mode": "reflect", "truncate": 4.0},
         )
         mask = ~np.isfinite(work)
         expected[mask] = work[mask]

--- a/src/tests/test_smooth_filters.py
+++ b/src/tests/test_smooth_filters.py
@@ -1,0 +1,309 @@
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy import ndimage
+
+import tests.context
+
+from test_utils.memory_cleanup import release_kept_refs
+from test_utils.test_model import WiserTestModel
+from wiser.utils.primitives import DeletePolicy, PriorityClass, ExternalRasterHandle
+from wiser.utils.storage_client import StorageClient
+from wiser.utils.task_stage_utils import (
+    SmoothingFilterSpatial,
+    SmoothingFilterSpectral,
+    build_smoothing_exclusion_mask,
+)
+from wiser.utils.task_system import (
+    AlgorithmPipeline,
+    DatasetPlanMeta,
+    ResourceModel,
+    SemanticTask,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+_JPL_HDR = Path(__file__).resolve().parent / ".." / "test_utils" / "test_datasets" / "jpl_425_7_7.hdr"
+
+_TASK_ID_COUNTER = iter(range(50000, 51000))
+
+
+class TestSmoothingFilters(unittest.TestCase):
+    def setUp(self):
+        self.test_model = WiserTestModel()
+
+    def tearDown(self):
+        self.test_model.close_app()
+        del self.test_model
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _run_stage(self, dataset, stage, output_ref_name: str):
+        """Register dataset, plan a single-stage pipeline, run it, and return (array, meta)."""
+        app_services = self.test_model.app_services
+
+        dataset_ref = app_services.storage_service.register_external(
+            ExternalRasterHandle(dataset_obj=dataset)
+        )
+
+        # Override delete policy so output survives after the plan finishes.
+        stage.set_output_delete_policy(output_ref_name, DeletePolicy.KEEP)
+
+        task = SemanticTask(
+            priority_class=PriorityClass.BACKGROUND,
+            input_ref=dataset_ref,
+            algorithm_pipeline=AlgorithmPipeline(stages=[stage]),
+        )
+        task.id = next(_TASK_ID_COUNTER)
+
+        task_plan = app_services.task_planner.plan_semantic_task(task)
+        future = app_services.scheduler.run_task_plan(task_plan)
+        future.result(timeout=180)
+
+        listener_address, listener_authkey = app_services.storage_service.get_connection_bootstrap()
+        storage_client = StorageClient(
+            service=None,  # type: ignore[arg-type]
+            service_address=listener_address,
+            service_authkey=listener_authkey,
+        )
+        output_ref = task_plan.bindings[output_ref_name]
+        output_data, _ = storage_client.read_data(output_ref, filter_data=False)
+        output_meta = storage_client.get_meta(output_ref)
+        storage_client.close()
+
+        release_kept_refs(app_services)
+        app_services.scheduler.shutdown(wait=True)
+        app_services.storage_service.close()
+
+        return np.asarray(output_data, dtype=np.float32), output_meta
+
+    def _make_spatial_stage(
+        self, dataset, *, filter_registry_key: str, filter_kwargs: dict, output_ref_name: str
+    ):
+        dataset_meta_shape = (
+            np.asarray(dataset.get_image_data(filter_data_ignore_value=False)).transpose(1, 2, 0).shape
+        )
+        input_meta = DatasetPlanMeta(shape=dataset_meta_shape, dtype=np.dtype(np.float32))
+        return SmoothingFilterSpatial(
+            default_executor="process",
+            input_plan_meta=input_meta,
+            _filter_registry_key=filter_registry_key,
+            _filter_kwargs=filter_kwargs,
+            _output_ref_name=output_ref_name,
+        )
+
+    def _make_spectral_stage(
+        self, dataset, *, filter_registry_key: str, filter_kwargs: dict, output_ref_name: str
+    ):
+        dataset_meta_shape = (
+            np.asarray(dataset.get_image_data(filter_data_ignore_value=False)).transpose(1, 2, 0).shape
+        )
+        input_meta = DatasetPlanMeta(shape=dataset_meta_shape, dtype=np.dtype(np.float32))
+        return SmoothingFilterSpectral(
+            default_executor="process",
+            input_plan_meta=input_meta,
+            _filter_registry_key=filter_registry_key,
+            _filter_kwargs=filter_kwargs,
+            _output_ref_name=output_ref_name,
+        )
+
+    def _expected_input(self, dataset) -> np.ndarray:
+        """
+        Return the dataset as float32 [y][x][b] with nodata / bad-band positions and
+        any remaining non-finite values set to NaN — exactly what the tile runner does
+        before passing the array to scipy.
+        """
+        arr = np.asarray(dataset.get_image_data(filter_data_ignore_value=False), dtype=np.float32).transpose(
+            1, 2, 0
+        )
+
+        exclusion = build_smoothing_exclusion_mask(
+            arr,
+            nodata=dataset.get_data_ignore_value(),
+            bad_bands=dataset.get_bad_bands(),
+        )
+        arr = arr.copy()
+        arr[exclusion] = np.nan
+        arr[~np.isfinite(arr)] = np.nan
+        return arr
+
+    def _check_meta(self, actual_meta, dataset) -> None:
+        bad_bands = dataset.get_bad_bands()
+        if bad_bands is None:
+            self.assertIsNone(actual_meta.bad_bands)
+        else:
+            self.assertTrue(np.array_equal(np.asarray(actual_meta.bad_bands), np.asarray(bad_bands)))
+        self.assertEqual(actual_meta.nodata, dataset.get_data_ignore_value())
+
+    # ------------------------------------------------------------------
+    # Spatial: mean (uniform_filter)
+    # ------------------------------------------------------------------
+
+    def test_spatial_mean_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        output_ref_name = "spatial_mean_jpl"
+        stage = self._make_spatial_stage(
+            dataset,
+            filter_registry_key="uniform_filter",
+            filter_kwargs={"size": 3, "mode": "reflect"},
+            output_ref_name=output_ref_name,
+        )
+        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.uniform_filter(work, size=(3, 3), axes=(0, 1), mode="reflect"),
+            dtype=np.float32,
+        )
+
+        self.assertEqual(actual.shape, expected.shape)
+        # Restore nodata/bad-band positions from input before comparing (mirrors task runner restore step).
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_meta(actual_meta, dataset)
+
+    # ------------------------------------------------------------------
+    # Spatial: median (median_filter)
+    # ------------------------------------------------------------------
+
+    def test_spatial_median_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        output_ref_name = "spatial_median_jpl"
+        stage = self._make_spatial_stage(
+            dataset,
+            filter_registry_key="median_filter",
+            filter_kwargs={"size": 3, "mode": "reflect"},
+            output_ref_name=output_ref_name,
+        )
+        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.median_filter(work, size=(3, 3), axes=(0, 1), mode="reflect"),
+            dtype=np.float32,
+        )
+
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_meta(actual_meta, dataset)
+
+    # ------------------------------------------------------------------
+    # Spatial: gaussian (gaussian_filter)
+    # ------------------------------------------------------------------
+
+    def test_spatial_gaussian_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        output_ref_name = "spatial_gaussian_jpl"
+        stage = self._make_spatial_stage(
+            dataset,
+            filter_registry_key="gaussian_filter",
+            filter_kwargs={"sigma": 1.0, "mode": "reflect"},
+            output_ref_name=output_ref_name,
+        )
+        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.gaussian_filter(work, sigma=(1.0, 1.0), axes=(0, 1), mode="reflect", truncate=4.0),
+            dtype=np.float32,
+        )
+
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_meta(actual_meta, dataset)
+
+    # ------------------------------------------------------------------
+    # Spectral: mean (uniform_filter)
+    # ------------------------------------------------------------------
+
+    def test_spectral_mean_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        output_ref_name = "spectral_mean_jpl"
+        stage = self._make_spectral_stage(
+            dataset,
+            filter_registry_key="uniform_filter",
+            filter_kwargs={"size": 5, "mode": "reflect"},
+            output_ref_name=output_ref_name,
+        )
+        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.uniform_filter(work, size=5, axes=(2,), mode="reflect"),
+            dtype=np.float32,
+        )
+
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_meta(actual_meta, dataset)
+
+    # ------------------------------------------------------------------
+    # Spectral: median (median_filter)
+    # ------------------------------------------------------------------
+
+    def test_spectral_median_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        output_ref_name = "spectral_median_jpl"
+        stage = self._make_spectral_stage(
+            dataset,
+            filter_registry_key="median_filter",
+            filter_kwargs={"size": 5, "mode": "reflect"},
+            output_ref_name=output_ref_name,
+        )
+        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.median_filter(work, size=5, axes=(2,), mode="reflect"),
+            dtype=np.float32,
+        )
+
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_meta(actual_meta, dataset)
+
+    # ------------------------------------------------------------------
+    # Spectral: gaussian (gaussian_filter)
+    # ------------------------------------------------------------------
+
+    def test_spectral_gaussian_matches_scipy_on_jpl(self) -> None:
+        dataset = self.test_model.load_dataset(str(_JPL_HDR))
+        output_ref_name = "spectral_gaussian_jpl"
+        stage = self._make_spectral_stage(
+            dataset,
+            filter_registry_key="gaussian_filter",
+            filter_kwargs={"sigma": 2.0, "mode": "reflect"},
+            output_ref_name=output_ref_name,
+        )
+        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+
+        work = self._expected_input(dataset)
+        expected = np.asarray(
+            ndimage.gaussian_filter(work, sigma=2.0, axes=(2,), mode="reflect", truncate=4.0),
+            dtype=np.float32,
+        )
+
+        mask = ~np.isfinite(work)
+        expected[mask] = work[mask]
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+        self._check_meta(actual_meta, dataset)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_smooth_filters.py
+++ b/src/tests/test_smooth_filters.py
@@ -15,6 +15,7 @@ from wiser.utils.storage_client import StorageClient
 from wiser.utils.task_stage_utils import (
     SmoothingFilterSpatial,
     SmoothingFilterSpectral,
+    _nan_aware_linear_ndimage_filtered_output,
     build_smoothing_exclusion_mask,
 )
 from wiser.utils.task_system import (
@@ -289,9 +290,10 @@ class TestSmoothingFilters(unittest.TestCase):
             actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
 
             work = self._expected_input(dataset)
-            expected = np.asarray(
-                ndimage.gaussian_filter(work, sigma=(1.0, 1.0), axes=(0, 1), mode="reflect", truncate=4.0),
-                dtype=np.float32,
+            expected = _nan_aware_linear_ndimage_filtered_output(
+                work,
+                ndimage.gaussian_filter,
+                {"sigma": (1.0, 1.0), "axes": (0, 1), "mode": "reflect", "truncate": 4.0},
             )
 
             mask = ~np.isfinite(work)
@@ -379,9 +381,10 @@ class TestSmoothingFilters(unittest.TestCase):
             actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
 
             work = self._expected_input(dataset)
-            expected = np.asarray(
-                ndimage.gaussian_filter(work, sigma=2.0, axes=(2,), mode="reflect", truncate=4.0),
-                dtype=np.float32,
+            expected = _nan_aware_linear_ndimage_filtered_output(
+                work,
+                ndimage.gaussian_filter,
+                {"sigma": 2.0, "axes": (2,), "mode": "reflect", "truncate": 4.0},
             )
 
             mask = ~np.isfinite(work)

--- a/src/tests/test_smooth_filters.py
+++ b/src/tests/test_smooth_filters.py
@@ -9,6 +9,7 @@ import tests.context
 
 from test_utils.memory_cleanup import release_kept_refs
 from test_utils.test_model import WiserTestModel
+from wiser.raster.dataset import RasterDataSet
 from wiser.utils.primitives import DeletePolicy, PriorityClass, ExternalRasterHandle
 from wiser.utils.storage_client import StorageClient
 from wiser.utils.task_stage_utils import (
@@ -52,7 +53,12 @@ class TestSmoothingFilters(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def _run_stage(self, dataset, stage, output_ref_name: str):
-        """Register dataset, plan a single-stage pipeline, run it, and return (array, meta)."""
+        """Register dataset, plan a single-stage pipeline, run it, and return (array, meta).
+
+        Does not shut down storage or the scheduler; callers must run
+        ``_finalize_pipeline_storage_mnf_style`` once after all pipeline work for this
+        test (same pattern as ``test_mnf``).
+        """
         app_services = self.test_model.app_services
 
         dataset_ref = app_services.storage_service.register_external(
@@ -79,16 +85,20 @@ class TestSmoothingFilters(unittest.TestCase):
             service_address=listener_address,
             service_authkey=listener_authkey,
         )
-        output_ref = task_plan.bindings[output_ref_name]
-        output_data, _ = storage_client.read_data(output_ref, filter_data=False)
-        output_meta = storage_client.get_meta(output_ref)
-        storage_client.close()
+        try:
+            output_ref = task_plan.bindings[output_ref_name]
+            output_data, _ = storage_client.read_data(output_ref, filter_data=False)
+            output_meta = storage_client.get_meta(output_ref)
+            return np.asarray(output_data, dtype=np.float32), output_meta
+        finally:
+            storage_client.close()
 
+    def _finalize_pipeline_storage_mnf_style(self) -> None:
+        """Match ``test_mnf`` teardown: release KEEP refs, stop workers, close storage."""
+        app_services = self.test_model.app_services
         release_kept_refs(app_services)
         app_services.scheduler.shutdown(wait=True)
         app_services.storage_service.close()
-
-        return np.asarray(output_data, dtype=np.float32), output_meta
 
     def _make_spatial_stage(
         self, dataset, *, filter_registry_key: str, filter_kwargs: dict, output_ref_name: str
@@ -151,6 +161,56 @@ class TestSmoothingFilters(unittest.TestCase):
     def _assert_output_not_all_nan(self, output: np.ndarray, label: str) -> None:
         self.assertFalse(np.isnan(output).all(), msg=f"{label} output is entirely NaN")
 
+    def _dataset_with_data_ignore_written_as_nan(self, base: RasterDataSet) -> RasterDataSet:
+        """
+        Rewrite the stored raster so invalid samples are NaN in the buffer:
+
+        - Pixels equal to the data-ignore sentinel become NaN (metadata ignore value unchanged).
+        - Every sample in a bad band (``bad_bands[b] == 0``) becomes NaN (bad-band list unchanged).
+
+        ``build_smoothing_exclusion_mask`` excludes by matching nodata or bad-band index, not by
+        ``isnan`` alone for finite nodata. Writing NaN into those cells makes them participate in
+        the filter like ordinary NaNs for NaN-propagation regression tests.
+        """
+        ignore = base.get_data_ignore_value()
+        if ignore is None:
+            raise AssertionError("NaN-propagation fixture must define a data-ignore value.")
+
+        arr = np.asarray(base.get_image_data(filter_data_ignore_value=False), dtype=np.float32)
+        if isinstance(ignore, (float, np.floating)) and np.isnan(ignore):
+            pass
+        else:
+            ignore_f = np.float32(ignore)
+            arr[np.isclose(arr, ignore_f, rtol=0.0, atol=0.0, equal_nan=True)] = np.nan
+
+        bad_bands = base.get_bad_bands()
+        if bad_bands is not None:
+            bb = np.asarray(bad_bands)
+            if bb.ndim != 1:
+                raise AssertionError(f"bad_bands must be 1-D, got shape {bb.shape}")
+            if bb.shape[0] != arr.shape[0]:
+                raise AssertionError(
+                    f"bad_bands length {bb.shape[0]} must match band dimension {arr.shape[0]}"
+                )
+            for b in range(bb.shape[0]):
+                if bb[b] == 0:
+                    arr[b, :, :] = np.nan
+
+        out = self.test_model.raster_data_loader.dataset_from_numpy_array(arr, self.test_model.data_cache)
+        base_name = base.get_name() or "dataset"
+        out.set_name(f"{base_name} (ignore+badbands→NaN)")
+        out.set_description(base.get_description())
+        out.set_data_ignore_value(ignore)
+        if base.get_bad_bands() is not None:
+            out.set_bad_bands(base.get_bad_bands())
+        if base.has_wavelengths():
+            out.copy_spectral_metadata(base.get_spectral_metadata())
+        if base.get_spatial_metadata().get_spatial_ref():
+            out.copy_spatial_metadata(base.get_spatial_metadata())
+
+        self.test_model.app_state.add_dataset(out)
+        return out
+
     # ------------------------------------------------------------------
     # Spatial: mean (uniform_filter)
     # ------------------------------------------------------------------
@@ -164,20 +224,23 @@ class TestSmoothingFilters(unittest.TestCase):
             filter_kwargs={"size": 3, "mode": "reflect"},
             output_ref_name=output_ref_name,
         )
-        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+        try:
+            actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
 
-        work = self._expected_input(dataset)
-        expected = np.asarray(
-            ndimage.uniform_filter(work, size=(3, 3), axes=(0, 1), mode="reflect"),
-            dtype=np.float32,
-        )
+            work = self._expected_input(dataset)
+            expected = np.asarray(
+                ndimage.uniform_filter(work, size=(3, 3), axes=(0, 1), mode="reflect"),
+                dtype=np.float32,
+            )
 
-        self.assertEqual(actual.shape, expected.shape)
-        # Restore nodata/bad-band positions from input before comparing (mirrors task runner restore step).
-        mask = ~np.isfinite(work)
-        expected[mask] = work[mask]
-        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
-        self._check_meta(actual_meta, dataset)
+            self.assertEqual(actual.shape, expected.shape)
+            # Restore nodata/bad-band positions from input before comparing
+            mask = ~np.isfinite(work)
+            expected[mask] = work[mask]
+            self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+            self._check_meta(actual_meta, dataset)
+        finally:
+            self._finalize_pipeline_storage_mnf_style()
 
     # ------------------------------------------------------------------
     # Spatial: median (median_filter)
@@ -192,19 +255,22 @@ class TestSmoothingFilters(unittest.TestCase):
             filter_kwargs={"size": 3, "mode": "reflect"},
             output_ref_name=output_ref_name,
         )
-        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+        try:
+            actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
 
-        work = self._expected_input(dataset)
-        expected = np.asarray(
-            ndimage.median_filter(work, size=(3, 3), axes=(0, 1), mode="reflect"),
-            dtype=np.float32,
-        )
+            work = self._expected_input(dataset)
+            expected = np.asarray(
+                ndimage.median_filter(work, size=(3, 3), axes=(0, 1), mode="reflect"),
+                dtype=np.float32,
+            )
 
-        mask = ~np.isfinite(work)
-        expected[mask] = work[mask]
-        self.assertEqual(actual.shape, expected.shape)
-        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
-        self._check_meta(actual_meta, dataset)
+            mask = ~np.isfinite(work)
+            expected[mask] = work[mask]
+            self.assertEqual(actual.shape, expected.shape)
+            self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+            self._check_meta(actual_meta, dataset)
+        finally:
+            self._finalize_pipeline_storage_mnf_style()
 
     # ------------------------------------------------------------------
     # Spatial: gaussian (gaussian_filter)
@@ -219,19 +285,22 @@ class TestSmoothingFilters(unittest.TestCase):
             filter_kwargs={"sigma": 1.0, "mode": "reflect"},
             output_ref_name=output_ref_name,
         )
-        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+        try:
+            actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
 
-        work = self._expected_input(dataset)
-        expected = np.asarray(
-            ndimage.gaussian_filter(work, sigma=(1.0, 1.0), axes=(0, 1), mode="reflect", truncate=4.0),
-            dtype=np.float32,
-        )
+            work = self._expected_input(dataset)
+            expected = np.asarray(
+                ndimage.gaussian_filter(work, sigma=(1.0, 1.0), axes=(0, 1), mode="reflect", truncate=4.0),
+                dtype=np.float32,
+            )
 
-        mask = ~np.isfinite(work)
-        expected[mask] = work[mask]
-        self.assertEqual(actual.shape, expected.shape)
-        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
-        self._check_meta(actual_meta, dataset)
+            mask = ~np.isfinite(work)
+            expected[mask] = work[mask]
+            self.assertEqual(actual.shape, expected.shape)
+            self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+            self._check_meta(actual_meta, dataset)
+        finally:
+            self._finalize_pipeline_storage_mnf_style()
 
     # ------------------------------------------------------------------
     # Spectral: mean (uniform_filter)
@@ -246,19 +315,22 @@ class TestSmoothingFilters(unittest.TestCase):
             filter_kwargs={"size": 5, "mode": "reflect"},
             output_ref_name=output_ref_name,
         )
-        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+        try:
+            actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
 
-        work = self._expected_input(dataset)
-        expected = np.asarray(
-            ndimage.uniform_filter(work, size=5, axes=(2,), mode="reflect"),
-            dtype=np.float32,
-        )
+            work = self._expected_input(dataset)
+            expected = np.asarray(
+                ndimage.uniform_filter(work, size=5, axes=(2,), mode="reflect"),
+                dtype=np.float32,
+            )
 
-        mask = ~np.isfinite(work)
-        expected[mask] = work[mask]
-        self.assertEqual(actual.shape, expected.shape)
-        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
-        self._check_meta(actual_meta, dataset)
+            mask = ~np.isfinite(work)
+            expected[mask] = work[mask]
+            self.assertEqual(actual.shape, expected.shape)
+            self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+            self._check_meta(actual_meta, dataset)
+        finally:
+            self._finalize_pipeline_storage_mnf_style()
 
     # ------------------------------------------------------------------
     # Spectral: median (median_filter)
@@ -273,19 +345,22 @@ class TestSmoothingFilters(unittest.TestCase):
             filter_kwargs={"size": 5, "mode": "reflect"},
             output_ref_name=output_ref_name,
         )
-        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+        try:
+            actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
 
-        work = self._expected_input(dataset)
-        expected = np.asarray(
-            ndimage.median_filter(work, size=5, axes=(2,), mode="reflect"),
-            dtype=np.float32,
-        )
+            work = self._expected_input(dataset)
+            expected = np.asarray(
+                ndimage.median_filter(work, size=5, axes=(2,), mode="reflect"),
+                dtype=np.float32,
+            )
 
-        mask = ~np.isfinite(work)
-        expected[mask] = work[mask]
-        self.assertEqual(actual.shape, expected.shape)
-        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
-        self._check_meta(actual_meta, dataset)
+            mask = ~np.isfinite(work)
+            expected[mask] = work[mask]
+            self.assertEqual(actual.shape, expected.shape)
+            self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+            self._check_meta(actual_meta, dataset)
+        finally:
+            self._finalize_pipeline_storage_mnf_style()
 
     # ------------------------------------------------------------------
     # Spectral: gaussian (gaussian_filter)
@@ -300,35 +375,42 @@ class TestSmoothingFilters(unittest.TestCase):
             filter_kwargs={"sigma": 2.0, "mode": "reflect"},
             output_ref_name=output_ref_name,
         )
-        actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
+        try:
+            actual, actual_meta = self._run_stage(dataset, stage, output_ref_name)
 
-        work = self._expected_input(dataset)
-        expected = np.asarray(
-            ndimage.gaussian_filter(work, sigma=2.0, axes=(2,), mode="reflect", truncate=4.0),
-            dtype=np.float32,
-        )
+            work = self._expected_input(dataset)
+            expected = np.asarray(
+                ndimage.gaussian_filter(work, sigma=2.0, axes=(2,), mode="reflect", truncate=4.0),
+                dtype=np.float32,
+            )
 
-        mask = ~np.isfinite(work)
-        expected[mask] = work[mask]
-        self.assertEqual(actual.shape, expected.shape)
-        self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
-        self._check_meta(actual_meta, dataset)
+            mask = ~np.isfinite(work)
+            expected[mask] = work[mask]
+            self.assertEqual(actual.shape, expected.shape)
+            self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
+            self._check_meta(actual_meta, dataset)
+        finally:
+            self._finalize_pipeline_storage_mnf_style()
 
     def _run_nan_propagation_cases(self, dataset, cases) -> None:
-        for label, stage_builder, filter_registry_key, filter_kwargs in cases:
-            with self.subTest(label=label):
-                output_ref_name = f"{label}_caltech_data_ignore"
-                stage = stage_builder(
-                    dataset,
-                    filter_registry_key=filter_registry_key,
-                    filter_kwargs=filter_kwargs,
-                    output_ref_name=output_ref_name,
-                )
-                actual, _ = self._run_stage(dataset, stage, output_ref_name)
-                self._assert_output_not_all_nan(actual, label)
+        try:
+            for label, stage_builder, filter_registry_key, filter_kwargs in cases:
+                with self.subTest(label=label):
+                    output_ref_name = f"{label}_caltech_data_ignore"
+                    stage = stage_builder(
+                        dataset,
+                        filter_registry_key=filter_registry_key,
+                        filter_kwargs=filter_kwargs,
+                        output_ref_name=output_ref_name,
+                    )
+                    actual, _ = self._run_stage(dataset, stage, output_ref_name)
+                    self._assert_output_not_all_nan(actual, label)
+        finally:
+            self._finalize_pipeline_storage_mnf_style()
 
     def test_caltech_data_ignore_mean_nan_propagation_outputs_not_all_nan(self) -> None:
-        dataset = self.test_model.load_dataset(str(_CALTECH_DATA_IGNORE_HDR))
+        base = self.test_model.load_dataset(str(_CALTECH_DATA_IGNORE_HDR))
+        dataset = self._dataset_with_data_ignore_written_as_nan(base)
         cases = [
             ("spatial_mean", self._make_spatial_stage, "uniform_filter", {"size": 3, "mode": "reflect"}),
             ("spectral_mean", self._make_spectral_stage, "uniform_filter", {"size": 5, "mode": "reflect"}),
@@ -336,7 +418,8 @@ class TestSmoothingFilters(unittest.TestCase):
         self._run_nan_propagation_cases(dataset, cases)
 
     def test_caltech_data_ignore_median_nan_propagation_outputs_not_all_nan(self) -> None:
-        dataset = self.test_model.load_dataset(str(_CALTECH_DATA_IGNORE_HDR))
+        base = self.test_model.load_dataset(str(_CALTECH_DATA_IGNORE_HDR))
+        dataset = self._dataset_with_data_ignore_written_as_nan(base)
         cases = [
             ("spatial_median", self._make_spatial_stage, "median_filter", {"size": 3, "mode": "reflect"}),
             ("spectral_median", self._make_spectral_stage, "median_filter", {"size": 5, "mode": "reflect"}),
@@ -344,7 +427,8 @@ class TestSmoothingFilters(unittest.TestCase):
         self._run_nan_propagation_cases(dataset, cases)
 
     def test_caltech_data_ignore_gaussian_nan_propagation_outputs_not_all_nan(self) -> None:
-        dataset = self.test_model.load_dataset(str(_CALTECH_DATA_IGNORE_HDR))
+        base = self.test_model.load_dataset(str(_CALTECH_DATA_IGNORE_HDR))
+        dataset = self._dataset_with_data_ignore_written_as_nan(base)
         cases = [
             (
                 "spatial_gaussian",

--- a/src/tests/test_smooth_filters.py
+++ b/src/tests/test_smooth_filters.py
@@ -28,6 +28,13 @@ pytestmark = [
 ]
 
 _JPL_HDR = Path(__file__).resolve().parent / ".." / "test_utils" / "test_datasets" / "jpl_425_7_7.hdr"
+_CALTECH_DATA_IGNORE_HDR = (
+    Path(__file__).resolve().parent
+    / ".."
+    / "test_utils"
+    / "test_datasets"
+    / "caltech_425_6_6_data_ignore.hdr"
+)
 
 _TASK_ID_COUNTER = iter(range(50000, 51000))
 
@@ -140,6 +147,9 @@ class TestSmoothingFilters(unittest.TestCase):
         else:
             self.assertTrue(np.array_equal(np.asarray(actual_meta.bad_bands), np.asarray(bad_bands)))
         self.assertEqual(actual_meta.nodata, dataset.get_data_ignore_value())
+
+    def _assert_output_not_all_nan(self, output: np.ndarray, label: str) -> None:
+        self.assertFalse(np.isnan(output).all(), msg=f"{label} output is entirely NaN")
 
     # ------------------------------------------------------------------
     # Spatial: mean (uniform_filter)
@@ -303,6 +313,53 @@ class TestSmoothingFilters(unittest.TestCase):
         self.assertEqual(actual.shape, expected.shape)
         self.assertTrue(np.allclose(actual, expected, atol=1e-5, equal_nan=True))
         self._check_meta(actual_meta, dataset)
+
+    def _run_nan_propagation_cases(self, dataset, cases) -> None:
+        for label, stage_builder, filter_registry_key, filter_kwargs in cases:
+            with self.subTest(label=label):
+                output_ref_name = f"{label}_caltech_data_ignore"
+                stage = stage_builder(
+                    dataset,
+                    filter_registry_key=filter_registry_key,
+                    filter_kwargs=filter_kwargs,
+                    output_ref_name=output_ref_name,
+                )
+                actual, _ = self._run_stage(dataset, stage, output_ref_name)
+                self._assert_output_not_all_nan(actual, label)
+
+    def test_caltech_data_ignore_mean_nan_propagation_outputs_not_all_nan(self) -> None:
+        dataset = self.test_model.load_dataset(str(_CALTECH_DATA_IGNORE_HDR))
+        cases = [
+            ("spatial_mean", self._make_spatial_stage, "uniform_filter", {"size": 3, "mode": "reflect"}),
+            ("spectral_mean", self._make_spectral_stage, "uniform_filter", {"size": 5, "mode": "reflect"}),
+        ]
+        self._run_nan_propagation_cases(dataset, cases)
+
+    def test_caltech_data_ignore_median_nan_propagation_outputs_not_all_nan(self) -> None:
+        dataset = self.test_model.load_dataset(str(_CALTECH_DATA_IGNORE_HDR))
+        cases = [
+            ("spatial_median", self._make_spatial_stage, "median_filter", {"size": 3, "mode": "reflect"}),
+            ("spectral_median", self._make_spectral_stage, "median_filter", {"size": 5, "mode": "reflect"}),
+        ]
+        self._run_nan_propagation_cases(dataset, cases)
+
+    def test_caltech_data_ignore_gaussian_nan_propagation_outputs_not_all_nan(self) -> None:
+        dataset = self.test_model.load_dataset(str(_CALTECH_DATA_IGNORE_HDR))
+        cases = [
+            (
+                "spatial_gaussian",
+                self._make_spatial_stage,
+                "gaussian_filter",
+                {"sigma": 1.0, "mode": "reflect"},
+            ),
+            (
+                "spectral_gaussian",
+                self._make_spectral_stage,
+                "gaussian_filter",
+                {"sigma": 2.0, "mode": "reflect"},
+            ),
+        ]
+        self._run_nan_propagation_cases(dataset, cases)
 
 
 if __name__ == "__main__":

--- a/src/wiser/gui/Makefile
+++ b/src/wiser/gui/Makefile
@@ -41,6 +41,7 @@ FILENAMES=\
 	scatter_plot_axes_ui.py \
 	scatter_plot_colormap_ui.py \
 	similarity_transform_dialog_ui.py \
+	smoothing_filter_dialog_ui.py \
 	spectral_angle_mapper_ui.py \
 	spectral_feature_fitting_ui.py \
 	spectrum_info_editor_ui.py \

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -12,15 +12,17 @@ import numpy as np
 import wiser.gui.generated.resources
 
 from .export_image import ExportImageDialog
-from .toolbarmenu import ToolbarMenu
+from .mnf import MinimumNoiseFractionDialog
+from .plugin_utils import add_plugin_context_menu_items
 from .rasterpane import RasterPane
 from .rasterview import RasterView
+from .sav_golay import SavGolayDialog
+from .scatter_plot_2D import ScatterPlot2DDialog
+from .smooth_filter import SmoothingFilterDialog, SmoothingFilterKind
 from .split_pane_dialog import SplitPaneDialog
 from .stretch_builder import StretchBuilderDialog
+from .toolbarmenu import ToolbarMenu
 from .util import add_toolbar_action, get_painter
-from .plugin_utils import add_plugin_context_menu_items
-from .scatter_plot_2D import ScatterPlot2DDialog
-from .mnf import MinimumNoiseFractionDialog
 
 # from .spectral_angle_mapper import SAMTool
 # from .spectral_feature_fitting import SFFTool
@@ -33,7 +35,8 @@ from wiser.raster import roi_export
 
 from wiser.raster.dataset import GeographicLinkState, reference_pixel_to_target_pixel_ds
 
-from wiser.config import FLAGS
+from wiser.bandmath.types import VariableType
+
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +209,34 @@ class MainViewWidget(RasterPane):
 
         act = submenu.addAction(self.tr("Minimum Noise Fraction"))
         act.triggered.connect(lambda checked=False, rv=rasterview, **kwargs: self._open_mnf_dialog(rv))
+
+        submenu = menu.addMenu(self.tr("Filters"))
+
+        act = submenu.addAction(self.tr("Savitzky-Golay Filter..."))
+        act.triggered.connect(lambda checked=False, rv=rasterview: self._open_savgol_dialog(rv))
+
+        submenu.addSeparator()
+
+        act = submenu.addAction(self.tr("Mean Smoothing Filter..."))
+        act.triggered.connect(
+            lambda checked=False, rv=rasterview: self._open_smoothing_filter_dialog(
+                rv, SmoothingFilterKind.MEAN
+            )
+        )
+
+        act = submenu.addAction(self.tr("Median Smoothing Filter..."))
+        act.triggered.connect(
+            lambda checked=False, rv=rasterview: self._open_smoothing_filter_dialog(
+                rv, SmoothingFilterKind.MEDIAN
+            )
+        )
+
+        act = submenu.addAction(self.tr("Gaussian Smoothing Filter..."))
+        act.triggered.connect(
+            lambda checked=False, rv=rasterview: self._open_smoothing_filter_dialog(
+                rv, SmoothingFilterKind.GAUSSIAN
+            )
+        )
 
         # Plugin context-menus
         add_plugin_context_menu_items(
@@ -713,6 +744,35 @@ class MainViewWidget(RasterPane):
             target_point = self._pixel_highlight.get_pixel()
 
         self._draw_crosshair_at_coord(target_point, widget)
+
+    def _open_savgol_dialog(self, rasterview) -> None:
+        dataset = rasterview.get_raster_data()
+        if dataset is None:
+            return
+        target_id = dataset.get_id()
+        if target_id is None:
+            target_id = self._app_state.take_next_id()
+            dataset.set_id(target_id)
+        dlg = SavGolayDialog(
+            app_state=self._app_state,
+            app_services=self._app_services,
+            target_type=VariableType.IMAGE_CUBE_DATASET,
+            target_id=int(target_id),
+            parent=self,
+        )
+        dlg.exec_()
+
+    def _open_smoothing_filter_dialog(self, rasterview, filter_kind: SmoothingFilterKind) -> None:
+        dataset = rasterview.get_raster_data()
+        target_id = None if dataset is None else dataset.get_id()
+        dlg = SmoothingFilterDialog(
+            app_state=self._app_state,
+            app_services=self._app_services,
+            filter_kind=filter_kind,
+            target_dataset_id=target_id,
+            parent=self,
+        )
+        dlg.exec_()
 
     def _on_zoom_to_actual(self, evt):
         """Zoom the view to 100% scale."""

--- a/src/wiser/gui/sav_golay.py
+++ b/src/wiser/gui/sav_golay.py
@@ -333,12 +333,6 @@ class SavGolayDialog(QDialog):
 
 class SavGolayPlugin(plugins.ContextMenuPlugin):
     def add_context_menu_items(self, context_type: plugins.ContextMenuType, context_menu, context):
-        if context_type == plugins.ContextMenuType.RASTER_VIEW:
-            act = context_menu.addAction(context_menu.tr("Savitzky-Golay Filter"))
-            act.triggered.connect(
-                lambda checked=False: self._show_dialog(context, VariableType.IMAGE_CUBE_DATASET)
-            )
-
         if context_type == plugins.ContextMenuType.SPECTRUM_PICK:
             act = context_menu.addAction(context_menu.tr("Savitzky-Golay Filter"))
             act.triggered.connect(lambda checked=False: self._show_dialog(context, VariableType.SPECTRUM))

--- a/src/wiser/gui/smooth_filter.py
+++ b/src/wiser/gui/smooth_filter.py
@@ -1,0 +1,224 @@
+from enum import Enum, auto
+from typing import Dict, Optional, TYPE_CHECKING, Union
+
+import numpy as np
+from PySide2.QtCore import QObject, Signal, Slot
+
+from wiser.utils.primitives import DataMeta, DataRef, DatasetRegionRef, PriorityClass
+from wiser.utils.task_stage_utils import (
+    NDIMAGE_SMOOTHING_FILTER_REGISTRY,
+    SmoothingFilterSpatial,
+    SmoothingFilterSpectral,
+)
+from wiser.utils.task_system import AlgorithmPipeline, DatasetPlanMeta, SemanticTask
+from wiser.utils.worker_runtime import get_process_storage_client
+
+if TYPE_CHECKING:
+    from wiser.gui.app_state import ApplicationState
+    from wiser.raster.dataset import RasterDataSet
+
+
+class SmoothingDomain(Enum):
+    SPATIAL = auto()
+    SPECTRAL = auto()
+
+
+class SmoothingFilterKind(Enum):
+    MEAN = "uniform_filter"
+    MEDIAN = "median_filter"
+    GAUSSIAN = "gaussian_filter"
+
+
+# Human-readable labels for task titles and task variable display.
+_DOMAIN_LABEL: Dict[SmoothingDomain, str] = {
+    SmoothingDomain.SPATIAL: "Spatial",
+    SmoothingDomain.SPECTRAL: "Spectral",
+}
+
+_KIND_LABEL: Dict[SmoothingFilterKind, str] = {
+    SmoothingFilterKind.MEAN: "Mean",
+    SmoothingFilterKind.MEDIAN: "Median",
+    SmoothingFilterKind.GAUSSIAN: "Gaussian",
+}
+
+
+def _build_smoothing_filter_pipeline(
+    *,
+    input_ref: DataRef,
+    domain: SmoothingDomain,
+    filter_kind: SmoothingFilterKind,
+    mode: str,
+    cval: float,
+    size: Optional[Union[int, tuple]],
+    sigma: Optional[Union[float, tuple]],
+    radius: Optional[Union[int, tuple]],
+    output_ref_name: str,
+) -> AlgorithmPipeline:
+    """
+    Construct the kwargs dict for the chosen scipy.ndimage function, then build
+    and return the appropriate single-stage AlgorithmPipeline.
+    """
+    from wiser.utils.worker_runtime import get_process_storage_client as _gsc
+
+    storage_client = _gsc()
+    dataset_meta = storage_client.get_meta(input_ref)
+    if len(dataset_meta.shape) != 3:
+        raise ValueError(f"Expected input dataset shape [y][x][b], got {dataset_meta.shape}")
+
+    input_plan_meta = DatasetPlanMeta(
+        shape=dataset_meta.shape,
+        dtype=np.dtype(dataset_meta.elem_type),
+    )
+
+    filter_kwargs: Dict = {"mode": mode, "cval": cval}
+
+    if filter_kind in (SmoothingFilterKind.MEAN, SmoothingFilterKind.MEDIAN):
+        if size is None:
+            raise ValueError(f"{_KIND_LABEL[filter_kind]} filter requires 'size'.")
+        filter_kwargs["size"] = size
+    elif filter_kind is SmoothingFilterKind.GAUSSIAN:
+        if sigma is None:
+            raise ValueError("Gaussian filter requires 'sigma'.")
+        filter_kwargs["sigma"] = sigma
+        if radius is not None:
+            filter_kwargs["radius"] = radius
+        # truncate is injected automatically by the stage's _normalize step (default 4.0).
+
+    registry_key = filter_kind.value
+
+    if domain is SmoothingDomain.SPATIAL:
+        stage = SmoothingFilterSpatial(
+            default_executor="process",
+            input_plan_meta=input_plan_meta,
+            _filter_registry_key=registry_key,
+            _filter_kwargs=filter_kwargs,
+            _output_ref_name=output_ref_name,
+        )
+    else:
+        stage = SmoothingFilterSpectral(
+            default_executor="process",
+            input_plan_meta=input_plan_meta,
+            _filter_registry_key=registry_key,
+            _filter_kwargs=filter_kwargs,
+            _output_ref_name=output_ref_name,
+        )
+
+    return AlgorithmPipeline([stage])
+
+
+class SmoothingFilterSemanticTask(QObject, SemanticTask):
+    result_ready = Signal(object, object)
+
+    def __init__(
+        self,
+        app_state: "ApplicationState",
+        source_dataset: "RasterDataSet",
+        input_ref: DataRef,
+        domain: SmoothingDomain,
+        filter_kind: SmoothingFilterKind,
+        mode: str,
+        cval: float = 0.0,
+        size: Optional[Union[int, tuple]] = None,
+        sigma: Optional[Union[float, tuple]] = None,
+        radius: Optional[Union[int, tuple]] = None,
+        output_ref_name: str = "smoothing_filtered_dataset",
+    ):
+        QObject.__init__(self)
+
+        pipeline = _build_smoothing_filter_pipeline(
+            input_ref=input_ref,
+            domain=domain,
+            filter_kind=filter_kind,
+            mode=mode,
+            cval=cval,
+            size=size,
+            sigma=sigma,
+            radius=radius,
+            output_ref_name=output_ref_name,
+        )
+
+        domain_label = _DOMAIN_LABEL[domain]
+        kind_label = _KIND_LABEL[filter_kind]
+        task_title = f"{domain_label} {kind_label} Smoothing Filter"
+
+        # Build task_variables from only the parameters that were actually provided,
+        # so the activity monitor shows relevant information rather than a wall of Nones.
+        task_variables: Dict = {"Dataset": source_dataset.get_name()}
+        task_variables["Domain"] = domain_label
+        task_variables["Mode"] = mode
+        task_variables["Cval"] = cval
+        if size is not None:
+            task_variables["Size"] = size
+        if sigma is not None:
+            task_variables["Sigma"] = sigma
+        if radius is not None:
+            task_variables["Radius"] = radius
+
+        SemanticTask.__init__(
+            self,
+            priority_class=PriorityClass.BACKGROUND,
+            input_ref=input_ref,
+            algorithm_pipeline=pipeline,
+            task_title=task_title,
+            task_variables=task_variables,
+        )
+
+        self.id = app_state.take_next_id()
+        self._app_state = app_state
+        self._source_dataset = source_dataset
+        self._output_ref_name = output_ref_name
+        self._domain = domain
+        self._filter_kind = filter_kind
+
+        self.result_ready.connect(self._load_result_into_wiser)
+
+    def completion_callback(self, bindings: Dict[str, DataRef]) -> None:
+        output_ref = bindings.get(self._output_ref_name)
+        if output_ref is None:
+            raise KeyError(f"Missing smoothing filter output binding: {self._output_ref_name!r}")
+
+        storage_client = get_process_storage_client()
+        output_meta = storage_client.get_meta(output_ref)
+        height, width, bands = output_meta.shape
+        output_region = DatasetRegionRef(y0=0, y1=height, x0=0, x1=width, b0=0, b1=bands)
+        output_data, _ = storage_client.read_region(output_ref, output_region, filter_data=False)
+        self.result_ready.emit(np.asarray(output_data), output_meta)
+
+    @Slot(object, object)
+    def _load_result_into_wiser(self, output_data: object, output_meta: object) -> None:
+        output_array = np.asarray(output_data)
+        # Storage layer uses [y][x][b]; the dataset loader expects [b][y][x].
+        output_array_by_band = output_array.transpose(2, 0, 1)
+
+        loader = self._app_state.get_loader()
+        cache = self._app_state.get_cache()
+        result_dataset = loader.dataset_from_numpy_array(output_array_by_band, cache)
+
+        source_name = self._source_dataset.get_name() or "Dataset"
+        domain_label = _DOMAIN_LABEL[self._domain]
+        kind_label = _KIND_LABEL[self._filter_kind]
+        result_dataset.set_name(
+            self._app_state.unique_dataset_name(f"{domain_label} {kind_label} on {source_name}")
+        )
+        result_dataset.set_description(self._source_dataset.get_description())
+
+        default_display_bands = self._source_dataset.default_display_bands()
+        if default_display_bands is not None:
+            result_dataset.set_default_display_bands(default_display_bands)
+
+        if self._source_dataset.get_spatial_metadata().get_spatial_ref():
+            result_dataset.copy_spatial_metadata(self._source_dataset.get_spatial_metadata())
+        if self._source_dataset.has_wavelengths():
+            result_dataset.copy_spectral_metadata(self._source_dataset.get_spectral_metadata())
+
+        if isinstance(output_meta, DataMeta):
+            result_dataset.set_data_ignore_value(output_meta.nodata)
+            if output_meta.bad_bands is not None:
+                result_dataset.set_bad_bands(np.asarray(output_meta.bad_bands).astype(int).tolist())
+        else:
+            # Fallback: carry metadata from source if the output meta is not a DataMeta.
+            result_dataset.set_data_ignore_value(self._source_dataset.get_data_ignore_value())
+            if self._source_dataset.get_bad_bands() is not None:
+                result_dataset.set_bad_bands(self._source_dataset.get_bad_bands())
+
+        self._app_state.add_dataset(result_dataset, view_dataset=False)

--- a/src/wiser/gui/smooth_filter.py
+++ b/src/wiser/gui/smooth_filter.py
@@ -1,10 +1,20 @@
 from enum import Enum, auto
-from typing import Dict, Optional, TYPE_CHECKING, Union
+from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 from PySide2.QtCore import QObject, Signal, Slot
+from PySide2.QtGui import QDoubleValidator, QIntValidator
+from PySide2.QtWidgets import QDialog, QDialogButtonBox, QMessageBox
 
-from wiser.utils.primitives import DataMeta, DataRef, DatasetRegionRef, PriorityClass
+from wiser.gui.app_services import AppServices
+from wiser.gui.generated.smoothing_filter_dialog_ui import Ui_SmoothingFilterDatasetDialog
+from wiser.utils.primitives import (
+    DataMeta,
+    DataRef,
+    DatasetRegionRef,
+    ExternalRasterHandle,
+    PriorityClass,
+)
 from wiser.utils.task_stage_utils import (
     NDIMAGE_SMOOTHING_FILTER_REGISTRY,
     SmoothingFilterSpatial,
@@ -52,6 +62,7 @@ def _build_smoothing_filter_pipeline(
     size: Optional[Union[int, tuple]],
     sigma: Optional[Union[float, tuple]],
     radius: Optional[Union[int, tuple]],
+    truncate: Optional[float],
     output_ref_name: str,
 ) -> AlgorithmPipeline:
     """
@@ -79,10 +90,14 @@ def _build_smoothing_filter_pipeline(
     elif filter_kind is SmoothingFilterKind.GAUSSIAN:
         if sigma is None:
             raise ValueError("Gaussian filter requires 'sigma'.")
+        if radius is not None and truncate is not None:
+            raise ValueError("Specify either 'radius' or 'truncate' for Gaussian, not both.")
         filter_kwargs["sigma"] = sigma
         if radius is not None:
             filter_kwargs["radius"] = radius
-        # truncate is injected automatically by the stage's _normalize step (default 4.0).
+        if truncate is not None:
+            filter_kwargs["truncate"] = truncate
+        # If neither is provided, the stage's _normalize step injects the default truncate (4.0).
 
     registry_key = filter_kind.value
 
@@ -121,6 +136,7 @@ class SmoothingFilterSemanticTask(QObject, SemanticTask):
         size: Optional[Union[int, tuple]] = None,
         sigma: Optional[Union[float, tuple]] = None,
         radius: Optional[Union[int, tuple]] = None,
+        truncate: Optional[float] = None,
         output_ref_name: str = "smoothing_filtered_dataset",
     ):
         QObject.__init__(self)
@@ -134,6 +150,7 @@ class SmoothingFilterSemanticTask(QObject, SemanticTask):
             size=size,
             sigma=sigma,
             radius=radius,
+            truncate=truncate,
             output_ref_name=output_ref_name,
         )
 
@@ -153,6 +170,8 @@ class SmoothingFilterSemanticTask(QObject, SemanticTask):
             task_variables["Sigma"] = sigma
         if radius is not None:
             task_variables["Radius"] = radius
+        if truncate is not None:
+            task_variables["Truncate"] = truncate
 
         SemanticTask.__init__(
             self,
@@ -222,3 +241,413 @@ class SmoothingFilterSemanticTask(QObject, SemanticTask):
                 result_dataset.set_bad_bands(self._source_dataset.get_bad_bands())
 
         self._app_state.add_dataset(result_dataset, view_dataset=False)
+
+
+# Combo-box options. The user-data carries the canonical value (enum or scipy string).
+_AXIS_OPTIONS: Tuple[Tuple[str, SmoothingDomain], ...] = (
+    ("Spectral", SmoothingDomain.SPECTRAL),
+    ("Spatial", SmoothingDomain.SPATIAL),
+)
+
+# scipy.ndimage filter "mode" parameter values.
+_MODE_OPTIONS: Tuple[Tuple[str, str], ...] = (
+    ("reflect", "reflect"),
+    ("constant", "constant"),
+    ("nearest", "nearest"),
+    ("mirror", "mirror"),
+    ("wrap", "wrap"),
+)
+
+_RAD_TRUNC_OPTIONS: Tuple[Tuple[str, str], ...] = (
+    ("Radius", "radius"),
+    ("Truncate", "truncate"),
+)
+
+
+class SmoothingFilterDialog(QDialog):
+    """
+    Dialog for configuring and submitting a SmoothingFilterSemanticTask.
+
+    The kind of filter (mean / median / gaussian) is fixed at construction time. Per-UI parameters
+    (axis, mode, cval, size, sigma, radius/truncate) are read directly from the widgets via getters
+    rather than mirrored into instance attributes. The only internal state we keep is one snapshot
+    per axis (spatial vs. spectral), so a user can switch axes without losing what they typed in
+    the other axis's parameter rows.
+    """
+
+    def __init__(
+        self,
+        app_state: "ApplicationState",
+        app_services: AppServices,
+        filter_kind: SmoothingFilterKind,
+        target_dataset_id: Optional[int] = None,
+        parent=None,
+    ):
+        super().__init__(parent=parent)
+        self._app_state = app_state
+        self._app_services = app_services
+        self._filter_kind = filter_kind
+        self._target_dataset_id = target_dataset_id
+
+        self._ui = Ui_SmoothingFilterDatasetDialog()
+        self._ui.setupUi(self)
+
+        # The .ui file leaves the truncate ledit with Qt Designer's default name `lineEdit_2`;
+        # alias it locally so the rest of this class can read like the rest of the widget names.
+        self._ledit_trunc = self._ui.ledit_trunc
+
+        # Per-axis snapshot of the parameter ledits + rad/trunc cbox. We only ever store the most
+        # recent state for each axis (at most one dict per axis). State is captured by calling the
+        # ledit getters at the moment the user switches axes.
+        self._saved_state_by_axis: Dict[SmoothingDomain, Dict[str, Any]] = {}
+
+        self._set_window_title()
+        self._setup_validators()
+        self._populate_combo_boxes()
+        self._set_initial_field_values()
+        self._wire_signals()
+        self._apply_visibility()
+
+    # region Setup helpers ---------------------------------------------------------------
+
+    def _set_window_title(self) -> None:
+        kind_label = _KIND_LABEL[self._filter_kind]
+        self.setWindowTitle(f"{kind_label} Smoothing Filter")
+
+    def _setup_validators(self) -> None:
+        # Sizes and radii are non-negative integers; sigma, truncate, cval are floats. cval may be
+        # any sign; sigma/truncate must be > 0 but the validator only constrains the format -
+        # semantic checks happen in `accept()`.
+        int_validator = QIntValidator(0, 1_000_000, self)
+        pos_float_validator = QDoubleValidator(0.0, 1.0e12, 12, self)
+        pos_float_validator.setNotation(QDoubleValidator.StandardNotation)
+        signed_float_validator = QDoubleValidator(-1.0e12, 1.0e12, 12, self)
+        signed_float_validator.setNotation(QDoubleValidator.StandardNotation)
+
+        self._ui.ledit_size_x.setValidator(int_validator)
+        self._ui.ledit_size_y.setValidator(int_validator)
+        self._ui.ledit_rad_x.setValidator(int_validator)
+        self._ui.ledit_rad_y.setValidator(int_validator)
+
+        self._ui.ledit_sigma.setValidator(pos_float_validator)
+        self._ui.ledit_sigma_y.setValidator(pos_float_validator)
+        self._ledit_trunc.setValidator(pos_float_validator)
+
+        self._ui.ledit_cval.setValidator(signed_float_validator)
+
+    def _populate_combo_boxes(self) -> None:
+        # Block signals so the initial population doesn't trigger axis-change snapshots etc.
+        for cbox in (
+            self._ui.cbox_dataset,
+            self._ui.cbox_axis,
+            self._ui.cbox_mode,
+            self._ui.cbox_rad_trunc,
+        ):
+            cbox.blockSignals(True)
+            cbox.clear()
+
+        datasets = self._app_state.get_datasets()
+        for dataset in datasets:
+            ds_id = dataset.get_id()
+            if ds_id is None:
+                ds_id = self._app_state.take_next_id()
+                dataset.set_id(ds_id)
+            self._ui.cbox_dataset.addItem(dataset.get_name() or "<unnamed>", ds_id)
+        self._ui.cbox_dataset.addItem(self.tr("(no data)"), -1)
+
+        if datasets:
+            initial_index = 0
+            if self._target_dataset_id is not None:
+                found = self._ui.cbox_dataset.findData(self._target_dataset_id)
+                if found >= 0:
+                    initial_index = found
+            self._ui.cbox_dataset.setCurrentIndex(initial_index)
+        else:
+            # Only "(no data)" exists.
+            self._ui.cbox_dataset.setCurrentIndex(0)
+
+        for label, value in _AXIS_OPTIONS:
+            self._ui.cbox_axis.addItem(label, value)
+        self._ui.cbox_axis.setCurrentIndex(self._ui.cbox_axis.findData(SmoothingDomain.SPECTRAL))
+
+        for label, value in _MODE_OPTIONS:
+            self._ui.cbox_mode.addItem(label, value)
+        self._ui.cbox_mode.setCurrentIndex(self._ui.cbox_mode.findData("reflect"))
+
+        for label, value in _RAD_TRUNC_OPTIONS:
+            self._ui.cbox_rad_trunc.addItem(label, value)
+        self._ui.cbox_rad_trunc.setCurrentIndex(self._ui.cbox_rad_trunc.findData("radius"))
+
+        for cbox in (
+            self._ui.cbox_dataset,
+            self._ui.cbox_axis,
+            self._ui.cbox_mode,
+            self._ui.cbox_rad_trunc,
+        ):
+            cbox.blockSignals(False)
+
+        # Disable Ok if no real datasets are loaded.
+        ok_button = self._ui.buttonBox.button(QDialogButtonBox.Ok)
+        if ok_button is not None:
+            ok_button.setEnabled(bool(datasets))
+
+    def _set_initial_field_values(self) -> None:
+        self._ui.ledit_cval.setText("0")
+        self._ui.ledit_size_x.clear()
+        self._ui.ledit_size_y.clear()
+        self._ui.ledit_sigma.clear()
+        self._ui.ledit_sigma_y.clear()
+        self._ui.ledit_rad_x.clear()
+        self._ui.ledit_rad_y.clear()
+        self._ledit_trunc.clear()
+
+    def _wire_signals(self) -> None:
+        self._ui.cbox_axis.currentIndexChanged.connect(self._on_axis_changed)
+        self._ui.cbox_rad_trunc.currentIndexChanged.connect(lambda _i: self._apply_visibility())
+
+    # endregion
+
+    # region Visibility ------------------------------------------------------------------
+
+    def _apply_visibility(self) -> None:
+        axis = self.get_axis()
+        is_spatial = axis is SmoothingDomain.SPATIAL
+        is_uniform = self._filter_kind in (SmoothingFilterKind.MEAN, SmoothingFilterKind.MEDIAN)
+        is_gaussian = self._filter_kind is SmoothingFilterKind.GAUSSIAN
+
+        # Size rows: only mean/median use "size".
+        self._ui.lbl_size_x.setVisible(is_uniform)
+        self._ui.ledit_size_x.setVisible(is_uniform)
+        self._ui.lbl_size_y.setVisible(is_uniform and is_spatial)
+        self._ui.ledit_size_y.setVisible(is_uniform and is_spatial)
+        if is_uniform:
+            self._ui.lbl_size_x.setText("Size X (width, cols)" if is_spatial else "Size")
+
+        # Sigma rows: only gaussian uses "sigma".
+        self._ui.lbl_sigma_x.setVisible(is_gaussian)
+        self._ui.ledit_sigma.setVisible(is_gaussian)
+        self._ui.lbl_sigma_y.setVisible(is_gaussian and is_spatial)
+        self._ui.ledit_sigma_y.setVisible(is_gaussian and is_spatial)
+        if is_gaussian:
+            self._ui.lbl_sigma_x.setText("Sigma X" if is_spatial else "Sigma")
+
+        # Radius / truncate row: only gaussian; X/Y labels only meaningful in spatial+radius mode.
+        self._ui.cbox_rad_trunc.setVisible(is_gaussian)
+        rt_kind = self.get_rad_trunc_kind() if is_gaussian else None
+        show_rad = is_gaussian and rt_kind == "radius"
+        show_trunc = is_gaussian and rt_kind == "truncate"
+
+        self._ui.ledit_rad_x.setVisible(show_rad)
+        self._ui.ledit_rad_y.setVisible(show_rad and is_spatial)
+        self._ui.lbl_rad_x.setVisible(show_rad and is_spatial)
+        self._ui.lbl_rad_y.setVisible(show_rad and is_spatial)
+        self._ledit_trunc.setVisible(show_trunc)
+
+    # endregion
+
+    # region Axis-switch state -----------------------------------------------------------
+
+    def _on_axis_changed(self, _index: int) -> None:
+        new_axis = self.get_axis()
+        # There are exactly two axes, so the "old" axis is the other one.
+        old_axis = (
+            SmoothingDomain.SPATIAL if new_axis is SmoothingDomain.SPECTRAL else SmoothingDomain.SPECTRAL
+        )
+
+        # Snapshot the current ledit/cbox state under the OLD axis by calling the getters now,
+        # before we mutate the widgets to reflect the NEW axis.
+        self._saved_state_by_axis[old_axis] = self._snapshot_param_state()
+
+        if new_axis in self._saved_state_by_axis:
+            self._restore_param_state(self._saved_state_by_axis[new_axis])
+        else:
+            # No prior state for this axis - reset the per-axis param ledits to empty defaults.
+            self._set_initial_field_values()
+
+        self._apply_visibility()
+
+    def _snapshot_param_state(self) -> Dict[str, Any]:
+        return {
+            "size_x": self._ui.ledit_size_x.text(),
+            "size_y": self._ui.ledit_size_y.text(),
+            "sigma": self._ui.ledit_sigma.text(),
+            "sigma_y": self._ui.ledit_sigma_y.text(),
+            "rad_x": self._ui.ledit_rad_x.text(),
+            "rad_y": self._ui.ledit_rad_y.text(),
+            "trunc": self._ledit_trunc.text(),
+            "rad_trunc_kind": self.get_rad_trunc_kind(),
+        }
+
+    def _restore_param_state(self, state: Dict[str, Any]) -> None:
+        self._ui.ledit_size_x.setText(state.get("size_x", ""))
+        self._ui.ledit_size_y.setText(state.get("size_y", ""))
+        self._ui.ledit_sigma.setText(state.get("sigma", ""))
+        self._ui.ledit_sigma_y.setText(state.get("sigma_y", ""))
+        self._ui.ledit_rad_x.setText(state.get("rad_x", ""))
+        self._ui.ledit_rad_y.setText(state.get("rad_y", ""))
+        self._ledit_trunc.setText(state.get("trunc", ""))
+
+        rt_kind = state.get("rad_trunc_kind", "radius")
+        rt_index = self._ui.cbox_rad_trunc.findData(rt_kind)
+        if rt_index >= 0:
+            self._ui.cbox_rad_trunc.blockSignals(True)
+            self._ui.cbox_rad_trunc.setCurrentIndex(rt_index)
+            self._ui.cbox_rad_trunc.blockSignals(False)
+
+    # endregion
+
+    # region Getters (UI is the source of truth) -----------------------------------------
+
+    def get_filter_kind(self) -> SmoothingFilterKind:
+        return self._filter_kind
+
+    def get_input_dataset(self) -> Optional["RasterDataSet"]:
+        ds_id = self._ui.cbox_dataset.currentData()
+        if ds_id is None or int(ds_id) < 0:
+            return None
+        return self._app_state.get_dataset(int(ds_id))
+
+    def get_axis(self) -> SmoothingDomain:
+        data = self._ui.cbox_axis.currentData()
+        if isinstance(data, SmoothingDomain):
+            return data
+        return SmoothingDomain.SPECTRAL
+
+    def get_mode(self) -> str:
+        data = self._ui.cbox_mode.currentData()
+        return str(data) if data is not None else "reflect"
+
+    def get_cval(self) -> float:
+        text = self._ui.ledit_cval.text().strip()
+        if not text:
+            return 0.0
+        return float(text)
+
+    def get_rad_trunc_kind(self) -> str:
+        data = self._ui.cbox_rad_trunc.currentData()
+        return str(data) if data is not None else "radius"
+
+    def get_size(self) -> Optional[Union[int, Tuple[int, int]]]:
+        if self._filter_kind not in (SmoothingFilterKind.MEAN, SmoothingFilterKind.MEDIAN):
+            return None
+        if self.get_axis() is SmoothingDomain.SPECTRAL:
+            text = self._ui.ledit_size_x.text().strip()
+            if not text:
+                return None
+            return int(text)
+        sx = self._ui.ledit_size_x.text().strip()
+        sy = self._ui.ledit_size_y.text().strip()
+        if not sx or not sy:
+            return None
+        # Spatial axes are ordered (axis 0 = y, axis 1 = x) per SmoothingFilterSpatial.
+        return (int(sy), int(sx))
+
+    def get_sigma(self) -> Optional[Union[float, Tuple[float, float]]]:
+        if self._filter_kind is not SmoothingFilterKind.GAUSSIAN:
+            return None
+        if self.get_axis() is SmoothingDomain.SPECTRAL:
+            text = self._ui.ledit_sigma.text().strip()
+            if not text:
+                return None
+            return float(text)
+        sx = self._ui.ledit_sigma.text().strip()
+        sy = self._ui.ledit_sigma_y.text().strip()
+        if not sx or not sy:
+            return None
+        return (float(sy), float(sx))
+
+    def get_radius(self) -> Optional[Union[int, Tuple[int, int]]]:
+        if self._filter_kind is not SmoothingFilterKind.GAUSSIAN:
+            return None
+        if self.get_rad_trunc_kind() != "radius":
+            return None
+        if self.get_axis() is SmoothingDomain.SPECTRAL:
+            text = self._ui.ledit_rad_x.text().strip()
+            if not text:
+                return None
+            return int(text)
+        rx = self._ui.ledit_rad_x.text().strip()
+        ry = self._ui.ledit_rad_y.text().strip()
+        if not rx or not ry:
+            return None
+        return (int(ry), int(rx))
+
+    def get_truncate(self) -> Optional[float]:
+        if self._filter_kind is not SmoothingFilterKind.GAUSSIAN:
+            return None
+        if self.get_rad_trunc_kind() != "truncate":
+            return None
+        text = self._ledit_trunc.text().strip()
+        if not text:
+            return None
+        return float(text)
+
+    # endregion
+
+    # region Accept ----------------------------------------------------------------------
+
+    def _show_error(self, message: str) -> None:
+        QMessageBox.critical(self, self.windowTitle(), message, QMessageBox.Ok)
+
+    def accept(self) -> None:
+        try:
+            dataset = self.get_input_dataset()
+            if dataset is None:
+                self._show_error("Please select an input dataset.")
+                return
+
+            axis = self.get_axis()
+            mode = self.get_mode()
+            cval = self.get_cval()
+            size = self.get_size()
+            sigma = self.get_sigma()
+            radius = self.get_radius()
+            truncate = self.get_truncate()
+        except ValueError as exc:
+            self._show_error(f"Invalid numeric input: {exc}")
+            return
+
+        if self._filter_kind in (SmoothingFilterKind.MEAN, SmoothingFilterKind.MEDIAN):
+            if size is None:
+                self._show_error("Please enter a size value for every visible size field.")
+                return
+        elif self._filter_kind is SmoothingFilterKind.GAUSSIAN:
+            if sigma is None:
+                self._show_error("Please enter a sigma value for every visible sigma field.")
+                return
+            rt_kind = self.get_rad_trunc_kind()
+            if rt_kind == "radius" and radius is None:
+                self._show_error("Please enter a radius value for every visible radius field.")
+                return
+            if rt_kind == "truncate" and truncate is None:
+                self._show_error("Please enter a truncate value.")
+                return
+
+        try:
+            dataset_ref = self._app_services.storage_service.register_external(
+                ExternalRasterHandle(dataset_obj=dataset)
+            )
+            task = SmoothingFilterSemanticTask(
+                app_state=self._app_state,
+                source_dataset=dataset,
+                input_ref=dataset_ref,
+                domain=axis,
+                filter_kind=self._filter_kind,
+                mode=mode,
+                cval=cval,
+                size=size,
+                sigma=sigma,
+                radius=radius,
+                truncate=truncate,
+            )
+            task_plan = self._app_services.task_planner.plan_semantic_task(task)
+            self._app_services.task_manager.register_and_submit_task_plan(
+                self._app_services.scheduler, task_plan
+            )
+        except Exception as exc:
+            self._show_error(str(exc))
+            return
+
+        super().accept()
+
+    # endregion

--- a/src/wiser/gui/ui_files/smoothing_filter_dialog.ui
+++ b/src/wiser/gui/ui_files/smoothing_filter_dialog.ui
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>SmoothingFilterDialog</class>
- <widget class="QDialog" name="SmoothingFilterDialog">
+ <class>SmoothingFilterDatasetDialog</class>
+ <widget class="QDialog" name="SmoothingFilterDatasetDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>419</width>
     <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Smoothing Filter</string>
+   <string>Smoothing Filter Dataset</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="6" column="0">
+   <item row="10" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -24,38 +24,32 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="lbl_size">
+   <item row="0" column="1">
+    <widget class="QComboBox" name="cbox_dataset"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="lbl_size_x">
      <property name="text">
-      <string>Size</string>
+      <string>Size X (width, cols)</string>
      </property>
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="lbl_cval">
-     <property name="text">
-      <string>cval</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QLabel" name="lbl_mode">
      <property name="text">
       <string>Mode</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="cbox_dataset"/>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="ledit_size"/>
-   </item>
    <item row="4" column="1">
-    <widget class="QLineEdit" name="ledit_sigma"/>
+    <widget class="QLineEdit" name="ledit_size_x"/>
    </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="cbox_mode"/>
+   <item row="7" column="0">
+    <widget class="QLabel" name="lbl_sigma_y">
+     <property name="text">
+      <string>Sigma Y</string>
+     </property>
+    </widget>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="lbl_input_ds">
@@ -64,21 +58,81 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="ledit_size_y"/>
+   </item>
+   <item row="3" column="1">
     <widget class="QLineEdit" name="ledit_cval"/>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="lbl_sigma">
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="ledit_sigma_y"/>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="lbl_sigma_x">
      <property name="text">
-      <string>Sigma</string>
+      <string>Sigma X</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QComboBox" name="cbox_radius_truncate"/>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="cbox_axis"/>
    </item>
-   <item row="5" column="1">
-    <widget class="QLineEdit" name="ledit_rad_trunc"/>
+   <item row="1" column="0">
+    <widget class="QLabel" name="lbl_axis">
+     <property name="text">
+      <string>Axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLineEdit" name="ledit_sigma"/>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="cbox_mode"/>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="lbl_size_y">
+     <property name="text">
+      <string>Size Y (height, rows)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="lbl_rad_x">
+       <property name="text">
+        <string>X:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="ledit_rad_x"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="lbl_rad_y">
+       <property name="text">
+        <string>Y:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="ledit_rad_y"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="ledit_trunc"/>
+     </item>
+    </layout>
+   </item>
+   <item row="8" column="0">
+    <widget class="QComboBox" name="cbox_rad_trunc"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="lbl_cval">
+     <property name="text">
+      <string>Constant Value (cval)</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -87,7 +141,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>SmoothingFilterDialog</receiver>
+   <receiver>SmoothingFilterDatasetDialog</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -103,7 +157,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>SmoothingFilterDialog</receiver>
+   <receiver>SmoothingFilterDatasetDialog</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/wiser/gui/ui_files/smoothing_filter_dialog.ui
+++ b/src/wiser/gui/ui_files/smoothing_filter_dialog.ui
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SmoothingFilterDialog</class>
+ <widget class="QDialog" name="SmoothingFilterDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Smoothing Filter</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="6" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="lbl_size">
+     <property name="text">
+      <string>Size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="lbl_cval">
+     <property name="text">
+      <string>cval</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="lbl_mode">
+     <property name="text">
+      <string>Mode</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="cbox_dataset"/>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="ledit_size"/>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="ledit_sigma"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="cbox_mode"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lbl_input_ds">
+     <property name="text">
+      <string>Input Dataset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="ledit_cval"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="lbl_sigma">
+     <property name="text">
+      <string>Sigma</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QComboBox" name="cbox_radius_truncate"/>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="ledit_rad_trunc"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SmoothingFilterDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SmoothingFilterDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/wiser/utils/task_stage_utils.py
+++ b/src/wiser/utils/task_stage_utils.py
@@ -1599,6 +1599,7 @@ def _run_smoothing_filter_ndimage_tile(
     output_write: "WriteSpec",
     ndimage_filter_fn: Callable[..., Any],
     filter_kwargs: Dict[str, Any],
+    filter_kind: Optional[str] = None,
 ) -> None:
     """
     Read tile, mask invalid samples to NaN, coerce non-finite values to NaN, run ndimage filter,
@@ -1620,8 +1621,20 @@ def _run_smoothing_filter_ndimage_tile(
     work[exclusion] = np.nan
     work[~np.isfinite(work)] = np.nan
 
-    filtered = ndimage_filter_fn(work, **filter_kwargs)
-    output_tile = np.asarray(filtered, dtype=np.float32, order="C")
+    if filter_kind == "uniform_filter":
+        # NaN-aware mean: filter values and finite-value mask separately, then normalize.
+        valid_mask = np.isfinite(work).astype(np.float32, copy=False)
+        values = np.nan_to_num(work, nan=0.0, posinf=0.0, neginf=0.0)
+
+        numerator = np.asarray(ndimage_filter_fn(values, **filter_kwargs), dtype=np.float32, order="C")
+        denominator = np.asarray(ndimage_filter_fn(valid_mask, **filter_kwargs), dtype=np.float32, order="C")
+
+        output_tile = np.full_like(numerator, np.nan, dtype=np.float32)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            np.divide(numerator, denominator, out=output_tile, where=denominator > 0.0)
+    else:
+        filtered = ndimage_filter_fn(work, **filter_kwargs)
+        output_tile = np.asarray(filtered, dtype=np.float32, order="C")
 
     # Restore original stored values at mask locations so nodata/bad-band
     # semantics stay aligned with metadata.
@@ -1662,6 +1675,7 @@ class SmoothingFilterSpatial(MapStage):
 
     _resolved_ndimage_filter_fn: Callable[..., Any] = field(init=False, repr=False)
     _resolved_filter_kwargs: Dict[str, Any] = field(init=False, repr=False)
+    _resolved_filter_kind: Optional[str] = field(init=False, repr=False)
 
     def __post_init__(self):
         self.output_bindings = self.output_bindings + [DataBinding(self._output_ref_name)]
@@ -1677,6 +1691,9 @@ class SmoothingFilterSpatial(MapStage):
 
         object.__setattr__(self, "_resolved_ndimage_filter_fn", fn)
         object.__setattr__(self, "_resolved_filter_kwargs", kwargs)
+        object.__setattr__(
+            self, "_resolved_filter_kind", self._filter_registry_key or getattr(fn, "__name__", None)
+        )
 
     def output_region_for(self, input_region: DataRegion) -> DataRegion:
         if not isinstance(input_region, DatasetRegionRef):
@@ -1724,6 +1741,7 @@ class SmoothingFilterSpatial(MapStage):
             output_write,
             self._resolved_ndimage_filter_fn,
             self._resolved_filter_kwargs,
+            self._resolved_filter_kind,
         )
 
     def post_task_fn(
@@ -1768,6 +1786,7 @@ class SmoothingFilterSpectral(MapStage):
 
     _resolved_ndimage_filter_fn: Callable[..., Any] = field(init=False, repr=False)
     _resolved_filter_kwargs: Dict[str, Any] = field(init=False, repr=False)
+    _resolved_filter_kind: Optional[str] = field(init=False, repr=False)
 
     def __post_init__(self):
         self.output_bindings = self.output_bindings + [DataBinding(self._output_ref_name)]
@@ -1783,6 +1802,9 @@ class SmoothingFilterSpectral(MapStage):
 
         object.__setattr__(self, "_resolved_ndimage_filter_fn", fn)
         object.__setattr__(self, "_resolved_filter_kwargs", kwargs)
+        object.__setattr__(
+            self, "_resolved_filter_kind", self._filter_registry_key or getattr(fn, "__name__", None)
+        )
 
     def output_region_for(self, input_region: DataRegion) -> DataRegion:
         if not isinstance(input_region, DatasetRegionRef):
@@ -1830,6 +1852,7 @@ class SmoothingFilterSpectral(MapStage):
             output_write,
             self._resolved_ndimage_filter_fn,
             self._resolved_filter_kwargs,
+            self._resolved_filter_kind,
         )
 
     def post_task_fn(

--- a/src/wiser/utils/task_stage_utils.py
+++ b/src/wiser/utils/task_stage_utils.py
@@ -1569,6 +1569,28 @@ def _smoothing_dataset_tile_exclusion_mask(tile_yxb: np.ndarray, region_meta: An
     return build_smoothing_exclusion_mask(tile_yxb, region_meta.nodata, region_meta.bad_bands)
 
 
+def _nan_aware_linear_ndimage_filtered_output(
+    work: np.ndarray,
+    ndimage_filter_fn: Callable[..., Any],
+    filter_kwargs: Dict[str, Any],
+) -> np.ndarray:
+    """
+    NaN-aware linear smoothing: run ``ndimage_filter_fn`` on zero-filled values and on a
+    finite mask, then divide (renormalize). Valid for ``uniform_filter`` and
+    ``gaussian_filter``; not for ``median_filter``.
+    """
+    valid_mask = np.isfinite(work).astype(np.float32, copy=False)
+    values = np.nan_to_num(work, nan=0.0, posinf=0.0, neginf=0.0)
+
+    numerator = np.asarray(ndimage_filter_fn(values, **filter_kwargs), dtype=np.float32, order="C")
+    denominator = np.asarray(ndimage_filter_fn(valid_mask, **filter_kwargs), dtype=np.float32, order="C")
+
+    output_tile = np.full_like(numerator, np.nan, dtype=np.float32)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        np.divide(numerator, denominator, out=output_tile, where=denominator > 0.0)
+    return output_tile
+
+
 def _write_smoothing_ndimage_output_meta(
     input_ref: DataRef,
     full_input_region: DataRegion,
@@ -1621,17 +1643,10 @@ def _run_smoothing_filter_ndimage_tile(
     work[exclusion] = np.nan
     work[~np.isfinite(work)] = np.nan
 
-    if filter_kind == "uniform_filter":
-        # NaN-aware mean: filter values and finite-value mask separately, then normalize.
-        valid_mask = np.isfinite(work).astype(np.float32, copy=False)
-        values = np.nan_to_num(work, nan=0.0, posinf=0.0, neginf=0.0)
-
-        numerator = np.asarray(ndimage_filter_fn(values, **filter_kwargs), dtype=np.float32, order="C")
-        denominator = np.asarray(ndimage_filter_fn(valid_mask, **filter_kwargs), dtype=np.float32, order="C")
-
-        output_tile = np.full_like(numerator, np.nan, dtype=np.float32)
-        with np.errstate(divide="ignore", invalid="ignore"):
-            np.divide(numerator, denominator, out=output_tile, where=denominator > 0.0)
+    if filter_kind in ("uniform_filter", "gaussian_filter"):
+        # NaN-aware linear smoother: zero non-finite samples, filter mask and values with the
+        # same kernel, then renormalize (valid for mean / Gaussian weights).
+        output_tile = _nan_aware_linear_ndimage_filtered_output(work, ndimage_filter_fn, filter_kwargs)
     else:
         filtered = ndimage_filter_fn(work, **filter_kwargs)
         output_tile = np.asarray(filtered, dtype=np.float32, order="C")

--- a/src/wiser/utils/task_stage_utils.py
+++ b/src/wiser/utils/task_stage_utils.py
@@ -1,7 +1,9 @@
+import inspect
 from dataclasses import dataclass, field, replace
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Protocol, Sequence, Tuple, Union
 import numpy as np
+from scipy import ndimage
 from scipy.signal import savgol_filter
 from sklearn.decomposition import IncrementalPCA, PCA
 from PySide2.QtCore import *
@@ -25,6 +27,7 @@ from wiser.utils.primitives import (
     SpectraBatchRef,
     SpectraListPlanMeta,
     SpatialTileScheme,
+    SpectralBatchDatasetScheme,
 )
 from wiser.utils.task_system import (
     AlgorithmPipeline,
@@ -1344,6 +1347,504 @@ def get_savgol_filter_pipeline(
             )
         ]
     )
+
+
+# region Smoothing filter MapStages (spatial / spectral ndimage)
+
+
+NDIMAGE_SMOOTHING_FILTER_REGISTRY: Dict[str, Callable[..., Any]] = {
+    "uniform_filter": ndimage.uniform_filter,
+    "median_filter": ndimage.median_filter,
+    "gaussian_filter": ndimage.gaussian_filter,
+}
+
+_GAUSSIAN_FILTER_DEFAULT_TRUNCATE = 4.0
+
+
+def _resolve_smoothing_ndimage_callable(
+    *,
+    ndimage_filter_fn: Optional[Callable[..., Any]],
+    filter_registry_key: Optional[str],
+) -> Callable[..., Any]:
+    if ndimage_filter_fn is not None:
+        return ndimage_filter_fn
+    if filter_registry_key is None:
+        raise ValueError("Provide _ndimage_filter_fn or _filter_registry_key (e.g. 'median_filter').")
+    fn = NDIMAGE_SMOOTHING_FILTER_REGISTRY.get(filter_registry_key)
+    if fn is None:
+        raise ValueError(
+            f"Unknown _filter_registry_key={filter_registry_key!r}. "
+            f"Known keys: {sorted(NDIMAGE_SMOOTHING_FILTER_REGISTRY.keys())}"
+        )
+    return fn
+
+
+def _normalize_smoothing_filter_kwargs(
+    fn: Callable[..., Any],
+    raw_kwargs: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Drop None-valued keys; apply gaussian_filter defaults (e.g. truncate)."""
+    kwargs = {k: v for k, v in dict(raw_kwargs or {}).items() if v is not None}
+    if fn is ndimage.gaussian_filter or getattr(fn, "__name__", "") == "gaussian_filter":
+        # SciPy default truncate is 4.0; we set explicitly so callers can rely on it.
+        kwargs.setdefault("truncate", _GAUSSIAN_FILTER_DEFAULT_TRUNCATE)
+    return kwargs
+
+
+def _finalize_smoothing_filter_kwargs_spatial(
+    fn: Callable[..., Any],
+    kwargs: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Force filtering on dataset axes (0, 1) = (y, x). ``size`` / ``sigma`` / ``radius`` must be int or float
+    (same along y and x) or a length-2 pair of int/float for (axis 0, axis 1).
+    """
+    out = dict(kwargs)
+    if "axes" in out and tuple(out["axes"]) != (0, 1):
+        raise ValueError(
+            "SmoothingFilterSpatial fixes axes=(0, 1) for (y, x); "
+            "remove 'axes' from _filter_kwargs or use (0, 1)."
+        )
+    out["axes"] = (0, 1)
+
+    name = getattr(fn, "__name__", "")
+    if fn is ndimage.gaussian_filter or name == "gaussian_filter":
+        sig = out["sigma"]
+        if isinstance(sig, (int, float)):
+            out["sigma"] = (sig, sig)
+        elif isinstance(sig, (tuple, list)) and len(sig) == 2:
+            if not isinstance(sig[0], (int, float)) or not isinstance(sig[1], (int, float)):
+                raise TypeError(f"Spatial gaussian_filter 'sigma' pair must be int or float, got {sig!r}")
+            out["sigma"] = (sig[0], sig[1])
+        else:
+            raise TypeError(
+                "Spatial gaussian_filter 'sigma' must be int or float "
+                f"or a pair of int/float, got {type(sig).__name__}"
+            )
+        if "radius" in out:
+            rad = out["radius"]
+            if isinstance(rad, (int, float)):
+                out["radius"] = (rad, rad)
+            elif isinstance(rad, (tuple, list)) and len(rad) == 2:
+                if not isinstance(rad[0], (int, float)) or not isinstance(rad[1], (int, float)):
+                    raise TypeError(
+                        f"Spatial gaussian_filter 'radius' pair must be int or float, got {rad!r}"
+                    )
+                out["radius"] = (rad[0], rad[1])
+            else:
+                raise TypeError(
+                    "Spatial gaussian_filter 'radius' must be int or float "
+                    f"or a pair of int/float, got {type(rad).__name__}"
+                )
+    elif fn in (ndimage.uniform_filter, ndimage.median_filter) or name in ("uniform_filter", "median_filter"):
+        sz = out["size"]
+        if isinstance(sz, (int, float)):
+            out["size"] = (sz, sz)
+        elif isinstance(sz, (tuple, list)) and len(sz) == 2:
+            if not isinstance(sz[0], (int, float)) or not isinstance(sz[1], (int, float)):
+                raise TypeError(f"Spatial {name} 'size' pair must be int or float, got {sz!r}")
+            out["size"] = (sz[0], sz[1])
+        else:
+            raise TypeError(
+                f"Spatial {name} 'size' must be int or float or a pair of int/float, got {type(sz).__name__}"
+            )
+    return out
+
+
+def _finalize_smoothing_filter_kwargs_spectral(
+    fn: Callable[..., Any], kwargs: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Force filtering on axis (2,) (spectral / band axis). Coerce size / sigma / radius to one scalar each.
+    """
+    out = dict(kwargs)
+    if "axes" in out and tuple(out["axes"]) != (2,):
+        raise ValueError(
+            "SmoothingFilterSpectral fixes axes=(2,) (spectral axis); "
+            "remove 'axes' from _filter_kwargs or use (2,)."
+        )
+    out["axes"] = (2,)
+
+    name = getattr(fn, "__name__", "")
+    if fn is ndimage.gaussian_filter or name == "gaussian_filter":
+        if not isinstance(out["sigma"], (int, float)):
+            raise TypeError(
+                f"Spectral gaussian_filter 'sigma' must be int or float, got {type(out['sigma']).__name__}"
+            )
+        if "radius" in out:
+            if not isinstance(out["radius"], (int, float)):
+                raise TypeError(
+                    "Spectral gaussian_filter 'radius' must be int or float, "
+                    f"got {type(out['radius']).__name__}"
+                )
+    elif fn in (ndimage.uniform_filter, ndimage.median_filter) or name in ("uniform_filter", "median_filter"):
+        if not isinstance(out["size"], (int, float)):
+            raise TypeError(f"Spectral {name} 'size' must be int or float, got {type(out['size']).__name__}")
+    return out
+
+
+def _validate_smoothing_ndimage_parameter_combinations(
+    fn: Callable[..., Any], kwargs: Dict[str, Any]
+) -> None:
+    """
+    Semantic rules beyond signature checks (no array dry-run).
+    """
+    name = getattr(fn, "__name__", "")
+    if fn is ndimage.gaussian_filter or name == "gaussian_filter":
+        if "sigma" not in kwargs:
+            raise ValueError("gaussian_filter requires keyword 'sigma' (must not be None).")
+        if kwargs["sigma"] is None:
+            raise ValueError("gaussian_filter keyword 'sigma' must not be None.")
+        # radius is optional; truncate is set in _normalize_smoothing_filter_kwargs
+    if fn in (ndimage.uniform_filter, ndimage.median_filter) or name in ("uniform_filter", "median_filter"):
+        if "size" not in kwargs:
+            raise ValueError(f"{name} requires keyword 'size' (must not be None).")
+
+
+def _validate_ndimage_kwargs_match_signature(fn: Callable[..., Any], kwargs: Dict[str, Any]) -> None:
+    """
+    Ensure every keyword is accepted by ``fn`` using inspect.signature and no value is None.
+    We run _normalize_smoothing_filter_kwargs before calling this function to get rid of None values.
+    """
+    for k, v in kwargs.items():
+        if v is None:
+            raise ValueError(f"Filter keyword {k!r} must not be None after normalization (got None).")
+
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError) as e:
+        raise TypeError(f"Cannot inspect signature of {fn!r}") from e
+
+    params = list(sig.parameters.values())
+    if not params:
+        raise TypeError(f"{fn!r} has no parameters")
+
+    var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params)
+    if var_kw:
+        return
+
+    # First parameter is the input array (positional); remaining names are keyword/positional-or-keyword.
+    accepted: set[str] = set()
+    for p in params[1:]:
+        if p.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            accepted.add(p.name)
+
+    for k in kwargs:
+        if k not in accepted:
+            raise TypeError(f"{getattr(fn, '__name__', fn)!r}() got an unexpected keyword argument {k!r}")
+
+
+def build_smoothing_exclusion_mask(
+    tile_yxb: np.ndarray,
+    nodata: Optional[float],
+    bad_bands: Optional[Any],
+) -> np.ndarray:
+    """
+    Return a boolean mask (same shape as ``tile_yxb``) that is True wherever a
+    sample should be treated as invalid before smoothing.
+
+    Invalid means either:
+    - the sample equals the dataset's nodata value (or is NaN when nodata is NaN), or
+    - the sample belongs to a bad band (bad_bands[b] == 0).
+
+    Split out from the tile runner so the test suite can build the same mask
+    when computing the reference (expected) array.
+    """
+    mask = np.zeros(tile_yxb.shape, dtype=np.bool_)
+    if nodata is not None:
+        if np.isnan(nodata):
+            mask |= np.isnan(tile_yxb)
+        else:
+            mask |= tile_yxb == nodata
+    if bad_bands is not None:
+        bad_band_mask = (np.asarray(bad_bands) == 0).reshape(1, 1, tile_yxb.shape[2])
+        mask |= np.broadcast_to(bad_band_mask, tile_yxb.shape)
+    return mask
+
+
+def _smoothing_dataset_tile_exclusion_mask(tile_yxb: np.ndarray, region_meta: Any) -> np.ndarray:
+    return build_smoothing_exclusion_mask(tile_yxb, region_meta.nodata, region_meta.bad_bands)
+
+
+def _write_smoothing_ndimage_output_meta(
+    input_ref: DataRef,
+    full_input_region: DataRegion,
+    output_write: "WriteSpec",
+) -> None:
+    if not isinstance(full_input_region, DatasetRegionRef):
+        raise TypeError("Smoothing filter metadata write requires DatasetRegionRef full_input_region")
+
+    client = get_process_storage_client()
+    input_region_meta = client.get_region_meta(input_ref, full_input_region)
+    output_meta = client.get_meta(output_write.ref)
+    out_meta = replace(
+        output_meta,
+        elem_type=np.dtype(np.float32),
+        nodata=input_region_meta.nodata,
+        wavelengths=input_region_meta.wavelengths,
+        wavelength_units=input_region_meta.wavelength_units,
+        bad_bands=input_region_meta.bad_bands,
+        crs_wkt=input_region_meta.crs_wkt,
+        geotransform=input_region_meta.geotransform,
+    )
+    client.write_meta(output_write.ref, out_meta)
+
+
+def _run_smoothing_filter_ndimage_tile(
+    input_ref: DataRef,
+    input_region: DataRegion,
+    output_write: "WriteSpec",
+    ndimage_filter_fn: Callable[..., Any],
+    filter_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Read tile, mask invalid samples to NaN, coerce non-finite values to NaN, run ndimage filter,
+    then copy original values back at excluded positions (nodata/bad-band cells from input).
+    Extra NaNs from the kernel near edges are left as-is (see feature spec).
+    """
+    if not isinstance(input_region, DatasetRegionRef):
+        raise TypeError("Smoothing filter stages require DatasetRegionRef input_region")
+
+    client = get_process_storage_client()
+    input_tile, region_meta = client.read_region(input_ref, input_region, filter_data=False)
+
+    if input_tile.ndim != 3:
+        raise ValueError(f"Expected dataset tile shape [y][x][b], got {input_tile.shape}")
+
+    exclusion = _smoothing_dataset_tile_exclusion_mask(input_tile, region_meta)
+
+    work = np.asarray(input_tile, dtype=np.float32, order="C")
+    work[exclusion] = np.nan
+    work[~np.isfinite(work)] = np.nan
+
+    filtered = ndimage_filter_fn(work, **filter_kwargs)
+    output_tile = np.asarray(filtered, dtype=np.float32, order="C")
+
+    # Restore original stored values at mask locations so nodata/bad-band
+    # semantics stay aligned with metadata.
+    output_tile[exclusion] = input_tile[exclusion]
+
+    assert output_write.region is not None, "output_write.region cannot be None for smoothing filter output"
+    output_write.region.validate_array_shape(output_tile)
+    client.write_spec(output_write, output_tile.astype(np.float32, copy=False))
+
+
+@dataclass
+class SmoothingFilterSpatial(MapStage):
+    """
+    Apply a scipy.ndimage filter over spatial axes (y, x).
+
+    ``axes=(0, 1)`` is set automatically. ``size`` (uniform/median) or ``sigma`` / optional ``radius``
+    (gaussian) must be one scalar (symmetric kernel) or a pair of two scalars for the two spatial axes.
+    Do not pass ``axes`` in ``_filter_kwargs`` unless it is ``(0, 1)``.
+
+    Uses ``SpectralBatchDatasetScheme`` so each work unit receives the full spatial extent
+    (H, W) for a subset of bands. Because spatial filtering only needs neighbors along y and x,
+    bands are independent and can be processed in slices without boundary effects.
+    """
+
+    _ndimage_filter_fn: Optional[Callable[..., Any]] = None
+    _filter_registry_key: Optional[str] = None
+    _filter_kwargs: Optional[Dict[str, Any]] = None
+    _output_ref_name: str = "spatial_smoothed_dataset"
+    resource_model: ResourceModel = field(
+        default_factory=lambda: ResourceModel(
+            fixed_overhead_bytes=0,
+            bytes_per_scalar_in=1,
+            bytes_per_scalar_out=1,
+            scratch_bytes_per_scalar_in=0,
+        )
+    )
+    chunking_scheme_type: type[ChunkingScheme] = SpectralBatchDatasetScheme
+
+    _resolved_ndimage_filter_fn: Callable[..., Any] = field(init=False, repr=False)
+    _resolved_filter_kwargs: Dict[str, Any] = field(init=False, repr=False)
+
+    def __post_init__(self):
+        self.output_bindings = self.output_bindings + [DataBinding(self._output_ref_name)]
+
+        fn = _resolve_smoothing_ndimage_callable(
+            ndimage_filter_fn=self._ndimage_filter_fn,
+            filter_registry_key=self._filter_registry_key,
+        )
+        kwargs = _normalize_smoothing_filter_kwargs(fn, self._filter_kwargs)
+        _validate_smoothing_ndimage_parameter_combinations(fn, kwargs)
+        kwargs = _finalize_smoothing_filter_kwargs_spatial(fn, kwargs)
+        _validate_ndimage_kwargs_match_signature(fn, kwargs)
+
+        object.__setattr__(self, "_resolved_ndimage_filter_fn", fn)
+        object.__setattr__(self, "_resolved_filter_kwargs", kwargs)
+
+    def output_region_for(self, input_region: DataRegion) -> DataRegion:
+        if not isinstance(input_region, DatasetRegionRef):
+            raise TypeError("SmoothingFilterSpatial expects DatasetRegionRef input")
+        return input_region
+
+    def generate_allocation_requests(
+        self,
+        *,
+        input_meta: "BasePlanMeta",
+        chosen_scheme: Optional[ChunkingScheme],
+    ) -> list[AllocationRequest]:
+        _ = chosen_scheme
+        assert isinstance(
+            input_meta, DatasetPlanMeta
+        ), "SmoothingFilterSpatial input_meta must be DatasetPlanMeta"
+        return [
+            AllocationRequest(
+                name=self._output_ref_name,
+                kind="dataset",
+                residency="ram_cacheable",
+                size_est=input_meta.height
+                * input_meta.width
+                * input_meta.bands
+                * np.dtype(np.float32).itemsize,
+                shape=(input_meta.height, input_meta.width, input_meta.bands),
+                dtype=np.dtype(np.float32),
+                delete_policy=self.get_output_delete_policy(self._output_ref_name),
+            )
+        ]
+
+    def task_fn(
+        self,
+        input_ref: DataRef,
+        input_region: DataRegion,
+        output_writes: Dict[str, "WriteSpec"],
+        broadcast_inputs: Dict[str, Any] = {},
+    ) -> Callable:
+        _ = broadcast_inputs
+        output_write = output_writes[self._output_ref_name]
+        return partial(
+            _run_smoothing_filter_ndimage_tile,
+            input_ref,
+            input_region,
+            output_write,
+            self._resolved_ndimage_filter_fn,
+            self._resolved_filter_kwargs,
+        )
+
+    def post_task_fn(
+        self,
+        input_ref: DataRef,
+        full_input_region: DataRegion,
+        output_writes: Dict[str, "WriteSpec"],
+        broadcast_inputs: Dict[str, Any] = {},
+    ) -> Callable:
+        _ = broadcast_inputs
+        output_write = output_writes[self._output_ref_name]
+        return partial(_write_smoothing_ndimage_output_meta, input_ref, full_input_region, output_write)
+
+
+@dataclass
+class SmoothingFilterSpectral(MapStage):
+    """
+    Apply a scipy.ndimage filter along the spectral (band) axis.
+
+    ``axes=(2,)`` is set automatically. ``size`` (uniform/median) or ``sigma`` / optional ``radius``
+    (gaussian) must be a single scalar (kernel along bands only). Do not pass ``axes`` in
+    ``_filter_kwargs`` unless it is ``(2,)``.
+
+    Uses ``SpatialTileScheme`` so each work unit receives a spatial tile with the full band depth
+    (b0=0, b1=B). This is required for spectral filtering: the kernel along axis 2 needs access to
+    every band of each pixel's spectrum to produce a correct result.
+    """
+
+    _ndimage_filter_fn: Optional[Callable[..., Any]] = None
+    _filter_registry_key: Optional[str] = None
+    _filter_kwargs: Optional[Dict[str, Any]] = None
+    _output_ref_name: str = "spectral_smoothed_dataset"
+    resource_model: ResourceModel = field(
+        default_factory=lambda: ResourceModel(
+            fixed_overhead_bytes=0,
+            bytes_per_scalar_in=1,
+            bytes_per_scalar_out=1,
+            scratch_bytes_per_scalar_in=0,
+        )
+    )
+    chunking_scheme_type: type[ChunkingScheme] = SpatialTileScheme
+
+    _resolved_ndimage_filter_fn: Callable[..., Any] = field(init=False, repr=False)
+    _resolved_filter_kwargs: Dict[str, Any] = field(init=False, repr=False)
+
+    def __post_init__(self):
+        self.output_bindings = self.output_bindings + [DataBinding(self._output_ref_name)]
+
+        fn = _resolve_smoothing_ndimage_callable(
+            ndimage_filter_fn=self._ndimage_filter_fn,
+            filter_registry_key=self._filter_registry_key,
+        )
+        kwargs = _normalize_smoothing_filter_kwargs(fn, self._filter_kwargs)
+        _validate_smoothing_ndimage_parameter_combinations(fn, kwargs)
+        kwargs = _finalize_smoothing_filter_kwargs_spectral(fn, kwargs)
+        _validate_ndimage_kwargs_match_signature(fn, kwargs)
+
+        object.__setattr__(self, "_resolved_ndimage_filter_fn", fn)
+        object.__setattr__(self, "_resolved_filter_kwargs", kwargs)
+
+    def output_region_for(self, input_region: DataRegion) -> DataRegion:
+        if not isinstance(input_region, DatasetRegionRef):
+            raise TypeError("SmoothingFilterSpectral expects DatasetRegionRef input")
+        return input_region
+
+    def generate_allocation_requests(
+        self,
+        *,
+        input_meta: "BasePlanMeta",
+        chosen_scheme: Optional[ChunkingScheme],
+    ) -> list[AllocationRequest]:
+        _ = chosen_scheme
+        assert isinstance(
+            input_meta, DatasetPlanMeta
+        ), "SmoothingFilterSpectral input_meta must be DatasetPlanMeta"
+        return [
+            AllocationRequest(
+                name=self._output_ref_name,
+                kind="dataset",
+                residency="ram_cacheable",
+                size_est=input_meta.height
+                * input_meta.width
+                * input_meta.bands
+                * np.dtype(np.float32).itemsize,
+                shape=(input_meta.height, input_meta.width, input_meta.bands),
+                dtype=np.dtype(np.float32),
+                delete_policy=self.get_output_delete_policy(self._output_ref_name),
+            )
+        ]
+
+    def task_fn(
+        self,
+        input_ref: DataRef,
+        input_region: DataRegion,
+        output_writes: Dict[str, "WriteSpec"],
+        broadcast_inputs: Dict[str, Any] = {},
+    ) -> Callable:
+        _ = broadcast_inputs
+        output_write = output_writes[self._output_ref_name]
+        return partial(
+            _run_smoothing_filter_ndimage_tile,
+            input_ref,
+            input_region,
+            output_write,
+            self._resolved_ndimage_filter_fn,
+            self._resolved_filter_kwargs,
+        )
+
+    def post_task_fn(
+        self,
+        input_ref: DataRef,
+        full_input_region: DataRegion,
+        output_writes: Dict[str, "WriteSpec"],
+        broadcast_inputs: Dict[str, Any] = {},
+    ) -> Callable:
+        _ = broadcast_inputs
+        output_write = output_writes[self._output_ref_name]
+        return partial(_write_smoothing_ndimage_output_meta, input_ref, full_input_region, output_write)
+
+
+# endregion Smoothing filter MapStages
 
 
 def _running_covariance(


### PR DESCRIPTION
## What does this change do?
This change adds three filters to the GUI. They all share one back end because there are so many similar parameters and functionalities that these filters share.

It is important to note how we deal with bad bands and data ignore values for these filters because their values can mess up the calculations . To do so we set them equal to np.nan. For uniform filter, we set the nan's equal to 0 and then we "reweight" the average based on how many 0s there were in a kernel. For the gaussian kernel we do something similar where we set the nan's to 0, but then we renormalize the kernel so the weights still sum to one. This is all done in the function _nan_aware_linear_ndimage_filtered_output. 

Closes #485

## What type of PR is this? (check all applicable) 
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [X] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
<!-- Context, problem solved, issue/ticket link -->

## How did you implement the change?
<!-- High-level approach -->

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->