### PR TITLE
refac: Making calc_rect_spec actually get a rect and not multiple points in rect

### DIFF
--- a/src/tests/test_avg_spectrum.py
+++ b/src/tests/test_avg_spectrum.py
@@ -1,19 +1,28 @@
-"""Unit tests for ROI average spectrum calculations and ROI raster transformations.
+"""Unit tests for average spectrum calculations (ROI and point-centered) and
+ROI raster transformations.
 
 This module verifies:
 - The correctness of region-based spectrum calculations in the WISER GUI.
+- The correctness of point-centered rectangular-window spectrum averaging
+  (``SpectrumAtPoint`` with an expanded area).
 - The behavior of raster-to-rectangle compression algorithms.
 - The accuracy of raster masks created from compound ROIs.
 
-Tests include GUI-based and non-GUI validation for datasets represented as NumPy arrays.
+Tests include GUI-based and non-GUI validation for datasets represented as
+NumPy arrays and ENVI files on disk.
 """
 import unittest
+from pathlib import Path
 
 import numpy as np
+
+import tests.context  # noqa: F401 – adds src/ to sys.path
 
 from wiser.raster.spectrum import (
     raster_to_combined_rectangles_x_axis,
     create_raster_from_roi,
+    SpectrumAtPoint,
+    SpectrumAverageMode,
 )
 from wiser.raster.roi import RegionOfInterest
 from wiser.raster.selection import (
@@ -42,6 +51,11 @@ pytestmark = [
     pytest.mark.functional,
     pytest.mark.smoke,
 ]
+
+
+_DATASETS = Path(__file__).resolve().parent / ".." / "test_utils" / "test_datasets"
+_JPL_HDR = (_DATASETS / "jpl_425_7_7.hdr").resolve()
+_CALTECH_BB_HDR = (_DATASETS / "caltech_15_20_20_data_ignore_bb.hdr").resolve()
 
 
 class TestRoiAvgSpectrum(unittest.TestCase):
@@ -345,3 +359,67 @@ class TestRoiAvgSpectrum(unittest.TestCase):
             ]
         )
         np.testing.assert_equal(raster, ground_truth)
+
+
+class TestPointSpecAvg(unittest.TestCase):
+    """
+    Validates ``SpectrumAtPoint`` area-averaging against ground truth computed
+    directly from the dataset's image cube. Covers both the clean case (no bad
+    bands, no data-ignore pixels) and the case where bad bands and
+    data-ignore-value pixels must be excluded from the mean.
+    """
+
+    def test_full_coverage_odd_dims_jpl(self):
+        """7x7 dataset, 7x7 window centered at (3, 3) — the window covers the
+        entire raster, so the result must equal the per-band mean over all 49
+        pixels."""
+        dataset = RasterDataLoader().load_from_file(str(_JPL_HDR))[0]
+
+        # No bad bands, no data ignore value → plain mean over (b, y, x).
+        image = np.asarray(dataset.get_image_data(filter_data_ignore_value=False))
+        assert image.shape == (425, 7, 7)
+        expected = image.mean(axis=(1, 2))
+
+        spec = SpectrumAtPoint(dataset, point=(3, 3), area=(7, 7), avg_mode=SpectrumAverageMode.MEAN)
+        spec._calculate_spectrum()
+        actual = spec._spectrum
+
+        assert actual.shape == (425,)
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+
+    def test_max_odd_window_even_dims_caltech_with_bb_and_nodata(self):
+        """20x20 dataset has even sides, so the largest odd window that fits is
+        19x19. Centered at (9, 9) the window covers pixels (0..18, 0..18). Bands
+        8 and 9 are bad (NaN) and the rows 0-3 cols 0-2 block holds the
+        data-ignore value (-9999) — both must be excluded from the mean."""
+        dataset = RasterDataLoader().load_from_file(str(_CALTECH_BB_HDR))[0]
+
+        bad_bands = np.array(dataset.get_bad_bands(), dtype=np.int8)
+        ignore_val = dataset.get_data_ignore_value()
+        assert bad_bands.tolist() == [1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1]
+        assert ignore_val == -9999
+
+        # Build ground truth: float copy with -9999 → NaN and bad bands → NaN,
+        # then nanmean over the 19x19 window starting at (0, 0).
+        image = np.asarray(dataset.get_image_data(filter_data_ignore_value=False), dtype=np.float64)
+        assert image.shape == (15, 20, 20)
+        image[image == ignore_val] = np.nan
+        image[bad_bands == 0, :, :] = np.nan
+        window = image[:, 0:19, 0:19]
+        # Bands 8 and 9 are entirely NaN → nanmean of an all-NaN slice warns and
+        # returns NaN; suppress just the expected warning.
+        with np.errstate(invalid="ignore"):
+            expected = np.nanmean(window, axis=(1, 2))
+
+        spec = SpectrumAtPoint(dataset, point=(9, 9), area=(19, 19), avg_mode=SpectrumAverageMode.MEAN)
+        spec._calculate_spectrum()
+        actual = spec._spectrum
+
+        assert actual.shape == (15,)
+        # Bands 8 and 9 are NaN in both actual and expected; equal_nan handles that.
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6, equal_nan=True)
+        assert np.isnan(actual[8]) and np.isnan(actual[9])
+        # And the good bands really do reflect a partial (non-NaN) average,
+        # i.e. they survived the data-ignore pixels.
+        good_idx = np.where(bad_bands == 1)[0]
+        assert np.all(np.isfinite(actual[good_idx]))

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -210,49 +210,26 @@ def calc_spectrum_fast(dataset: RasterDataSet, roi: RegionOfInterest, mode=Spect
 def calc_rect_spectrum(dataset: RasterDataSet, rect: QRect, mode=SpectrumAverageMode.MEAN):
     """
     Calculate a spectrum over a rectangular area of the specified dataset.
-    The calculation mode can be specified with the mode argument.
+    Reads the whole rectangle in one block, then averages across pixels.
 
     The rect argument is expected to be a QRect object.
     """
-    points = [(rect.left() + dx, rect.top() + dy) for dx, dy in np.ndindex(rect.width(), rect.height())]
+    try:
+        block = dataset.get_all_bands_at_rect(rect.left(), rect.top(), rect.width(), rect.height())
+    except BaseException:
+        return np.full((dataset.num_bands(),), np.nan)
 
-    return calc_spectrum(dataset, points, mode)
+    # block is (bands, H, W) for normal datasets; reshape collapses the spatial
+    # dims so we can aggregate per band in a single call. -1 also handles the
+    # case where an underlying impl returns (bands, N) for a 1-thick rectangle.
+    spectra = block.reshape(block.shape[0], -1)
 
-
-def calc_spectrum(dataset: RasterDataSet, points: List[QPoint], mode=SpectrumAverageMode.MEAN):
-    """
-    Calculate a spectrum over a collection of points from the specified dataset.
-    The calculation mode can be specified with the mode argument.
-
-    The points argument can be any iterable that produces coordinates for this
-    function to use.
-    """
-
-    n = 0
-    spectra = []
-
-    # Collect the spectra that we need for the calculation
-    for p in points:
-        n += 1
-        s = dataset.get_all_bands_at(p[0], p[1])
-        spectra.append(s)
-
-    if len(spectra) > 1:
-        # Need to compute mean/median/... of the collection of spectra
-        if mode == SpectrumAverageMode.MEAN:
-            spectrum = np.mean(spectra, axis=0)
-
-        elif mode == SpectrumAverageMode.MEDIAN:
-            spectrum = np.median(spectra, axis=0)
-
-        else:
-            raise ValueError(f"Unrecognized average type {mode}")
-
+    if mode == SpectrumAverageMode.MEAN:
+        return np.nanmean(spectra, axis=1)
+    elif mode == SpectrumAverageMode.MEDIAN:
+        return np.nanmedian(spectra, axis=1)
     else:
-        # Only one spectrum, don't need to compute mean/median
-        spectrum = spectra[0]
-
-    return spectrum
+        raise ValueError(f"Unrecognized average type {mode}")
 
 
 def get_all_spectra_in_roi(


### PR DESCRIPTION
## What does this change do?
As the title says, calc_rect_spec would get all the individual points in the rect and get all the spectra at those points. But going back and forth between python and GDALs C++ backing was causing a big delay. This only does one call which is good. 

Closes #536

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [X] Performance Improvements
- [X] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
We want better performance here.

## How did you implement the change?
Using get_all_bands_at_rect instead of mlutiple get_all_bands_at_point

## Added tests?
- [X] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed
