### PR TITLE
fix: Build Sphinx docs can now write to pull-requests

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What does this change do?
Change fixes an issue I was getting [here](https://github.com/Ehlmann-research-group/WISER/actions/runs/26133871564/job/76864645913?pr=506) due to not having pull_request write [(says here)](https://github.com/Ehlmann-research-group/WISER/actions/runs/26133871564/job/76864645913?pr=506#step:7:73).

Closes #530

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
PR autodocs are failing

## Added tests?
- [ ] yes
- [X] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [X] There is an issue associated with this pull request
- [X] Code compiles/builds without errors
- [X] No new lint/style issues introduced
- [X] Branch is up-to-date with main/master
- [X] All CI checks passed
