### PR TITLE
feat: Move PCA to data analysis section

### DIFF
--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -470,7 +470,6 @@ class DataVisualizerApp(QMainWindow):
         # cool plugins are made)
         permanent_plugins = [
             ("ContinuumRemovalPlugin", ContinuumRemovalPlugin()),
-            ("PCAPlugin", PCAPlugin()),
             ("SavGolayPlugin", SavGolayPlugin()),
         ]
         for pc_name, plugin_class in permanent_plugins:

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -398,6 +398,9 @@ class DataVisualizerApp(QMainWindow):
         act = submenu.addAction(self.tr("Mixture Tuned Matched Filter"))
         act.triggered.connect(self.show_mtmf_dialog)
 
+        act = submenu.addAction(self.tr("Principal Component Analysis"))
+        act.triggered.connect(self.show_pca_dialog)
+
         act = submenu.addAction(self.tr("Linear Unmixing"))
         act.triggered.connect(self.show_linear_unmixing_dialog)
 
@@ -1026,6 +1029,20 @@ class DataVisualizerApp(QMainWindow):
         self._mtmf_dialog.show()
         self._mtmf_dialog.raise_()
         self._mtmf_dialog.activateWindow()
+
+    def show_pca_dialog(self):
+        rasterview = self._main_view.get_rasterview()
+        dataset = rasterview.get_raster_data() if rasterview is not None else None
+        if dataset is None:
+            return
+        self._pca_plugin = PCAPlugin()
+        self._pca_plugin.show_pca(
+            context={
+                "dataset": dataset,
+                "wiser": self._app_state,
+                "app_services": self._app_services,
+            }
+        )
 
     def show_kmeans_dialog(self):
         self._kmeans_dialog = KMeansDialog(self._app_state, self._app_services, parent=self)

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -16,6 +16,7 @@ from .kmeans import KMeansDialog
 from .linear_unmixing import LinearUnmixingDialog
 from .mnf import MinimumNoiseFractionDialog
 from .mtmf import MTMFDialog
+from .permanent_plugins.pca_plugin import PCAPlugin
 from .plugin_utils import add_plugin_context_menu_items
 from .rasterpane import RasterPane
 from .rasterview import RasterView
@@ -217,6 +218,9 @@ class MainViewWidget(RasterPane):
 
         act = submenu.addAction(self.tr("Mixture Tuned Matched Filter"))
         act.triggered.connect(lambda checked=False, rv=rasterview, **kwargs: self._open_mtmf_dialog(rv))
+
+        act = submenu.addAction(self.tr("Principal Component Analysis"))
+        act.triggered.connect(lambda checked=False, rv=rasterview, **kwargs: self._open_pca_dialog(rv))
 
         act = submenu.addAction(self.tr("Linear Unmixing"))
         act.triggered.connect(
@@ -458,6 +462,19 @@ class MainViewWidget(RasterPane):
         self._mtmf_dialog.show()
         self._mtmf_dialog.raise_()
         self._mtmf_dialog.activateWindow()
+
+    def _open_pca_dialog(self, rasterview):
+        dataset = rasterview.get_raster_data()
+        if dataset is None:
+            return
+        self._pca_plugin = PCAPlugin()
+        self._pca_plugin.show_pca(
+            context={
+                "dataset": dataset,
+                "wiser": self._app_state,
+                "app_services": self._app_services,
+            }
+        )
 
     def _open_linear_unmixing_dialog(self, rasterview):
         dataset = rasterview.get_raster_data()


### PR DESCRIPTION
## What does this change do?
As the title says, we just move PCA to the data analysis section of the Tools Menu and the Main View context menu. We remove PCA from the main view context menu where it was added as a plugin.

Closes #519

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [x] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
PCA not being in data analysis didn't make sense,

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed
