### PR TITLE
fix: Saving boolean arrays in gdal

### DIFF
--- a/src/tests/test_save_dataset.py
+++ b/src/tests/test_save_dataset.py
@@ -11,6 +11,9 @@ from wiser.raster.dataset_impl import NetCDF_GDALRasterDataImpl
 from wiser.raster.loader import RasterDataLoader
 from wiser.raster.utils import spectral_unit_to_string
 
+ID_SET_1 = 6174
+ID_SET_2 = 42
+
 
 class TestSaveDataset(unittest.TestCase):
     def setUp(self):
@@ -35,7 +38,21 @@ class TestSaveDataset(unittest.TestCase):
             equal_nan=True,
         )
 
-    def _run_save_roundtrip_test(self, dataset: RasterDataSet, save_path: Path) -> None:
+    def _assert_equal_or_both_none_or_empty(self, left, right, msg=None) -> None:
+        """``None`` and ``''`` compare equal to each other; otherwise require ``==``."""
+        left_missing = left is None or left == ""
+        right_missing = right is None or right == ""
+        if left_missing and right_missing:
+            return
+        self.assertEqual(left, right, msg)
+
+    def _run_save_roundtrip_test(
+        self,
+        dataset: RasterDataSet,
+        save_path: Path,
+        *,
+        skip_band_info_equal: bool = False,
+    ) -> None:
         loader = RasterDataLoader()
         band_info = dataset.band_list()
         saved_hdr_path = save_path.with_suffix(".hdr")
@@ -73,18 +90,28 @@ class TestSaveDataset(unittest.TestCase):
             self.assertTrue(saved_hdr_path.exists())
 
             reopened = loader.load_from_file(str(saved_hdr_path), interactive=False)[0]
+            reopened.set_id(ID_SET_2)
             self.assertIsInstance(reopened, RasterDataSet)
 
             self.assertEqual(reopened.get_bad_bands(), dataset.get_bad_bands())
-            self.assertEqual(reopened.get_data_ignore_value(), dataset.get_data_ignore_value())
-            self.assertEqual(reopened.get_wkt_spatial_reference(), dataset.get_wkt_spatial_reference())
+            self._assert_equal_or_both_none_or_empty(
+                reopened.get_data_ignore_value(),
+                dataset.get_data_ignore_value(),
+            )
+            # We have to do this because NumpyRasterDatasetImpl returns None for the wkt string
+            # but GDALRasterDatasetImpl returns an emtpy string when wkt is not present
+            self._assert_equal_or_both_none_or_empty(
+                reopened.get_wkt_spatial_reference(),
+                dataset.get_wkt_spatial_reference(),
+            )
             self.assertEqual(reopened.get_geo_transform(), dataset.get_geo_transform())
             self.assertEqual(reopened.get_width(), dataset.get_width())
             self.assertEqual(reopened.get_height(), dataset.get_height())
             self.assertEqual(reopened.num_bands(), dataset.num_bands())
             self.assertEqual(reopened.get_band_unit(), dataset.get_band_unit())
             self.assertEqual(reopened.default_display_bands(), dataset.default_display_bands())
-            self.assertTrue(band_info_list_equal(reopened._band_info, dataset._band_info))
+            if not skip_band_info_equal:
+                self.assertTrue(band_info_list_equal(reopened._band_info, dataset._band_info))
 
             expected_raw = np.ma.array(
                 dataset.get_image_data(filter_data_ignore_value=False),
@@ -133,6 +160,44 @@ class TestSaveDataset(unittest.TestCase):
             / "caltech_425_6_6_data_ignore_saved.img"
         ).resolve()
         self._run_save_roundtrip_test(dataset, save_path)
+
+    def test_save_dataset_helper_preserves_bool_numpy_dataset(self):
+        """
+        Boolean cubes (e.g. SAM classification) save as GDAL byte bands; roundtrip
+        values must match when interpreted as 0/1.
+        """
+        loader = RasterDataLoader()
+        cache = self.test_model.app_state.get_cache()
+        arr = np.array(
+            [
+                [
+                    [True, False, True, False],
+                    [False, True, False, True],
+                    [True, True, False, False],
+                ],
+                [
+                    [False, False, True, True],
+                    [True, False, True, False],
+                    [False, True, False, True],
+                ],
+            ],
+            dtype=np.bool_,
+        )
+        dataset = loader.dataset_from_numpy_array(arr, cache)
+        dataset.set_id(ID_SET_1)
+        self.assertEqual(dataset.get_elem_type(), np.dtype(np.bool_))
+
+        save_path = (
+            Path(__file__).resolve().parent
+            / ".."
+            / "test_utils"
+            / "test_datasets"
+            / "artifacts"
+            / "bool_classification_saved.img"
+        ).resolve()
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        # Reopened ENVI band descriptions often differ from NumPy placeholder names.
+        self._run_save_roundtrip_test(dataset, save_path, skip_band_info_equal=True)
 
     def test_save_dataset_helper_preserves_netcdf_reflectance_dataset(self):
         fixture_path = Path(__file__).resolve().parent / ".." / "test_utils" / "test_datasets" / "netcdf.nc"

--- a/src/wiser/bandmath/utils.py
+++ b/src/wiser/bandmath/utils.py
@@ -925,6 +925,9 @@ def write_raster_to_dataset(
     if isinstance(result, np.ma.MaskedArray):
         result = np.ma.filled(result, default_ignore_value)
 
+    if isinstance(result, np.ndarray) and np.issubdtype(result.dtype, np.bool_):
+        result = result.astype(np.uint8, copy=False)
+
     gdal_band_list_current = [band + 1 for band in band_index_list]
 
     out_dataset_gdal.WriteRaster(
@@ -943,6 +946,10 @@ def write_raster_to_dataset(
 
 def np_dtype_to_gdal(np_dtype):
     """Converts a NumPy dtype to the corresponding GDAL GDT type."""
+
+    np_dtype = np.dtype(np_dtype)
+    if np.issubdtype(np_dtype, np.bool_) or np_dtype == np.dtype(bool):
+        return gdal.GDT_Byte
 
     # Create a mapping between NumPy dtypes and GDAL GDT types
     dtype_mapping = {

--- a/src/wiser/gui/geo_reference_dialog.py
+++ b/src/wiser/gui/geo_reference_dialog.py
@@ -29,6 +29,7 @@ from wiser.raster.dataset import RasterDataSet
 from wiser.raster.dataset_impl import GDALRasterDataImpl
 from wiser.raster.utils import (
     copy_metadata_to_gdal_dataset,
+    numpy_dtype_to_gdal_export_types,
     set_data_ignore_of_gdal_dataset,
 )
 
@@ -2033,7 +2034,7 @@ class GeoReferencerDialog(QDialog):
             output_size: Tuple[int, int] = None
             output_dataset: gdal.Dataset = None
             driver: gdal.Driver = gdal.GetDriverByName("GTiff")
-            gdal_dtype = gdal_array.NumericTypeCodeToGDALTypeCode(target_dataset.get_elem_type())
+            gdal_dtype, _ = numpy_dtype_to_gdal_export_types(target_dataset.get_elem_type())
 
             # Get the output size
             warp_options = gdal.WarpOptions(**self._warp_kwargs)

--- a/src/wiser/gui/similarity_transform_dialog.py
+++ b/src/wiser/gui/similarity_transform_dialog.py
@@ -21,12 +21,12 @@ from .util import (
     make_into_help_button,
 )
 
-from osgeo import gdal, gdal_array
+from osgeo import gdal
 
 from wiser.bandmath.builtins.constants import MAX_RAM_BYTES
 from wiser.bandmath.utils import write_raster_to_dataset
 
-from wiser.raster.utils import copy_metadata_to_gdal_dataset
+from wiser.raster.utils import copy_metadata_to_gdal_dataset, numpy_dtype_to_gdal_export_types
 
 import numpy as np
 
@@ -502,9 +502,7 @@ class SimilarityTransformDialog(QDialog):
             pixmap_width = pixmap.width()
             num_bands = self._rotate_scale_dataset.num_bands()
             np_dtype = self._rotate_scale_dataset.get_elem_type()  # Returns a numpy dtype
-            gdal_data_type = gdal_array.NumericTypeCodeToGDALTypeCode(
-                np_dtype
-            )  # Convert numpy dtype to GDAL type
+            gdal_data_type, _ = numpy_dtype_to_gdal_export_types(np_dtype)
 
             output_bytes = pixmap_width * pixmap_height * num_bands * np_dtype.itemsize
 
@@ -648,9 +646,7 @@ class SimilarityTransformDialog(QDialog):
                 width = self._translation_dataset.get_width()
                 num_bands = self._translation_dataset.num_bands()
                 np_dtype = self._translation_dataset.get_elem_type()  # Returns a numpy dtype
-                gdal_data_type = gdal_array.NumericTypeCodeToGDALTypeCode(
-                    np_dtype
-                )  # Convert numpy dtype to GDAL type
+                gdal_data_type, _ = numpy_dtype_to_gdal_export_types(np_dtype)
 
                 output_bytes = width * height * num_bands * np_dtype.itemsize
                 ratio = MAX_RAM_BYTES / output_bytes

--- a/src/wiser/raster/dataset.py
+++ b/src/wiser/raster/dataset.py
@@ -1731,6 +1731,8 @@ class RasterDataSet(Serializable):
         """
         if self._data_ignore_value is not None:
             return hash((self._id, self._data_ignore_value))
+        if self._id is None:
+            raise ValueError("Dataset ID must be set in order to hash!")
         return self._id
 
     def __eq__(self, other) -> bool:

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -14,9 +14,7 @@ from contextlib import contextmanager
 
 from .utils import (
     make_spectral_value,
-    convert_spectral,
     get_spectral_unit,
-    get_netCDF_reflectance_path,
     numpy_dtype_to_gdal_export_types,
 )
 from .loaders import envi

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -17,6 +17,7 @@ from .utils import (
     convert_spectral,
     get_spectral_unit,
     get_netCDF_reflectance_path,
+    numpy_dtype_to_gdal_export_types,
 )
 from .loaders import envi
 
@@ -1929,7 +1930,7 @@ class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
             )
 
         elem_type = src_dataset.get_elem_type()
-        gdal_elem_type = gdal_array.NumericTypeCodeToGDALTypeCode(elem_type)
+        gdal_elem_type, band_write_dtype = numpy_dtype_to_gdal_export_types(elem_type)
 
         # logger.debug('Destination raster image values:\n' +
         #     f'width={dst_width}, height={dst_height}\n' +
@@ -2020,6 +2021,8 @@ class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
             ]
             # print(f"Destination-array size: {dst_data.size}")
             # print(f'Destination-array shape:  {dst_data.shape}')
+            if dst_data.dtype != band_write_dtype:
+                dst_data = np.asarray(dst_data, dtype=band_write_dtype)
             dst_band.WriteArray(dst_data, 0, 0)
             chunk_size += dst_data.size
             if chunk_size >= CHUNK_WRITE_SIZE:

--- a/src/wiser/raster/utils.py
+++ b/src/wiser/raster/utils.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional, Union, TYPE_CHECKING, Any, Tuple
 
-from osgeo import gdal, osr
+from osgeo import gdal, gdal_array, osr
 
 from sklearn.decomposition import PCA
 import numpy as np
@@ -24,6 +24,26 @@ ARRAY_NUMBA_THRESHOLD = 150000000  # 150 MB
 
 # For easier typing in this module
 Number = Union[int, float]
+
+
+def numpy_dtype_to_gdal_export_types(elem_type: Union[np.dtype, type]) -> Tuple[int, np.dtype]:
+    """
+    Map an in-memory per-pixel dtype to a GDAL raster band type and a NumPy dtype
+    for ``WriteArray`` / ``WriteRaster``.
+
+    GDAL has no native boolean band type. Boolean cubes (for example SAM or SFF
+    classification masks) are exported as ``GDT_Byte`` with values 0/1, so callers
+    should cast band arrays to the returned NumPy dtype when it differs from the
+    source element type.
+    """
+    et = np.dtype(elem_type)
+    if np.issubdtype(et, np.bool_) or et == np.dtype(bool):
+        return gdal.GDT_Byte, np.dtype(np.uint8)
+
+    gdal_elem_type = gdal_array.NumericTypeCodeToGDALTypeCode(et)
+    if gdal_elem_type is None:
+        raise TypeError(f"Unsupported NumPy dtype for GDAL export: {et}")
+    return gdal_elem_type, et
 
 
 # ============================================================================


### PR DESCRIPTION
## What does this change do?
This PR allows users to save a classification dataset. There was a mismatch between numpy boolean type and the corresponding gdal type. This fixes that mismatch. A regression test is added. Closes #492 Closes #330 .

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
So we can save classification arrays.

## Added tests?
- [X] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->