### PR TITLE
feat: Adding single spectrum save to active spectrum

### DIFF
--- a/src/wiser/gui/spectrum_plot.py
+++ b/src/wiser/gui/spectrum_plot.py
@@ -1235,6 +1235,9 @@ class SpectrumPlotGeneric(QWidget):
             act = menu.addAction(self.tr("Edit..."))
             act.triggered.connect(lambda *args, treeitem=treeitem: self._on_edit_spectrum(treeitem))
 
+            act = menu.addAction(self.tr("Save to file..."))
+            act.triggered.connect(lambda *args, treeitem=treeitem: self._on_save_single_spectrum(treeitem))
+
             menu.addSeparator()
 
             act = menu.addAction(self.tr("Discard..."))
@@ -2002,6 +2005,9 @@ class SpectrumPlot(SpectrumPlotGeneric):
 
             act = menu.addAction(self.tr("Edit..."))
             act.triggered.connect(lambda *args, treeitem=treeitem: self._on_edit_spectrum(treeitem))
+
+            act = menu.addAction(self.tr("Save to file..."))
+            act.triggered.connect(lambda *args, treeitem=treeitem: self._on_save_single_spectrum(treeitem))
 
             # Add plugin menu items
             add_plugin_context_menu_items(


### PR DESCRIPTION
## What does this change do?
Add single spectrum save to active spectrum. A previous PR only did collected spectrum. Closes #490 

## What type of PR is this? (check all applicable) 
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
<!-- Context, problem solved, issue/ticket link -->

## How did you implement the change?
<!-- High-level approach -->

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->