### PR TITLE
feat: Added ability to save single collected spectrum

### DIFF
--- a/src/wiser/gui/spectrum_plot.py
+++ b/src/wiser/gui/spectrum_plot.py
@@ -1226,6 +1226,9 @@ class SpectrumPlotGeneric(QWidget):
                 act = menu.addAction(self.tr("Edit..."))
                 act.triggered.connect(lambda *args, treeitem=treeitem: self._on_edit_spectrum(treeitem))
 
+            act = menu.addAction(self.tr("Save to file..."))
+            act.triggered.connect(lambda *args, treeitem=treeitem: self._on_save_single_spectrum(treeitem))
+
             if spectrum.is_discardable():
                 menu.addSeparator()
 
@@ -1345,6 +1348,23 @@ class SpectrumPlotGeneric(QWidget):
                 spectra.append(treeitem.data(0, Qt.UserRole))
 
             export_spectrum_list(selected[0], spectra)
+
+    def _on_save_single_spectrum(self, treeitem):
+        spectrum = treeitem.data(0, Qt.UserRole)
+        supported_formats = [
+            self.tr("Text files (*.txt)"),
+            self.tr("All files (*)"),
+        ]
+
+        selected = QFileDialog.getSaveFileName(
+            self,
+            self.tr("Save Spectrum"),
+            self._app_state.get_current_dir(),
+            ";;".join(supported_formats),
+        )
+
+        if len(selected[0]) > 0:
+            export_spectrum_list(selected[0], [spectrum])
 
     def _on_discard_spectrum(self, treeitem, display_confirm=True):
         spectrum = treeitem.data(0, Qt.UserRole)
@@ -1985,6 +2005,9 @@ class SpectrumPlot(SpectrumPlotGeneric):
             if spectrum.is_editable():
                 act = menu.addAction(self.tr("Edit..."))
                 act.triggered.connect(lambda *args, treeitem=treeitem: self._on_edit_spectrum(treeitem))
+
+            act = menu.addAction(self.tr("Save to file..."))
+            act.triggered.connect(lambda *args, treeitem=treeitem: self._on_save_single_spectrum(treeitem))
 
             # Add plugin menu items
             add_plugin_context_menu_items(


### PR DESCRIPTION
## What does this change do?
As the title says, this adds the ability to save a single spectrum that has been collected. Closes #490 

## What type of PR is this? (check all applicable) 
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
Makes it easier to save a spectrum.

## Added tests?
- [ ] yes
- [X] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->