### PR TITLE
feat: Adding scree plot to WISER for PCA and MNF

### DIFF
--- a/src/tests/test_pca_task.py
+++ b/src/tests/test_pca_task.py
@@ -9,7 +9,12 @@ import numpy as np
 from test_utils.memory_cleanup import release_kept_refs
 from test_utils.test_model import WiserTestModel
 
-from wiser.gui.permanent_plugins.pca_plugin import ESTIMATOR_TYPES, PCAPlugin, PCAPluginTask
+from wiser.gui.permanent_plugins.pca_plugin import (
+    ESTIMATOR_TYPES,
+    PCAPlugin,
+    PCAPluginTask,
+    compute_max_pca_components,
+)
 from wiser.raster.utils import compute_PCA_on_image
 from wiser.utils.primitives import DeletePolicy, PriorityClass
 from wiser.utils.storage_client import StorageClient
@@ -152,6 +157,7 @@ class TestPcaTask(unittest.TestCase):
                 source_dataset=dataset,
                 input_ref=dataset_ref,
                 num_components=3,
+                max_components_available=compute_max_pca_components(dataset),
             )
 
             task_plan = app_services.task_planner.plan_semantic_task(task)

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -1017,9 +1017,11 @@ class DataVisualizerApp(QMainWindow):
 
     def show_mnf_dialog(self):
         dlg = MinimumNoiseFractionDialog(self._app_state, self._app_services, parent=self)
+        dlg.setAttribute(Qt.WA_DeleteOnClose, True)
         dlg.select_dataset(None)
-        if dlg.exec_() == QDialog.Accepted:
-            pass
+        dlg.show()
+        dlg.raise_()
+        dlg.activateWindow()
 
     def show_mtmf_dialog(self):
         self._mtmf_dialog = MTMFDialog(self._app_state, self._app_services, parent=self)

--- a/src/wiser/gui/app_state.py
+++ b/src/wiser/gui/app_state.py
@@ -46,6 +46,8 @@ if TYPE_CHECKING:
     from wiser.gui.reference_creator_dialog import CrsCreatorState
     from wiser.gui.kmeans import KMeansParameters, KMeansCentroids
     from wiser.gui.linear_unmixing import LinearUnmixingHistoryManager
+    from wiser.gui.permanent_plugins.pca_plugin import PCAHistoryManager
+    from wiser.gui.mnf import MNFHistoryManager
 
 
 def make_unique_name(candidate: str, used_names: str) -> str:
@@ -198,9 +200,27 @@ class ApplicationState(QObject):
 
         self._linear_unmix_history = LinearUnmixingHistoryManager(self)
 
+        # PCA and MNF histories follow the same pattern — application state
+        # so the past-runs viewer survives across dialog open/close cycles.
+        # Local imports for the same reason as above (the modules they live in
+        # transitively import from this one).
+        from wiser.gui.permanent_plugins.pca_plugin import PCAHistoryManager
+        from wiser.gui.mnf import MNFHistoryManager
+
+        self._pca_history = PCAHistoryManager(self)
+        self._mnf_history = MNFHistoryManager(self)
+
     def get_linear_unmix_history(self) -> "LinearUnmixingHistoryManager":
         """Return the application-wide linear-unmixing run history manager."""
         return self._linear_unmix_history
+
+    def get_pca_history(self) -> "PCAHistoryManager":
+        """Return the application-wide PCA run history manager."""
+        return self._pca_history
+
+    def get_mnf_history(self) -> "MNFHistoryManager":
+        """Return the application-wide MNF run history manager."""
+        return self._mnf_history
 
     def add_running_process(self, process_manager: ProcessManager):
         process_manager_id = process_manager.get_process_manager_id()

--- a/src/wiser/gui/eigen_run_history.py
+++ b/src/wiser/gui/eigen_run_history.py
@@ -1,0 +1,81 @@
+"""Shared base class for PCA/MNF (and future eigen-decomposition) run history.
+
+PCA and MNF each have their own concrete record type so the two histories are
+never accidentally conflated, but the manager logic — store records, emit
+``records_changed`` on add/remove/dataset_removed, expose liveness/status of
+the input dataset — is identical between them.  This module factors that
+shared logic into :class:`EigenRunHistoryManagerBase` so the per-task-type
+managers (see :mod:`wiser.gui.pca_history` and :mod:`wiser.gui.mnf_history`)
+are tiny shells declaring their record type.
+"""
+
+from __future__ import annotations
+
+from typing import Generic, List, Protocol, TYPE_CHECKING, TypeVar
+
+from PySide2.QtCore import QObject, Signal
+
+if TYPE_CHECKING:
+    from wiser.gui.app_state import ApplicationState
+
+
+class _HasRunIdAndInputDataset(Protocol):
+    """The minimal shape a record must have for the base manager to use it."""
+
+    run_id: int
+    input_dataset_id: int
+
+
+R = TypeVar("R", bound=_HasRunIdAndInputDataset)
+
+
+class EigenRunHistoryManagerBase(QObject, Generic[R]):
+    """Generic in-memory list of completed eigen-decomposition runs.
+
+    Subclass and bind ``R`` to your concrete record type.  The subclass
+    typically doesn't need to override anything — just inherit and
+    instantiate.
+    """
+
+    records_changed = Signal()
+
+    def __init__(self, app_state: "ApplicationState") -> None:
+        super().__init__()
+        self._app_state = app_state
+        self._records: List[R] = []
+        # Any dataset removal could flip liveness for any record; we just
+        # re-emit unconditionally and let the view re-render.  Re-rendering
+        # N rows is cheap for typical N.
+        app_state.dataset_removed.connect(self._on_dataset_removed)
+
+    # ----- mutation -----
+
+    def add_record(self, record: R) -> None:
+        self._records.append(record)
+        self.records_changed.emit()
+
+    def remove_record(self, run_id: int) -> None:
+        before = len(self._records)
+        self._records = [r for r in self._records if r.run_id != run_id]
+        if len(self._records) != before:
+            self.records_changed.emit()
+
+    # ----- read -----
+
+    def get_records(self) -> List[R]:
+        return list(self._records)
+
+    def is_input_alive(self, record: R) -> bool:
+        try:
+            self._app_state.get_dataset(record.input_dataset_id)
+            return True
+        except KeyError:
+            return False
+
+    def get_status_text(self, record: R) -> str:
+        return "Available" if self.is_input_alive(record) else "Input dataset closed"
+
+    # ----- signal slots -----
+
+    def _on_dataset_removed(self, _removed_id: int) -> None:
+        self.records_changed.emit()

--- a/src/wiser/gui/linear_unmixing.py
+++ b/src/wiser/gui/linear_unmixing.py
@@ -24,6 +24,7 @@ from wiser.gui.app_services import AppServices
 from wiser.gui.app_state import ApplicationState
 from wiser.gui.generated.linear_unmixing_dialog_ui import Ui_LinearUnmixingDialog
 from wiser.gui.import_spectra_text import ImportSpectraTextDialog
+from wiser.gui.run_history import RunHistoryManagerBase
 from wiser.gui.util import StateChange
 from wiser.gui.util import GenericMultiSelectDialog, build_trash_button
 from wiser.raster.dataset import RasterDataSet
@@ -870,52 +871,17 @@ class LinearUnmixingRunRecord:
     sum_to_unity_weight: float
 
 
-class LinearUnmixingHistoryManager(QObject):
+class LinearUnmixingHistoryManager(RunHistoryManagerBase[LinearUnmixingRunRecord]):
     """Owns the in-memory list of completed linear-unmixing runs.
 
     Lives on :class:`~wiser.gui.app_state.ApplicationState` so the history
     persists across closing and reopening the linear-unmixing dialog.
 
-    Subscribes to ``ApplicationState.dataset_removed`` and re-emits
-    ``records_changed`` so any open history dialog re-renders with updated
-    liveness state — records are never silently dropped on dataset removal,
-    they just move into the "closed runs" section.
+    Extends the shared base with output-dataset liveness — unlike PCA/MNF, a
+    linear-unmix run produces a separate output dataset (the abundance cube)
+    whose presence the past-runs viewer also cares about (the View button
+    surfaces the input + output datasets in the main view).
     """
-
-    records_changed = Signal()
-
-    def __init__(self, app_state: ApplicationState) -> None:
-        super().__init__()
-        self._app_state = app_state
-        self._records: List[LinearUnmixingRunRecord] = []
-        # Any dataset removal could change the liveness label of any record,
-        # so just re-emit unconditionally.  Re-rendering N rows for typical
-        # N < 100 is cheap.
-        app_state.dataset_removed.connect(self._on_dataset_removed)
-
-    # ----- mutation -----
-
-    def add_record(self, record: LinearUnmixingRunRecord) -> None:
-        self._records.append(record)
-        self.records_changed.emit()
-
-    def remove_record(self, run_id: int) -> None:
-        before = len(self._records)
-        self._records = [r for r in self._records if r.run_id != run_id]
-        if len(self._records) != before:
-            self.records_changed.emit()
-
-    # ----- read -----
-
-    def get_records(self) -> List[LinearUnmixingRunRecord]:
-        return list(self._records)
-
-    def is_input_alive(self, record: LinearUnmixingRunRecord) -> bool:
-        try:
-            self._app_state.get_dataset(record.input_dataset_id)
-            return True
-        except KeyError:
-            return False
 
     def is_output_alive(self, record: LinearUnmixingRunRecord) -> bool:
         try:
@@ -937,11 +903,6 @@ class LinearUnmixingHistoryManager(QObject):
         if not input_alive:
             return "Input dataset closed"
         return "Output dataset closed"
-
-    # ----- signal slots -----
-
-    def _on_dataset_removed(self, _removed_id: int) -> None:
-        self.records_changed.emit()
 
 
 # ---------------------------------------------------------------------------

--- a/src/wiser/gui/main_view.py
+++ b/src/wiser/gui/main_view.py
@@ -437,9 +437,11 @@ class MainViewWidget(RasterPane):
         dataset_id = None if dataset is None else dataset.get_id()
         app_services = self._app_services
         dlg = MinimumNoiseFractionDialog(self._app_state, app_services, parent=self)
+        dlg.setAttribute(Qt.WA_DeleteOnClose, True)
         dlg.select_dataset(dataset_id)
-        if dlg.exec_() == QDialog.Accepted:
-            pass
+        dlg.show()
+        dlg.raise_()
+        dlg.activateWindow()
 
     def _open_kmeans_dialog(self, rasterview):
         dataset = rasterview.get_raster_data()

--- a/src/wiser/gui/mnf.py
+++ b/src/wiser/gui/mnf.py
@@ -545,9 +545,55 @@ class MinimumNoiseFractionDialog(QDialog):
         self._ui = Ui_MNFDialog()
         self._ui.setupUi(self)
 
+        # Keep the component-count spin box in sync with whichever dataset is
+        # picked: max changes per dataset (depends on its dimensions), and we
+        # default to the max so the user can see the ceiling at a glance.
+        self._ui.comboBox.currentIndexChanged.connect(self._refresh_component_limits)
+
+    @staticmethod
+    def _compute_max_components(dataset) -> int:
+        """Maximum components the MNF pipeline will accept for this dataset.
+
+        Matches the ceiling enforced inside ``get_mnf_pipeline``: the pipeline
+        only accepts ``num_components in [1, num_features]`` where
+        ``num_features`` is the count of *good* bands (see mnf.py:242-250).
+        Also bounded by the shift-difference noise pixel count so a small
+        image can't request more components than there are noise samples.
+        """
+        bad_bands = dataset.get_bad_bands()
+        if bad_bands is not None:
+            num_features = int(np.sum(bad_bands))
+        else:
+            num_features = dataset.num_bands()
+        height = dataset.get_height()
+        width = dataset.get_width()
+        data_pixels = height * width
+        noise_pixels = max(0, height - 1) * width
+        return min(num_features, max(0, data_pixels - 1), max(0, noise_pixels - 1))
+
+    def _refresh_component_limits(self) -> None:
+        """Set spin-box min/max/value based on the currently selected dataset."""
+        sbox = self._ui.sbox_component
+        sbox.setMinimum(1)
+        dataset = self.get_selected_dataset()
+        if dataset is None:
+            # No dataset chosen yet; leave a generous ceiling and a sane floor
+            # so the spin box is interactable but won't accept an invalid value
+            # (perform_mnf will recompute the true cap on submit).
+            sbox.setMaximum(10_000)
+            sbox.setValue(1)
+            return
+        max_components = max(1, self._compute_max_components(dataset))
+        sbox.setMaximum(max_components)
+        sbox.setValue(max_components)
+
     def show_mnf(self, dataset_id: Optional[int] = None) -> None:
         cbox_dataset = self._ui.comboBox
         datasets = self._app_state.get_datasets()
+        # Block signals while repopulating so currentIndexChanged doesn't fire
+        # for every intermediate addItem — we call _refresh_component_limits
+        # once at the end.
+        cbox_dataset.blockSignals(True)
         cbox_dataset.clear()
         cbox_dataset.addItem(self.tr("(no data)"), -1)
         for dataset in datasets:
@@ -561,11 +607,9 @@ class MinimumNoiseFractionDialog(QDialog):
                 cbox_dataset.setCurrentIndex(0)
         else:
             cbox_dataset.setCurrentIndex(0)
+        cbox_dataset.blockSignals(False)
 
-        self._ui.sbox_component.setMinimum(1)
-        self._ui.sbox_component.setMaximum(10_000)
-        if self._ui.sbox_component.value() < 1:
-            self._ui.sbox_component.setValue(1)
+        self._refresh_component_limits()
 
     def showEvent(self, event):
         self.show_mnf(dataset_id=self._selected_dataset_id)
@@ -600,12 +644,10 @@ class MinimumNoiseFractionDialog(QDialog):
         dataset_ref = self._app_services.storage_service.register_external(
             ExternalRasterHandle(dataset_obj=selected_dataset)
         )
-        storage_client = get_process_storage_client()
-        data_meta = storage_client.get_meta(dataset_ref)
-        height, width, bands = data_meta.shape
-        data_pixels = height * width
-        noise_pixels = max(0, height - 1) * width
-        max_components = min(bands, max(0, data_pixels - 1), max(0, noise_pixels - 1))
+        # Cap to the pipeline's accepted range (good-band count + noise-pixel
+        # ceiling) using the same helper that drives the spin box, so the
+        # dialog's display and the submission agree.
+        max_components = self._compute_max_components(selected_dataset)
         num_components = min(self.get_num_components(), max_components)
         if num_components <= 0:
             raise ValueError("No valid MNF component count for selected dataset")

--- a/src/wiser/gui/mnf.py
+++ b/src/wiser/gui/mnf.py
@@ -484,7 +484,18 @@ def get_mnf_pipeline(
 
 
 class MNFSemanticTask(QObject, SemanticTask):
-    result_ready = Signal(object)
+    # (reduced_data, eigenvalues) — second arg is the full whitened-noise
+    # eigenvalue spectrum, snapshotted in completion_callback before the
+    # ref it lived in goes out of scope.
+    result_ready = Signal(object, object)
+    # Emitted from _load_result_into_wiser; payload is an MNFRunRecord.
+    run_recorded = Signal(object)
+
+    # Allocation name that EigenDecompositionStage registers for the whitened
+    # eigenvalues, derived from `whitened_eigen_ref_name="mnf_whitened_eigen"`
+    # in get_mnf_pipeline.  Kept as a class constant so the binding lookup
+    # below isn't a magic string.
+    _WHITENED_EIGEN_VALUES_REF_NAME = "mnf_whitened_eigen_values"
 
     def __init__(
         self,
@@ -492,6 +503,7 @@ class MNFSemanticTask(QObject, SemanticTask):
         source_dataset: "RasterDataSet",
         input_ref: DataRef,
         num_components: int,
+        max_components_available: int,
         output_ref_name: str = "mnf_data",
     ):
         QObject.__init__(self)
@@ -512,6 +524,8 @@ class MNFSemanticTask(QObject, SemanticTask):
         self._app_state = app_state
         self._source_dataset = source_dataset
         self._output_ref_name = output_ref_name
+        self._num_components_chosen = num_components
+        self._max_components_available = max_components_available
         self.result_ready.connect(self._load_result_into_wiser)
 
     def completion_callback(self, bindings: Dict[str, DataRef]) -> None:
@@ -524,10 +538,21 @@ class MNFSemanticTask(QObject, SemanticTask):
         height, width, bands = data_meta.shape
         output_region = DatasetRegionRef(y0=0, y1=height, x0=0, x1=width, b0=0, b1=bands)
         reduced_data, _ = storage_client.read_region(output_ref, output_region)
-        self.result_ready.emit(np.asarray(reduced_data))
 
-    @Slot(object)
-    def _load_result_into_wiser(self, reduced_data: object) -> None:
+        # Snapshot the full whitened-noise eigenvalue spectrum so the scree
+        # plot in the past-runs viewer survives after the underlying ref is
+        # released.  EigenDecompositionStage stores values descending, which
+        # is what the scree plot expects.
+        eigen_values_ref = bindings.get(self._WHITENED_EIGEN_VALUES_REF_NAME)
+        if eigen_values_ref is None:
+            raise KeyError(f"Missing MNF eigenvalues binding: {self._WHITENED_EIGEN_VALUES_REF_NAME}")
+        eigen_values_raw, _ = storage_client.read_data(eigen_values_ref)
+        eigenvalues = np.asarray(np.ma.getdata(eigen_values_raw), dtype=np.float64).ravel().copy()
+
+        self.result_ready.emit(np.asarray(reduced_data), eigenvalues)
+
+    @Slot(object, object)
+    def _load_result_into_wiser(self, reduced_data: object, eigenvalues: object) -> None:
         reduced_array = np.asarray(reduced_data)
         reduced_array_by_band = reduced_array.transpose(2, 0, 1)
 
@@ -542,6 +567,18 @@ class MNFSemanticTask(QObject, SemanticTask):
         reduced_dataset.copy_spatial_metadata(self._source_dataset.get_spatial_metadata())
         reduced_dataset.set_data_ignore_value(self._source_dataset.get_data_ignore_value())
         self._app_state.add_dataset(reduced_dataset, view_dataset=False)
+
+        self.run_recorded.emit(
+            MNFRunRecord(
+                run_id=self.id,
+                timestamp=datetime.datetime.now(),
+                input_dataset_id=self._source_dataset.get_id(),
+                input_dataset_name_snapshot=source_name,
+                num_components_chosen=self._num_components_chosen,
+                max_components_available=self._max_components_available,
+                eigenvalues=np.asarray(eigenvalues, dtype=np.float64),
+            )
+        )
 
 
 class MinimumNoiseFractionDialog(QDialog):
@@ -681,7 +718,11 @@ class MinimumNoiseFractionDialog(QDialog):
             source_dataset=selected_dataset,
             input_ref=dataset_ref,
             num_components=num_components,
+            max_components_available=max_components,
         )
+        # Record the run in the application-level history once the task
+        # finishes loading its result into the app (mirrors linear_unmixing.py:393).
+        mnf_task.run_recorded.connect(self._app_state.get_mnf_history().add_record)
 
         task_plan = self._app_services.task_planner.plan_semantic_task(mnf_task)
         future = self._app_services.task_manager.register_and_submit_task_plan(

--- a/src/wiser/gui/mnf.py
+++ b/src/wiser/gui/mnf.py
@@ -623,6 +623,21 @@ class MinimumNoiseFractionDialog(QDialog):
         self._past_runs_dialog: Optional[MNFHistoryDialog] = None
         self._ui.btn_past_results.clicked.connect(self._on_view_past_runs)
 
+        # Keep the dataset combo box in sync with the application's dataset
+        # list while this dialog is open.  Without this the combo would only
+        # refresh on showEvent — datasets added/removed while the dialog is
+        # already up (it's non-modal) would be invisible to the user.
+        app_state.dataset_added.connect(self._on_datasets_changed)
+        app_state.dataset_removed.connect(self._on_datasets_changed)
+
+    def _on_datasets_changed(self, *_args) -> None:
+        # Preserve the currently selected dataset if it still exists; the
+        # sentinel "(no data)" item uses currentData() == -1, so treat
+        # anything < 0 as "no selection".
+        current_id = self._ui.comboBox.currentData()
+        preserve_id = current_id if (current_id is not None and int(current_id) >= 0) else None
+        self.show_mnf(dataset_id=preserve_id)
+
     def _on_view_past_runs(self) -> None:
         if self._past_runs_dialog is None:
             self._past_runs_dialog = MNFHistoryDialog(

--- a/src/wiser/gui/mnf.py
+++ b/src/wiser/gui/mnf.py
@@ -11,7 +11,7 @@ from PySide2.QtWidgets import *
 
 from wiser.gui.app_services import AppServices
 from wiser.gui.app_state import ApplicationState
-from wiser.gui.run_history import RunHistoryManagerBase
+from wiser.gui.run_history import EigenScreeRunHistoryDialog, RunHistoryManagerBase
 from wiser.gui.generated.mnf_dialog_ui import Ui_MNFDialog
 from wiser.utils.primitives import (
     AllocationRequest,
@@ -68,6 +68,12 @@ class MNFRunRecord:
 
 class MNFHistoryManager(RunHistoryManagerBase[MNFRunRecord]):
     """Owns the in-memory list of completed MNF runs."""
+
+
+class MNFHistoryDialog(EigenScreeRunHistoryDialog[MNFRunRecord]):
+    """Non-modal viewer for past MNF runs.  See base class for behavior."""
+
+    task_label = "MNF"
 
 
 # region MNF

--- a/src/wiser/gui/mnf.py
+++ b/src/wiser/gui/mnf.py
@@ -605,6 +605,7 @@ class MinimumNoiseFractionDialog(QDialog):
         parent=None,
     ):
         super().__init__(parent=parent)
+        self.setModal(False)
         self._app_state = app_state
         self._app_services = app_services
         self._selected_dataset_id: Optional[int] = None

--- a/src/wiser/gui/mnf.py
+++ b/src/wiser/gui/mnf.py
@@ -11,7 +11,7 @@ from PySide2.QtWidgets import *
 
 from wiser.gui.app_services import AppServices
 from wiser.gui.app_state import ApplicationState
-from wiser.gui.eigen_run_history import EigenRunHistoryManagerBase
+from wiser.gui.run_history import RunHistoryManagerBase
 from wiser.gui.generated.mnf_dialog_ui import Ui_MNFDialog
 from wiser.utils.primitives import (
     AllocationRequest,
@@ -66,7 +66,7 @@ class MNFRunRecord:
     eigenvalues: np.ndarray
 
 
-class MNFHistoryManager(EigenRunHistoryManagerBase[MNFRunRecord]):
+class MNFHistoryManager(RunHistoryManagerBase[MNFRunRecord]):
     """Owns the in-memory list of completed MNF runs."""
 
 

--- a/src/wiser/gui/mnf.py
+++ b/src/wiser/gui/mnf.py
@@ -11,6 +11,7 @@ from PySide2.QtWidgets import *
 
 from wiser.gui.app_services import AppServices
 from wiser.gui.app_state import ApplicationState
+from wiser.gui.eigen_run_history import EigenRunHistoryManagerBase
 from wiser.gui.generated.mnf_dialog_ui import Ui_MNFDialog
 from wiser.utils.primitives import (
     AllocationRequest,
@@ -45,6 +46,29 @@ from wiser.utils.worker_runtime import get_process_storage_client
 
 if TYPE_CHECKING:
     from wiser.raster.dataset import RasterDataSet
+
+
+@dataclass(frozen=True)
+class MNFRunRecord:
+    """Immutable record of one completed MNF run.
+
+    ``eigenvalues`` is the full eigenvalue spectrum produced by the whitened
+    eigendecomposition (length equal to the number of good bands), regardless
+    of how many components the user asked the pipeline to project onto.
+    """
+
+    run_id: int
+    timestamp: datetime.datetime
+    input_dataset_id: int
+    input_dataset_name_snapshot: str
+    num_components_chosen: int
+    max_components_available: int
+    eigenvalues: np.ndarray
+
+
+class MNFHistoryManager(EigenRunHistoryManagerBase[MNFRunRecord]):
+    """Owns the in-memory list of completed MNF runs."""
+
 
 # region MNF
 

--- a/src/wiser/gui/mnf.py
+++ b/src/wiser/gui/mnf.py
@@ -617,6 +617,23 @@ class MinimumNoiseFractionDialog(QDialog):
         # default to the max so the user can see the ceiling at a glance.
         self._ui.comboBox.currentIndexChanged.connect(self._refresh_component_limits)
 
+        # Past-runs viewer is lazily created on first click and kept alive on
+        # this dialog so reopening it preserves scroll position / closed-runs
+        # toggle state.  The records themselves live on app_state.
+        self._past_runs_dialog: Optional[MNFHistoryDialog] = None
+        self._ui.btn_past_results.clicked.connect(self._on_view_past_runs)
+
+    def _on_view_past_runs(self) -> None:
+        if self._past_runs_dialog is None:
+            self._past_runs_dialog = MNFHistoryDialog(
+                app_state=self._app_state,
+                manager=self._app_state.get_mnf_history(),
+                parent=self,
+            )
+        self._past_runs_dialog.show()
+        self._past_runs_dialog.raise_()
+        self._past_runs_dialog.activateWindow()
+
     @staticmethod
     def _compute_max_components(dataset) -> int:
         """Maximum components the MNF pipeline will accept for this dataset.

--- a/src/wiser/gui/permanent_plugins/pca_plugin.py
+++ b/src/wiser/gui/permanent_plugins/pca_plugin.py
@@ -120,6 +120,7 @@ class PCAPlugin(plugins.ContextMenuPlugin):
 
         pca_dialog._ui.sbox_num_components.setMinimum(1)
         pca_dialog._ui.sbox_num_components.setMaximum(num_valid_bands)
+        pca_dialog._ui.sbox_num_components.setValue(num_valid_bands)
 
         for est in ESTIMATOR_TYPES:
             pca_dialog._ui.cbox_estimator.addItem(est.value, est)

--- a/src/wiser/gui/permanent_plugins/pca_plugin.py
+++ b/src/wiser/gui/permanent_plugins/pca_plugin.py
@@ -12,7 +12,7 @@ from PySide2.QtCore import QObject, Signal, Slot
 from PySide2.QtWidgets import QDialog
 
 from wiser import plugins
-from wiser.gui.eigen_run_history import EigenRunHistoryManagerBase
+from wiser.gui.run_history import RunHistoryManagerBase
 from wiser.gui.generated.pca_dialog_ui import Ui_PCA_Dialog
 from wiser.raster import RasterDataLoader, RasterDataSet
 from wiser.raster.utils import compute_PCA_on_image, create_pca_metadata_widget
@@ -49,7 +49,7 @@ class PCARunRecord:
     eigenvalues: np.ndarray
 
 
-class PCAHistoryManager(EigenRunHistoryManagerBase[PCARunRecord]):
+class PCAHistoryManager(RunHistoryManagerBase[PCARunRecord]):
     """Owns the in-memory list of completed PCA runs."""
 
 

--- a/src/wiser/gui/permanent_plugins/pca_plugin.py
+++ b/src/wiser/gui/permanent_plugins/pca_plugin.py
@@ -14,7 +14,7 @@ from sklearn.decomposition import PCA
 
 from wiser import plugins
 from wiser.gui.run_history import EigenScreeRunHistoryDialog, RunHistoryManagerBase
-from wiser.gui.scree_plot import build_scree_plot_figure
+from wiser.gui.scree_plot import attach_scree_click_inspector, build_scree_plot_figure
 from wiser.gui.generated.pca_dialog_ui import Ui_PCA_Dialog
 from wiser.raster import RasterDataLoader, RasterDataSet
 from wiser.raster.utils import compute_PCA_on_image, create_pca_metadata_widget
@@ -180,6 +180,10 @@ class PCAPluginTask(QObject, SemanticTask):
             window_title=scree_title,
             description=scree_description,
         )
+        # Must be attached AFTER show_matplotlib_display_widget — that call
+        # wraps the figure in a fresh Qt FigureCanvas, replacing any canvas
+        # that existed before and discarding earlier mpl_connect handlers.
+        attach_scree_click_inspector(figure, axes, eigenvalues)
 
         self.run_recorded.emit(
             PCARunRecord(

--- a/src/wiser/gui/permanent_plugins/pca_plugin.py
+++ b/src/wiser/gui/permanent_plugins/pca_plugin.py
@@ -1,6 +1,8 @@
 from __future__ import division
 
+import datetime
 from concurrent.futures import Future
+from dataclasses import dataclass
 import logging
 from enum import Enum
 from typing import Dict, TYPE_CHECKING, Optional
@@ -10,6 +12,7 @@ from PySide2.QtCore import QObject, Signal, Slot
 from PySide2.QtWidgets import QDialog
 
 from wiser import plugins
+from wiser.gui.eigen_run_history import EigenRunHistoryManagerBase
 from wiser.gui.generated.pca_dialog_ui import Ui_PCA_Dialog
 from wiser.raster import RasterDataLoader, RasterDataSet
 from wiser.raster.utils import compute_PCA_on_image, create_pca_metadata_widget
@@ -22,6 +25,32 @@ from wiser.utils.worker_runtime import get_process_storage_client
 if TYPE_CHECKING:
     from wiser.gui.app_services import AppServices
     from wiser.gui.app_state import ApplicationState
+
+
+@dataclass(frozen=True)
+class PCARunRecord:
+    """Immutable record of one completed PCA run.
+
+    Snapshots the eigenvalue array (sklearn's ``pca.explained_variance_``)
+    so the scree plot is still viewable after the input dataset is closed
+    or the sklearn ``PCA`` object is gone.
+
+    ``eigenvalues`` has length ``num_components_chosen`` — sklearn only
+    retains the top-N components it was asked for, so this is necessarily
+    a subset of the full spectrum.  That is acceptable for the scree plot.
+    """
+
+    run_id: int
+    timestamp: datetime.datetime
+    input_dataset_id: int
+    input_dataset_name_snapshot: str
+    num_components_chosen: int
+    max_components_available: int
+    eigenvalues: np.ndarray
+
+
+class PCAHistoryManager(EigenRunHistoryManagerBase[PCARunRecord]):
+    """Owns the in-memory list of completed PCA runs."""
 
 
 class ESTIMATOR_TYPES(Enum):

--- a/src/wiser/gui/permanent_plugins/pca_plugin.py
+++ b/src/wiser/gui/permanent_plugins/pca_plugin.py
@@ -13,7 +13,7 @@ from PySide2.QtWidgets import QDialog
 from sklearn.decomposition import PCA
 
 from wiser import plugins
-from wiser.gui.run_history import RunHistoryManagerBase
+from wiser.gui.run_history import EigenScreeRunHistoryDialog, RunHistoryManagerBase
 from wiser.gui.generated.pca_dialog_ui import Ui_PCA_Dialog
 from wiser.raster import RasterDataLoader, RasterDataSet
 from wiser.raster.utils import compute_PCA_on_image, create_pca_metadata_widget
@@ -52,6 +52,12 @@ class PCARunRecord:
 
 class PCAHistoryManager(RunHistoryManagerBase[PCARunRecord]):
     """Owns the in-memory list of completed PCA runs."""
+
+
+class PCAHistoryDialog(EigenScreeRunHistoryDialog[PCARunRecord]):
+    """Non-modal viewer for past PCA runs.  See base class for behavior."""
+
+    task_label = "PCA"
 
 
 def compute_max_pca_components(dataset: RasterDataSet) -> int:

--- a/src/wiser/gui/permanent_plugins/pca_plugin.py
+++ b/src/wiser/gui/permanent_plugins/pca_plugin.py
@@ -10,6 +10,7 @@ from typing import Dict, TYPE_CHECKING, Optional
 import numpy as np
 from PySide2.QtCore import QObject, Signal, Slot
 from PySide2.QtWidgets import QDialog
+from sklearn.decomposition import PCA
 
 from wiser import plugins
 from wiser.gui.run_history import RunHistoryManagerBase
@@ -53,12 +54,28 @@ class PCAHistoryManager(RunHistoryManagerBase[PCARunRecord]):
     """Owns the in-memory list of completed PCA runs."""
 
 
+def compute_max_pca_components(dataset: RasterDataSet) -> int:
+    """Maximum number of principal components meaningfully extractable.
+
+    PCA is fit on the *good* bands only (bad bands are dropped before the
+    covariance is built — see :func:`compute_PCA_on_image`), so the ceiling
+    is the count of good bands.  Used both to seed the dialog's spin-box
+    bounds/default and to populate ``max_components_available`` on the
+    :class:`PCARunRecord` written when a run completes.
+    """
+    return int(sum(dataset.get_bad_bands()))
+
+
 class ESTIMATOR_TYPES(Enum):
     COVARIANCE = "Covariance"
 
 
 class PCAPluginTask(QObject, SemanticTask):
     result_ready = Signal(object, object)
+    # Emitted from _load_result_into_wiser once the run record is built.
+    # Payload is a PCARunRecord; the plugin wires this to
+    # app_state.get_pca_history().add_record so the past-runs viewer sees it.
+    run_recorded = Signal(object)
 
     def __init__(
         self,
@@ -66,6 +83,7 @@ class PCAPluginTask(QObject, SemanticTask):
         source_dataset: RasterDataSet,
         input_ref: DataRef,
         num_components: int,
+        max_components_available: int,
         output_ref_name: str = "pca_image",
         pca_json_ref_name: str = "pca_model",
     ):
@@ -91,6 +109,10 @@ class PCAPluginTask(QObject, SemanticTask):
         self._source_dataset = source_dataset
         self._output_ref_name = output_ref_name
         self._pca_json_ref_name = pca_json_ref_name
+        # Snapshotted for the run record so the past-runs table can show how
+        # many components were chosen out of how many were available.
+        self._num_components_chosen = num_components
+        self._max_components_available = max_components_available
         self.result_ready.connect(self._load_result_into_wiser)
 
     def completion_callback(self, bindings: Dict[str, DataRef]) -> None:
@@ -124,10 +146,27 @@ class PCAPluginTask(QObject, SemanticTask):
         reduced_dataset.copy_spatial_metadata(self._source_dataset.get_spatial_metadata())
         reduced_dataset.set_data_ignore_value(self._source_dataset.get_data_ignore_value())
 
-        self._pca_widget = create_pca_metadata_widget(pca=pca_payload["pca"], dataset=reduced_dataset)
+        pca: PCA = pca_payload["pca"]
+        self._pca_widget = create_pca_metadata_widget(pca=pca, dataset=reduced_dataset)
         self._pca_widget.show()
 
         self._app_state.add_dataset(reduced_dataset, view_dataset=False)
+
+        # Snapshot the eigenvalues (sklearn calls these explained_variance_)
+        # into a fresh array so the record is independent of sklearn's
+        # internal storage.
+        eigenvalues = np.asarray(pca.explained_variance_, dtype=np.float64).copy()
+        self.run_recorded.emit(
+            PCARunRecord(
+                run_id=self.id,
+                timestamp=datetime.datetime.now(),
+                input_dataset_id=self._source_dataset.get_id(),
+                input_dataset_name_snapshot=self._source_dataset.get_name() or "Dataset",
+                num_components_chosen=self._num_components_chosen,
+                max_components_available=self._max_components_available,
+                eigenvalues=eigenvalues,
+            )
+        )
 
 
 class PCAPlugin(plugins.ContextMenuPlugin):
@@ -145,11 +184,11 @@ class PCAPlugin(plugins.ContextMenuPlugin):
         pca_dialog._ui.setupUi(pca_dialog)
 
         dataset: RasterDataSet = context["dataset"]
-        num_valid_bands = sum(dataset.get_bad_bands())
+        max_components = compute_max_pca_components(dataset)
 
         pca_dialog._ui.sbox_num_components.setMinimum(1)
-        pca_dialog._ui.sbox_num_components.setMaximum(num_valid_bands)
-        pca_dialog._ui.sbox_num_components.setValue(num_valid_bands)
+        pca_dialog._ui.sbox_num_components.setMaximum(max_components)
+        pca_dialog._ui.sbox_num_components.setValue(max_components)
 
         for est in ESTIMATOR_TYPES:
             pca_dialog._ui.cbox_estimator.addItem(est.value, est)
@@ -163,6 +202,7 @@ class PCAPlugin(plugins.ContextMenuPlugin):
             self.run_pca(
                 dataset=dataset,
                 num_components=num_components,
+                max_components_available=max_components,
                 estimator=estimator,
                 app_state=context["wiser"],
                 app_services=context.get("app_services"),
@@ -176,6 +216,7 @@ class PCAPlugin(plugins.ContextMenuPlugin):
         app_state: "ApplicationState",
         app_services: "AppServices" = None,
         test_mode: bool = False,
+        max_components_available: Optional[int] = None,
     ) -> Optional[Future]:
         _ = estimator
         if app_services is None:
@@ -208,12 +249,21 @@ class PCAPlugin(plugins.ContextMenuPlugin):
         dataset_ref = app_services.storage_service.register_external(
             ExternalRasterHandle(dataset_obj=dataset)
         )
+        # If the caller didn't tell us the dataset's max-components ceiling
+        # (e.g. an external script calling run_pca directly), fall back to
+        # the canonical value — the same one the dialog uses.
+        if max_components_available is None:
+            max_components_available = compute_max_pca_components(dataset)
         pca_task = PCAPluginTask(
             app_state=app_state,
             source_dataset=dataset,
             input_ref=dataset_ref,
             num_components=num_components,
+            max_components_available=max_components_available,
         )
+        # Record the run in the application-level history once the task
+        # finishes loading its result into the app (mirrors linear_unmixing.py:393).
+        pca_task.run_recorded.connect(app_state.get_pca_history().add_record)
         self._last_pca_task = pca_task
         task_plan = app_services.task_planner.plan_semantic_task(pca_task)
         return app_services.task_manager.register_and_submit_task_plan(app_services.scheduler, task_plan)

--- a/src/wiser/gui/permanent_plugins/pca_plugin.py
+++ b/src/wiser/gui/permanent_plugins/pca_plugin.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Dict, TYPE_CHECKING, Optional
 
 import numpy as np
-from PySide2.QtCore import QObject, Signal, Slot
+from PySide2.QtCore import QObject, Qt, Signal, Slot
 from PySide2.QtWidgets import QDialog
 from sklearn.decomposition import PCA
 
@@ -178,6 +178,28 @@ class PCAPluginTask(QObject, SemanticTask):
 class PCAPlugin(plugins.ContextMenuPlugin):
     def __init__(self):
         logging.info("PCA Initializing")
+        # Cached so reopening the past-runs viewer preserves scroll position
+        # and the Closed Runs toggle state.  Re-parented on each open in
+        # case the previous parent dialog was destroyed.
+        self._past_runs_dialog: Optional[PCAHistoryDialog] = None
+
+    def _open_past_runs_dialog(self, app_state: "ApplicationState", *, parent) -> None:
+        if self._past_runs_dialog is None:
+            self._past_runs_dialog = PCAHistoryDialog(
+                app_state=app_state,
+                manager=app_state.get_pca_history(),
+                parent=parent,
+            )
+        else:
+            # Reparent in case the previous parent (an old pca_dialog) was
+            # destroyed when the user dismissed it last time.
+            self._past_runs_dialog.setParent(parent)
+            # setParent on a top-level widget strips its window flags — put
+            # the Window flag back so it shows as its own window again.
+            self._past_runs_dialog.setWindowFlag(Qt.Window, True)
+        self._past_runs_dialog.show()
+        self._past_runs_dialog.raise_()
+        self._past_runs_dialog.activateWindow()
 
     def add_context_menu_items(self, context_type: plugins.types.ContextMenuType, context_menu, context):
         if context_type == plugins.ContextMenuType.RASTER_VIEW:
@@ -201,6 +223,15 @@ class PCAPlugin(plugins.ContextMenuPlugin):
 
         if pca_dialog._ui.cbox_estimator.count() == 1:
             pca_dialog._ui.cbox_estimator.setEnabled(False)
+
+        # Past-runs viewer.  The dialog is non-modal so the user can leave it
+        # open while still interacting with the modal PCA dialog above it;
+        # records live on app_state so they persist across PCA dialog opens
+        # regardless of whether this widget is cached.
+        app_state: "ApplicationState" = context["wiser"]
+        pca_dialog._ui.btn_past_results.clicked.connect(
+            lambda checked=False: self._open_past_runs_dialog(app_state, parent=pca_dialog)
+        )
 
         if pca_dialog.exec() == QDialog.Accepted:
             num_components = pca_dialog._ui.sbox_num_components.value()

--- a/src/wiser/gui/permanent_plugins/pca_plugin.py
+++ b/src/wiser/gui/permanent_plugins/pca_plugin.py
@@ -5,11 +5,11 @@ from concurrent.futures import Future
 from dataclasses import dataclass
 import logging
 from enum import Enum
-from typing import Dict, TYPE_CHECKING, Optional
+from typing import Callable, Dict, TYPE_CHECKING, Optional
 
 import numpy as np
-from PySide2.QtCore import QObject, Qt, Signal, Slot
-from PySide2.QtWidgets import QDialog
+from PySide2.QtCore import QObject, Signal, Slot
+from PySide2.QtWidgets import QDialog, QMessageBox
 from sklearn.decomposition import PCA
 
 from wiser import plugins
@@ -175,31 +175,113 @@ class PCAPluginTask(QObject, SemanticTask):
         )
 
 
-class PCAPlugin(plugins.ContextMenuPlugin):
-    def __init__(self):
-        logging.info("PCA Initializing")
-        # Cached so reopening the past-runs viewer preserves scroll position
-        # and the Closed Runs toggle state.  Re-parented on each open in
-        # case the previous parent dialog was destroyed.
-        self._past_runs_dialog: Optional[PCAHistoryDialog] = None
+class PCADialog(QDialog):
+    """Non-modal dialog for configuring and launching a PCA task.
 
-    def _open_past_runs_dialog(self, app_state: "ApplicationState", *, parent) -> None:
+    A persistent instance is owned by :class:`PCAPlugin` and reused across
+    every "PCA" right-click invocation; we just re-bind it to whichever
+    dataset the user clicked on via :meth:`configure_for_dataset`.
+
+    Being non-modal matters: while a PCA run is being configured the user
+    may want to open the past-runs viewer and inspect a scree plot, which
+    appears as its own top-level matplotlib window.  An ``exec()``-style
+    modal dialog would block input to that scree plot.
+    """
+
+    def __init__(
+        self,
+        app_state: "ApplicationState",
+        run_callback: Callable[[RasterDataSet, int, "ESTIMATOR_TYPES", int], None],
+        parent=None,
+    ) -> None:
+        super().__init__(parent=parent)
+        self.setModal(False)
+        self._app_state = app_state
+        self._run_callback = run_callback
+        # Tracked as a plain id (not a dataset object) so we can detect when
+        # the underlying dataset is removed from the app while we're still
+        # showing — see :meth:`_on_dataset_removed`.
+        self._dataset_id: Optional[int] = None
+
+        self._ui = Ui_PCA_Dialog()
+        self._ui.setupUi(self)
+
+        self._ui.sbox_num_components.setMinimum(1)
+        for est in ESTIMATOR_TYPES:
+            self._ui.cbox_estimator.addItem(est.value, est)
+        if self._ui.cbox_estimator.count() == 1:
+            self._ui.cbox_estimator.setEnabled(False)
+
+        # Past-runs viewer — lazily created on first click and kept alive on
+        # this dialog so reopening preserves scroll position / closed-runs
+        # toggle state.  The records themselves live on app_state.
+        self._past_runs_dialog: Optional[PCAHistoryDialog] = None
+        self._ui.btn_past_results.clicked.connect(self._on_view_past_runs)
+
+        app_state.dataset_removed.connect(self._on_dataset_removed)
+
+    def configure_for_dataset(self, dataset: RasterDataSet) -> None:
+        """Bind this dialog to a specific dataset and reset the form."""
+        self._dataset_id = dataset.get_id()
+        self.setWindowTitle(self.tr(f"PCA: {dataset.get_name() or 'Dataset'}"))
+        # max() guards against datasets where every band is bad (0 good
+        # bands); spin-box max must be ≥ min (1) or Qt rejects the setter.
+        max_components = max(1, compute_max_pca_components(dataset))
+        self._ui.sbox_num_components.setMaximum(max_components)
+        self._ui.sbox_num_components.setValue(max_components)
+
+    def accept(self) -> None:
+        # The selected dataset may have been removed between the context-menu
+        # click and the user pressing OK.  Bail with a warning rather than
+        # submit a task against a stale id.
+        if self._dataset_id is None:
+            return
+        try:
+            dataset = self._app_state.get_dataset(self._dataset_id)
+        except KeyError:
+            QMessageBox.warning(
+                self,
+                self.tr("PCA"),
+                self.tr("The dataset this PCA dialog was bound to is no longer available."),
+            )
+            return
+
+        num_components = self._ui.sbox_num_components.value()
+        estimator: "ESTIMATOR_TYPES" = self._ui.cbox_estimator.currentData()
+        # The spin-box maximum was set in configure_for_dataset to the true
+        # max — reuse it here so the run record reports the same value the
+        # user saw in the dialog.
+        max_components = self._ui.sbox_num_components.maximum()
+
+        self._run_callback(dataset, num_components, estimator, max_components)
+        super().accept()
+
+    def _on_view_past_runs(self) -> None:
         if self._past_runs_dialog is None:
             self._past_runs_dialog = PCAHistoryDialog(
-                app_state=app_state,
-                manager=app_state.get_pca_history(),
-                parent=parent,
+                app_state=self._app_state,
+                manager=self._app_state.get_pca_history(),
+                parent=self,
             )
-        else:
-            # Reparent in case the previous parent (an old pca_dialog) was
-            # destroyed when the user dismissed it last time.
-            self._past_runs_dialog.setParent(parent)
-            # setParent on a top-level widget strips its window flags — put
-            # the Window flag back so it shows as its own window again.
-            self._past_runs_dialog.setWindowFlag(Qt.Window, True)
         self._past_runs_dialog.show()
         self._past_runs_dialog.raise_()
         self._past_runs_dialog.activateWindow()
+
+    def _on_dataset_removed(self, removed_id: int) -> None:
+        # If the dataset we were configured against goes away, close quietly.
+        # Submitting PCA against a deleted dataset would fail downstream, and
+        # leaving the dialog open with a stale binding is confusing.
+        if self._dataset_id is not None and int(removed_id) == int(self._dataset_id):
+            self.close()
+
+
+class PCAPlugin(plugins.ContextMenuPlugin):
+    def __init__(self):
+        logging.info("PCA Initializing")
+        # Persistent dialog reused across context-menu invocations.  Created
+        # lazily because the plugin is constructed before app_state /
+        # app_services exist.
+        self._dialog: Optional[PCADialog] = None
 
     def add_context_menu_items(self, context_type: plugins.types.ContextMenuType, context_menu, context):
         if context_type == plugins.ContextMenuType.RASTER_VIEW:
@@ -207,43 +289,35 @@ class PCAPlugin(plugins.ContextMenuPlugin):
             act1.triggered.connect(lambda checked=False: self.show_pca(context=context))
 
     def show_pca(self, context: Dict):
-        pca_dialog = QDialog()
-        pca_dialog._ui = Ui_PCA_Dialog()
-        pca_dialog._ui.setupUi(pca_dialog)
-
         dataset: RasterDataSet = context["dataset"]
-        max_components = compute_max_pca_components(dataset)
-
-        pca_dialog._ui.sbox_num_components.setMinimum(1)
-        pca_dialog._ui.sbox_num_components.setMaximum(max_components)
-        pca_dialog._ui.sbox_num_components.setValue(max_components)
-
-        for est in ESTIMATOR_TYPES:
-            pca_dialog._ui.cbox_estimator.addItem(est.value, est)
-
-        if pca_dialog._ui.cbox_estimator.count() == 1:
-            pca_dialog._ui.cbox_estimator.setEnabled(False)
-
-        # Past-runs viewer.  The dialog is non-modal so the user can leave it
-        # open while still interacting with the modal PCA dialog above it;
-        # records live on app_state so they persist across PCA dialog opens
-        # regardless of whether this widget is cached.
         app_state: "ApplicationState" = context["wiser"]
-        pca_dialog._ui.btn_past_results.clicked.connect(
-            lambda checked=False: self._open_past_runs_dialog(app_state, parent=pca_dialog)
-        )
+        app_services: "AppServices" = context.get("app_services")
 
-        if pca_dialog.exec() == QDialog.Accepted:
-            num_components = pca_dialog._ui.sbox_num_components.value()
-            estimator: ESTIMATOR_TYPES = pca_dialog._ui.cbox_estimator.currentData()
-            self.run_pca(
-                dataset=dataset,
-                num_components=num_components,
-                max_components_available=max_components,
-                estimator=estimator,
-                app_state=context["wiser"],
-                app_services=context.get("app_services"),
-            )
+        if self._dialog is None:
+            # Capture app_state + app_services in the callback closure so the
+            # dialog stays decoupled from the plugin; both are singletons
+            # within a WISER session so capturing once is safe.
+            def _submit(
+                ds: RasterDataSet,
+                num_components: int,
+                estimator: "ESTIMATOR_TYPES",
+                max_components_available: int,
+            ) -> None:
+                self.run_pca(
+                    dataset=ds,
+                    num_components=num_components,
+                    estimator=estimator,
+                    app_state=app_state,
+                    app_services=app_services,
+                    max_components_available=max_components_available,
+                )
+
+            self._dialog = PCADialog(app_state=app_state, run_callback=_submit)
+
+        self._dialog.configure_for_dataset(dataset)
+        self._dialog.show()
+        self._dialog.raise_()
+        self._dialog.activateWindow()
 
     def run_pca(
         self,

--- a/src/wiser/gui/permanent_plugins/pca_plugin.py
+++ b/src/wiser/gui/permanent_plugins/pca_plugin.py
@@ -14,6 +14,7 @@ from sklearn.decomposition import PCA
 
 from wiser import plugins
 from wiser.gui.run_history import EigenScreeRunHistoryDialog, RunHistoryManagerBase
+from wiser.gui.scree_plot import build_scree_plot_figure
 from wiser.gui.generated.pca_dialog_ui import Ui_PCA_Dialog
 from wiser.raster import RasterDataLoader, RasterDataSet
 from wiser.raster.utils import compute_PCA_on_image, create_pca_metadata_widget
@@ -162,6 +163,24 @@ class PCAPluginTask(QObject, SemanticTask):
         # into a fresh array so the record is independent of sklearn's
         # internal storage.
         eigenvalues = np.asarray(pca.explained_variance_, dtype=np.float64).copy()
+
+        # Pop the scree plot up alongside the PCA metadata widget so the user
+        # immediately sees the eigenvalue spectrum that justifies (or doesn't)
+        # the component count they picked.  The same plot is reachable later
+        # via the past-runs dialog — this is just the on-completion surface.
+        scree_title = f"PCA Run {self.id} — Scree Plot ({source_name})"
+        scree_description = (
+            f"PCA run {self.id} on '{source_name}' — "
+            f"{self._num_components_chosen} of {self._max_components_available} components kept."
+        )
+        figure, axes = build_scree_plot_figure(eigenvalues, title=scree_title)
+        self._app_state.show_matplotlib_display_widget(
+            figure=figure,
+            axes=axes,
+            window_title=scree_title,
+            description=scree_description,
+        )
+
         self.run_recorded.emit(
             PCARunRecord(
                 run_id=self.id,

--- a/src/wiser/gui/run_history.py
+++ b/src/wiser/gui/run_history.py
@@ -1,4 +1,4 @@
-"""Shared base class for per-task-type completed-run histories.
+"""Shared base classes for per-task-type completed-run histories and viewers.
 
 PCA, MNF, and linear unmixing each have their own concrete record type so the
 histories are never accidentally conflated, but the manager logic — store
@@ -8,13 +8,32 @@ module factors that shared logic into :class:`RunHistoryManagerBase` so the
 per-task-type managers (see :mod:`wiser.gui.permanent_plugins.pca_plugin`,
 :mod:`wiser.gui.mnf`, :mod:`wiser.gui.linear_unmixing`) are tiny shells
 declaring their record type and overriding only what differs.
+
+The eigenvalue-based past-runs viewer (PCA + MNF) also lives here as
+:class:`EigenScreeRunHistoryDialog`; linear unmixing has its own viewer
+because its rows show endmember spectra rather than a scree plot.
 """
 
 from __future__ import annotations
 
+import datetime
 from typing import Generic, List, Protocol, TYPE_CHECKING, TypeVar
 
-from PySide2.QtCore import QObject, Signal
+import numpy as np
+from PySide2.QtCore import QObject, Qt, Signal, Slot
+from PySide2.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from wiser.gui.scree_plot import build_scree_plot_figure
 
 if TYPE_CHECKING:
     from wiser.gui.app_state import ApplicationState
@@ -28,6 +47,21 @@ class _HasRunIdAndInputDataset(Protocol):
 
 
 R = TypeVar("R", bound=_HasRunIdAndInputDataset)
+
+
+class _EigenRunRecord(Protocol):
+    """Shape a record must have for :class:`EigenScreeRunHistoryDialog`."""
+
+    run_id: int
+    timestamp: datetime.datetime
+    input_dataset_id: int
+    input_dataset_name_snapshot: str
+    num_components_chosen: int
+    max_components_available: int
+    eigenvalues: np.ndarray
+
+
+ER = TypeVar("ER", bound=_EigenRunRecord)
 
 
 class RunHistoryManagerBase(QObject, Generic[R]):
@@ -82,3 +116,231 @@ class RunHistoryManagerBase(QObject, Generic[R]):
 
     def _on_dataset_removed(self, _removed_id: int) -> None:
         self.records_changed.emit()
+
+
+# Column indices for the eigen-scree past-runs table.  Shared between the
+# active + closed tables.
+_RUN_COL_RUN = 0
+_RUN_COL_TIME = 1
+_RUN_COL_INPUT = 2
+_RUN_COL_NUM_USED = 3
+_RUN_COL_MAX_AVAIL = 4
+_RUN_COL_STATUS = 5
+_RUN_COL_VIEW = 6
+_RUN_COL_DELETE = 7
+_RUN_COL_COUNT = 8
+
+# Unicode arrows for the Closed Runs toggle button (mirrors activity monitor
+# and the linear-unmix history dialog).
+_ARROW_EXPANDED = "▼"
+_ARROW_COLLAPSED = "▶"
+
+
+class EigenScreeRunHistoryDialog(QDialog, Generic[ER]):
+    """Non-modal viewer for past runs that produced an eigenvalue spectrum.
+
+    Used by PCA and MNF; structurally mirrors
+    :class:`wiser.gui.linear_unmixing.LinearUnmixingHistoryDialog` (active +
+    collapsible-closed tables), but the View button opens a scree plot of the
+    captured eigenvalues rather than re-displaying spectra.
+
+    Subclasses customize:
+      * :attr:`task_label` — short name used in the window title and the
+        scree-plot title (e.g. ``"PCA"``, ``"MNF"``).
+
+    The manager is passed in and must be a
+    :class:`RunHistoryManagerBase` instance whose records satisfy
+    :class:`_EigenRunRecord` (i.e. carry the ``eigenvalues``,
+    ``num_components_chosen``, etc. fields).
+    """
+
+    # Subclasses override.  Used in the window title and scree-plot title.
+    task_label: str = "Run"
+
+    def __init__(
+        self,
+        app_state: "ApplicationState",
+        manager: RunHistoryManagerBase[ER],
+        parent=None,
+    ) -> None:
+        super().__init__(parent=parent)
+        self.setWindowTitle(self.tr(f"{self.task_label} — Past Runs"))
+        self.setModal(False)
+        self.resize(800, 500)
+
+        self._app_state = app_state
+        self._manager = manager
+        self._closed_expanded = False
+
+        outer = QVBoxLayout(self)
+
+        outer.addWidget(QLabel(self.tr("Active Runs"), self))
+        self._tbl_active = self._make_table()
+        outer.addWidget(self._tbl_active)
+
+        self._btn_toggle_closed = QPushButton(self)
+        self._btn_toggle_closed.clicked.connect(self._toggle_closed_section)
+        outer.addWidget(self._btn_toggle_closed)
+
+        self._tbl_closed = self._make_table()
+        self._tbl_closed.setVisible(self._closed_expanded)
+        outer.addWidget(self._tbl_closed)
+
+        btn_close = QPushButton(self.tr("Close"), self)
+        btn_close.clicked.connect(self.close)
+        bottom = QHBoxLayout()
+        bottom.addStretch(1)
+        bottom.addWidget(btn_close)
+        outer.addLayout(bottom)
+
+        self._manager.records_changed.connect(self._rebuild_tables)
+        self._rebuild_tables()
+
+    # ----- helpers -----
+
+    def _make_table(self) -> QTableWidget:
+        table = QTableWidget(self)
+        table.setColumnCount(_RUN_COL_COUNT)
+        table.setHorizontalHeaderLabels(
+            [
+                self.tr("Run"),
+                self.tr("Time"),
+                self.tr("Input dataset"),
+                self.tr("# Used"),
+                self.tr("# Available"),
+                self.tr("Status"),
+                self.tr(""),
+                self.tr(""),
+            ]
+        )
+        table.verticalHeader().setVisible(False)
+        table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        table.setSelectionMode(QAbstractItemView.NoSelection)
+        header = table.horizontalHeader()
+        header.setSectionResizeMode(_RUN_COL_INPUT, QHeaderView.Stretch)
+        header.setSectionResizeMode(_RUN_COL_STATUS, QHeaderView.Stretch)
+        for col in (
+            _RUN_COL_RUN,
+            _RUN_COL_TIME,
+            _RUN_COL_NUM_USED,
+            _RUN_COL_MAX_AVAIL,
+            _RUN_COL_VIEW,
+            _RUN_COL_DELETE,
+        ):
+            header.setSectionResizeMode(col, QHeaderView.ResizeToContents)
+        return table
+
+    def _toggle_closed_section(self) -> None:
+        self._closed_expanded = not self._closed_expanded
+        self._tbl_closed.setVisible(self._closed_expanded)
+        self._sync_closed_toggle_button()
+
+    def _sync_closed_toggle_button(self) -> None:
+        arrow = _ARROW_EXPANDED if self._closed_expanded else _ARROW_COLLAPSED
+        count = self._tbl_closed.rowCount()
+        self._btn_toggle_closed.setText(self.tr(f"Closed Runs ({count}) {arrow}"))
+
+    # ----- rendering -----
+
+    @Slot()
+    def _rebuild_tables(self) -> None:
+        self._tbl_active.setRowCount(0)
+        self._tbl_closed.setRowCount(0)
+        for record in self._manager.get_records():
+            if self._manager.is_input_alive(record):
+                self._append_row(self._tbl_active, record, alive=True)
+            else:
+                self._append_row(self._tbl_closed, record, alive=False)
+        self._sync_closed_toggle_button()
+
+    def _append_row(self, table: QTableWidget, record: ER, *, alive: bool) -> None:
+        row = table.rowCount()
+        table.insertRow(row)
+
+        table.setItem(row, _RUN_COL_RUN, QTableWidgetItem(str(record.run_id)))
+        table.setItem(
+            row,
+            _RUN_COL_TIME,
+            QTableWidgetItem(record.timestamp.strftime("%Y-%m-%d %H:%M:%S")),
+        )
+        table.setItem(
+            row,
+            _RUN_COL_INPUT,
+            self._make_dataset_item(
+                record.input_dataset_id,
+                record.input_dataset_name_snapshot,
+                alive=alive,
+            ),
+        )
+        table.setItem(
+            row,
+            _RUN_COL_NUM_USED,
+            QTableWidgetItem(str(record.num_components_chosen)),
+        )
+        table.setItem(
+            row,
+            _RUN_COL_MAX_AVAIL,
+            QTableWidgetItem(str(record.max_components_available)),
+        )
+        table.setItem(
+            row,
+            _RUN_COL_STATUS,
+            QTableWidgetItem(self._manager.get_status_text(record)),
+        )
+
+        # Lambda binding captures rid by default arg to avoid the
+        # late-binding-loop-variable pitfall.
+        rid = record.run_id
+        btn_view = QPushButton(self.tr("View"), table)
+        btn_view.clicked.connect(lambda checked=False, r=rid: self._on_view_clicked(r))
+        table.setCellWidget(row, _RUN_COL_VIEW, btn_view)
+
+        btn_delete = QPushButton(self.tr("Delete"), table)
+        btn_delete.clicked.connect(lambda checked=False, r=rid: self._manager.remove_record(r))
+        table.setCellWidget(row, _RUN_COL_DELETE, btn_delete)
+
+    def _make_dataset_item(
+        self,
+        dataset_id: int,
+        snapshot_name: str,
+        *,
+        alive: bool,
+    ) -> QTableWidgetItem:
+        if alive:
+            ds = self._app_state.get_dataset(dataset_id)
+            return QTableWidgetItem(ds.get_name() or snapshot_name)
+        item = QTableWidgetItem(f"{snapshot_name} (closed)")
+        font = item.font()
+        font.setItalic(True)
+        item.setFont(font)
+        item.setForeground(Qt.gray)
+        return item
+
+    # ----- View click -----
+
+    def _on_view_clicked(self, run_id: int) -> None:
+        # Liveness can change between the click and the slot firing; re-fetch
+        # the record fresh rather than capturing it in the lambda.
+        record = next(
+            (r for r in self._manager.get_records() if r.run_id == run_id),
+            None,
+        )
+        if record is None:
+            return
+
+        title = (
+            f"{self.task_label} Run {record.run_id} — Scree Plot " f"({record.input_dataset_name_snapshot})"
+        )
+        description = (
+            f"{self.task_label} run {record.run_id} on "
+            f"'{record.input_dataset_name_snapshot}' — "
+            f"{record.num_components_chosen} of {record.max_components_available} "
+            f"components kept."
+        )
+        figure, axes = build_scree_plot_figure(record.eigenvalues, title=title)
+        self._app_state.show_matplotlib_display_widget(
+            figure=figure,
+            axes=axes,
+            window_title=title,
+            description=description,
+        )

--- a/src/wiser/gui/run_history.py
+++ b/src/wiser/gui/run_history.py
@@ -33,7 +33,7 @@ from PySide2.QtWidgets import (
     QVBoxLayout,
 )
 
-from wiser.gui.scree_plot import build_scree_plot_figure
+from wiser.gui.scree_plot import attach_scree_click_inspector, build_scree_plot_figure
 
 if TYPE_CHECKING:
     from wiser.gui.app_state import ApplicationState
@@ -344,3 +344,7 @@ class EigenScreeRunHistoryDialog(QDialog, Generic[ER]):
             window_title=title,
             description=description,
         )
+        # Must be attached AFTER show_matplotlib_display_widget — that call
+        # wraps the figure in a fresh Qt FigureCanvas, replacing any canvas
+        # that existed before and discarding earlier mpl_connect handlers.
+        attach_scree_click_inspector(figure, axes, record.eigenvalues)

--- a/src/wiser/gui/run_history.py
+++ b/src/wiser/gui/run_history.py
@@ -1,12 +1,13 @@
-"""Shared base class for PCA/MNF (and future eigen-decomposition) run history.
+"""Shared base class for per-task-type completed-run histories.
 
-PCA and MNF each have their own concrete record type so the two histories are
-never accidentally conflated, but the manager logic — store records, emit
-``records_changed`` on add/remove/dataset_removed, expose liveness/status of
-the input dataset — is identical between them.  This module factors that
-shared logic into :class:`EigenRunHistoryManagerBase` so the per-task-type
-managers (see :mod:`wiser.gui.pca_history` and :mod:`wiser.gui.mnf_history`)
-are tiny shells declaring their record type.
+PCA, MNF, and linear unmixing each have their own concrete record type so the
+histories are never accidentally conflated, but the manager logic — store
+records, emit ``records_changed`` on add/remove/dataset_removed, expose
+liveness/status of the input dataset — is identical between them.  This
+module factors that shared logic into :class:`RunHistoryManagerBase` so the
+per-task-type managers (see :mod:`wiser.gui.permanent_plugins.pca_plugin`,
+:mod:`wiser.gui.mnf`, :mod:`wiser.gui.linear_unmixing`) are tiny shells
+declaring their record type and overriding only what differs.
 """
 
 from __future__ import annotations
@@ -29,12 +30,14 @@ class _HasRunIdAndInputDataset(Protocol):
 R = TypeVar("R", bound=_HasRunIdAndInputDataset)
 
 
-class EigenRunHistoryManagerBase(QObject, Generic[R]):
-    """Generic in-memory list of completed eigen-decomposition runs.
+class RunHistoryManagerBase(QObject, Generic[R]):
+    """Generic in-memory list of completed task runs.
 
     Subclass and bind ``R`` to your concrete record type.  The subclass
     typically doesn't need to override anything — just inherit and
-    instantiate.
+    instantiate.  Override :meth:`get_status_text` (and add accessors like
+    ``is_output_alive``) if your task tracks more liveness than just the
+    input dataset.
     """
 
     records_changed = Signal()

--- a/src/wiser/gui/scree_plot.py
+++ b/src/wiser/gui/scree_plot.py
@@ -115,6 +115,16 @@ def attach_scree_click_inspector(
     )
     readout.set_visible(False)
 
+    # Dotted crosshair through the snapped point — matches the style used by
+    # SpectrumPlotGeneric's point selection (see CROSSHAIR_WIDTH in
+    # spectrum_plot.py).  axvline / axhline span the full axes regardless of
+    # data range so the lines extend across the whole plot.  Initial x/y are
+    # placeholders; the click handler moves them.
+    vline = axes.axvline(x=0, linestyle="dotted", color="black", linewidth=0.5, zorder=1)
+    hline = axes.axhline(y=0, linestyle="dotted", color="black", linewidth=0.5, zorder=1)
+    vline.set_visible(False)
+    hline.set_visible(False)
+
     def _on_click(event):
         # Ignore clicks outside the scree axes (toolbar, figure margins,
         # other axes) — event.xdata is None in those cases too, but the
@@ -125,8 +135,16 @@ def attach_scree_click_inspector(
         # range so clicks outside the data still produce a sensible label.
         idx = int(round(event.xdata)) - 1
         idx = max(0, min(values.size - 1, idx))
-        readout.set_text(f"PC{idx + 1}: {values[idx]:.4g}")
+        x = idx + 1
+        y = values[idx]
+        readout.set_text(f"PC{x}: {y:.4g}")
         readout.set_visible(True)
+        # set_xdata on an axvline expects a 2-element sequence (the line's
+        # two endpoints share the same x); same for axhline with y.
+        vline.set_xdata([x, x])
+        hline.set_ydata([y, y])
+        vline.set_visible(True)
+        hline.set_visible(True)
         figure.canvas.draw_idle()
 
     figure.canvas.mpl_connect("button_press_event", _on_click)

--- a/src/wiser/gui/scree_plot.py
+++ b/src/wiser/gui/scree_plot.py
@@ -1,0 +1,92 @@
+"""Shared matplotlib helper for rendering scree plots of eigenvalues.
+
+Used by PCA and MNF past-runs viewers (see :mod:`wiser.gui.pca_history` and
+:mod:`wiser.gui.mnf_history`).  The eigenvalues passed in may be a subset of
+the full spectrum (e.g. sklearn PCA only retains ``num_components`` of them);
+that is acceptable — we just plot what we have.
+
+The caller is responsible for displaying the returned ``(figure, axes)`` via
+:meth:`wiser.gui.app_state.ApplicationState.show_matplotlib_display_widget`,
+which owns the window and cleans it up on close.
+"""
+
+from typing import Tuple
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+
+def build_scree_plot_figure(
+    eigenvalues: np.ndarray,
+    *,
+    title: str,
+    x_label: str = "Component index",
+    y_label: str = "Eigenvalue",
+) -> Tuple[Figure, Axes]:
+    """Build a scree plot of ``eigenvalues`` vs 1-indexed component position.
+
+    Args:
+        eigenvalues: 1-D array of eigenvalues, ordered descending (the
+            convention used by both the sklearn PCA result and WISER's
+            ``EigenDecompositionStage``).  May be a subset of the full
+            spectrum — the plot just renders what is given.
+        title: Plot title (becomes the matplotlib axes title; the caller
+            typically also uses it as the window title).
+        x_label, y_label: Axis labels.
+
+    Returns:
+        A ``(Figure, Axes)`` pair.  The figure is not displayed — pass it to
+        ``ApplicationState.show_matplotlib_display_widget`` so the window is
+        properly owned and torn down on close.
+    """
+    values = np.asarray(eigenvalues, dtype=np.float64).ravel()
+    if values.size == 0:
+        raise ValueError("Cannot build a scree plot from an empty eigenvalue array.")
+
+    component_indices = np.arange(1, values.size + 1)
+
+    figure = Figure(figsize=(6.0, 4.0))
+    # Tight layout keeps tick labels and title from being clipped when the
+    # window is small.
+    figure.set_tight_layout(True)
+    axes = figure.add_subplot(111)
+
+    axes.plot(component_indices, values, marker="o", linestyle="-", linewidth=1.2)
+
+    axes.set_title(title)
+    axes.set_xlabel(x_label)
+    axes.set_ylabel(y_label)
+
+    # Force integer ticks on the x-axis — fractional component indices make
+    # no sense.  For small N (<= 30) show every index; for larger N let
+    # matplotlib decide but still constrain to integers.
+    if values.size <= 30:
+        axes.set_xticks(component_indices)
+
+    # Log scale is the right default — eigenvalue spectra typically span many
+    # orders of magnitude.  Matplotlib silently drops non-positive values in
+    # log mode, which is acceptable: zero eigenvalues mean the corresponding
+    # direction is degenerate and there's nothing meaningful to plot.  Fall
+    # back to linear when *every* value is non-positive (pathological but
+    # possible) so the plot still renders.
+    if np.any(values > 0):
+        axes.set_yscale("log")
+    axes.grid(True, which="both", linestyle="--", alpha=0.4)
+
+    return figure, axes
+
+
+if __name__ == "__main__":
+    # Smoke test: synthetic decaying spectrum to eyeball that the plot renders.
+    import matplotlib
+
+    matplotlib.use("Qt5Agg")
+    import matplotlib.pyplot as plt
+
+    synthetic = np.array([100.0, 30.0, 9.0, 3.0, 1.0, 0.3, 0.1, 0.03])
+    fig, _ = build_scree_plot_figure(synthetic, title="Synthetic scree plot")
+    # In the smoke test we just want to see the figure — in production the
+    # MatplotlibDisplayWidget owns the canvas instead.
+    plt.figure(fig.number)
+    plt.show()

--- a/src/wiser/gui/scree_plot.py
+++ b/src/wiser/gui/scree_plot.py
@@ -77,6 +77,61 @@ def build_scree_plot_figure(
     return figure, axes
 
 
+def attach_scree_click_inspector(
+    figure: Figure,
+    axes: Axes,
+    eigenvalues: np.ndarray,
+) -> None:
+    """Make the scree plot click-inspectable.
+
+    On every click inside ``axes``, snaps to the nearest component along the
+    x-axis (1-indexed) and writes ``PC{idx}: {value}`` into a small readout
+    pinned to the top-left corner of the plot.  Subsequent clicks update the
+    same readout in place rather than stacking annotations.
+
+    Must be called *after* the figure has been wrapped in its final Qt
+    canvas (i.e. after
+    :meth:`wiser.gui.app_state.ApplicationState.show_matplotlib_display_widget`).
+    Constructing a new ``FigureCanvas`` around the figure replaces
+    ``figure.canvas`` and silently discards any earlier ``mpl_connect``
+    bindings, so connecting too early is a no-op at runtime.
+    """
+    values = np.asarray(eigenvalues, dtype=np.float64).ravel()
+    if values.size == 0:
+        return
+
+    # Pinned readout in axes-fraction coordinates so it stays in the top-left
+    # corner regardless of pan/zoom.  Created hidden so the box only appears
+    # after the user actually clicks something.
+    readout = axes.text(
+        0.02,
+        0.98,
+        "",
+        transform=axes.transAxes,
+        ha="left",
+        va="top",
+        fontsize=9,
+        bbox=dict(boxstyle="round,pad=0.3", fc="white", ec="0.5", alpha=0.9),
+    )
+    readout.set_visible(False)
+
+    def _on_click(event):
+        # Ignore clicks outside the scree axes (toolbar, figure margins,
+        # other axes) — event.xdata is None in those cases too, but the
+        # axes check is the more readable guard.
+        if event.inaxes is not axes or event.xdata is None:
+            return
+        # Snap to the nearest 1-indexed component, clamped to the available
+        # range so clicks outside the data still produce a sensible label.
+        idx = int(round(event.xdata)) - 1
+        idx = max(0, min(values.size - 1, idx))
+        readout.set_text(f"PC{idx + 1}: {values[idx]:.4g}")
+        readout.set_visible(True)
+        figure.canvas.draw_idle()
+
+    figure.canvas.mpl_connect("button_press_event", _on_click)
+
+
 if __name__ == "__main__":
     # Smoke test: synthetic decaying spectrum to eyeball that the plot renders.
     import matplotlib
@@ -85,8 +140,9 @@ if __name__ == "__main__":
     import matplotlib.pyplot as plt
 
     synthetic = np.array([100.0, 30.0, 9.0, 3.0, 1.0, 0.3, 0.1, 0.03])
-    fig, _ = build_scree_plot_figure(synthetic, title="Synthetic scree plot")
-    # In the smoke test we just want to see the figure — in production the
-    # MatplotlibDisplayWidget owns the canvas instead.
+    fig, ax = build_scree_plot_figure(synthetic, title="Synthetic scree plot")
+    # pyplot.show() will give the figure a real canvas; attach the inspector
+    # after that so the click handler is bound to the live canvas.
     plt.figure(fig.number)
+    attach_scree_click_inspector(fig, ax, synthetic)
     plt.show()

--- a/src/wiser/gui/ui_files/mnf_dialog.ui
+++ b/src/wiser/gui/ui_files/mnf_dialog.ui
@@ -44,6 +44,13 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QPushButton" name="btn_past_results">
+     <property name="text">
+      <string>View Past Results</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/wiser/gui/ui_files/pca_dialog.ui
+++ b/src/wiser/gui/ui_files/pca_dialog.ui
@@ -57,6 +57,13 @@
      </property>
     </spacer>
    </item>
+   <item row="3" column="0">
+    <widget class="QPushButton" name="btn_past_results">
+     <property name="text">
+      <string>View Past Results</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/wiser/raster/utils.py
+++ b/src/wiser/raster/utils.py
@@ -126,12 +126,15 @@ def create_pca_metadata_widget(pca, dataset, parent=None) -> QWidget:
         def _fmt_array(self, arr, indent="    "):
             # Nicely format numpy arrays with indentation
             arr = np.asarray(arr)
+            # Use numpy's default truncation threshold (~1000 elements) so big
+            # learned attributes like components_ — which is (N, N) for an
+            # all-components fit — don't blow Qt's text layout with O(N²)
+            # formatted floats.  Power users can still pickle ``pca`` directly.
             arr_str = np.array2string(
                 arr,
                 precision=4,
                 suppress_small=True,
                 max_line_width=120,
-                threshold=arr.size,
             )
             return "\n".join(indent + line for line in arr_str.splitlines())
 


### PR DESCRIPTION
## What does this change do?
This change adds scree plots to WISER for PCA and MNF. It also adds the ability to view past runs of PCA and MNF. It also defaults the GUI components line edit to have the maximum number of components they can run.

Closes #548
Closes #512

## What type of PR is this? (check all applicable) 
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Added tests?
- [ ] yes
- [X] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [ ] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->