### PR TITLE
fix: bug: Fix broken process pool error

### DIFF
--- a/src/tests/test_work_scheduler.py
+++ b/src/tests/test_work_scheduler.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import time
 import unittest
+from concurrent.futures import BrokenExecutor, Future
 from io import StringIO
 from functools import partial
 from multiprocessing.shared_memory import SharedMemory
@@ -22,7 +23,12 @@ from wiser.utils.primitives import (
 )
 from wiser.utils.storage_service import StorageService, shared_mem_exists
 from wiser.utils.task_system import TaskPlan, WorkUnit
-from wiser.utils.work_scheduler import RecordingWorkScheduler, SchedulerConfig, WorkScheduler
+from wiser.utils.work_scheduler import (
+    RecordingWorkScheduler,
+    SchedulerConfig,
+    WorkScheduler,
+    _RestartableExecutor,
+)
 
 import pytest
 
@@ -798,28 +804,63 @@ class TestWorkScheduler(unittest.TestCase):
                 service.close()
 
 
+class _FakeBreakingExecutor:
+    """Test double that raises BrokenExecutor on its first submit, then works.
+
+    Used to exercise `_RestartableExecutor`'s recovery path deterministically,
+    without killing real worker processes/threads.
+    """
+
+    def __init__(self, *, breaks_on_first_submit: bool) -> None:
+        self.breaks_on_first_submit = breaks_on_first_submit
+        self.submit_count = 0
+        self.shutdown_calls: list[tuple[bool, bool]] = []
+
+    def submit(self, fn, *args, **kwargs) -> Future:
+        self.submit_count += 1
+        if self.breaks_on_first_submit and self.submit_count == 1:
+            raise BrokenExecutor("simulated broken pool")
+        future: Future = Future()
+        future.set_result(fn(*args, **kwargs))
+        return future
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        self.shutdown_calls.append((wait, cancel_futures))
+
+
+class TestRestartableExecutor(unittest.TestCase):
+    """Unit tests for the generic self-healing executor wrapper (process + thread)."""
+
+    def test_submit_restarts_once_on_broken_executor_and_retries(self) -> None:
+        created: list[_FakeBreakingExecutor] = []
+
+        def factory() -> _FakeBreakingExecutor:
+            # Only the very first executor simulates a break.
+            executor = _FakeBreakingExecutor(breaks_on_first_submit=len(created) == 0)
+            created.append(executor)
+            return executor
+
+        pool = _RestartableExecutor("FakePool", factory)
+        result = pool.submit(lambda value: value, "payload").result(timeout=5)
+
+        self.assertEqual(result, "payload")
+        self.assertEqual(len(created), 2, "the broken executor should have been replaced exactly once")
+        self.assertIs(pool.executor, created[1])
+        # The broken executor was torn down without blocking and cancelling backlog.
+        self.assertEqual(created[0].shutdown_calls, [(False, True)])
+
+    def test_submit_propagates_when_fresh_executor_also_breaks(self) -> None:
+        # Every executor this factory produces breaks: recovery must give up
+        # rather than loop forever.
+        pool = _RestartableExecutor(
+            "AlwaysBroken", lambda: _FakeBreakingExecutor(breaks_on_first_submit=True)
+        )
+        with self.assertRaises(BrokenExecutor):
+            pool.submit(lambda: "never runs")
+
+
 class TestWorkSchedulerBrokenPoolRecovery(unittest.TestCase):
-    """Recovery behavior when the ProcessPoolExecutor breaks (issue: BrokenProcessPool)."""
-
-    def test_restart_process_executor_swaps_in_fresh_pool(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            service = StorageService(root_dir=tmp_dir)
-            scheduler = WorkScheduler(SchedulerConfig(_process_budget=3, _thread_budget=3), service)
-            try:
-                old_executor = scheduler._process_executor
-                with scheduler._state_lock:
-                    scheduler._restart_process_executor_locked()
-                new_executor = scheduler._process_executor
-
-                self.assertIsNot(new_executor, old_executor)
-                # The replaced pool was shut down; it no longer accepts work.
-                with self.assertRaises(RuntimeError):
-                    old_executor.submit(_ok_process_a)
-                # The fresh pool is usable.
-                self.assertEqual(new_executor.submit(_ok_process_a).result(timeout=15), "ok-process-a")
-            finally:
-                scheduler.shutdown(wait=True)
-                service.close()
+    """End-to-end recovery when the scheduler's ProcessPoolExecutor breaks."""
 
     def test_recovers_after_worker_kills_process_pool(self) -> None:
         """A killed worker breaks the pool; the next plan must transparently restart it."""
@@ -844,7 +885,7 @@ class TestWorkSchedulerBrokenPoolRecovery(unittest.TestCase):
                 with self.assertRaises(Exception):
                     scheduler.run_task_plan(kill_plan).result(timeout=30)
 
-                broken_executor = scheduler._process_executor
+                broken_executor = scheduler._process_pool.executor
 
                 # Plan 2: ordinary process work that must succeed on a restarted pool.
                 recover_unit = _make_work_unit(
@@ -863,9 +904,11 @@ class TestWorkSchedulerBrokenPoolRecovery(unittest.TestCase):
                 with self.assertLogs("wiser.utils.work_scheduler", level="WARNING") as log_ctx:
                     scheduler.run_task_plan(recover_plan).result(timeout=30)
 
-                # The pool was replaced and the restart was logged.
-                self.assertIsNot(scheduler._process_executor, broken_executor)
-                self.assertTrue(any("restarted with a fresh pool" in message for message in log_ctx.output))
+                # The underlying pool was replaced and the restart was logged.
+                self.assertIsNot(scheduler._process_pool.executor, broken_executor)
+                self.assertTrue(
+                    any("restarted with a fresh executor" in message for message in log_ctx.output)
+                )
             finally:
                 scheduler.shutdown(wait=True)
                 service.close()

--- a/src/tests/test_work_scheduler.py
+++ b/src/tests/test_work_scheduler.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import time
 import unittest
@@ -53,6 +54,15 @@ def _sleep_then_return(label: str, sleep_seconds: float) -> str:
 
 def _boom_process() -> None:
     raise RuntimeError("boom")
+
+
+def _kill_worker_process() -> None:
+    """Abruptly terminate the worker process to break the ProcessPoolExecutor.
+
+    This simulates an OOM kill / segfault / native crash in a compute worker,
+    which leaves the pool in a permanent `BrokenProcessPool` state.
+    """
+    os._exit(1)
 
 
 def _make_input_ref(ref_id: str) -> DataRef:
@@ -786,3 +796,80 @@ class TestWorkScheduler(unittest.TestCase):
             finally:
                 scheduler.shutdown(wait=True)
                 service.close()
+
+
+class TestWorkSchedulerBrokenPoolRecovery(unittest.TestCase):
+    """Recovery behavior when the ProcessPoolExecutor breaks (issue: BrokenProcessPool)."""
+
+    def test_restart_process_executor_swaps_in_fresh_pool(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = StorageService(root_dir=tmp_dir)
+            scheduler = WorkScheduler(SchedulerConfig(_process_budget=3, _thread_budget=3), service)
+            try:
+                old_executor = scheduler._process_executor
+                with scheduler._state_lock:
+                    scheduler._restart_process_executor_locked()
+                new_executor = scheduler._process_executor
+
+                self.assertIsNot(new_executor, old_executor)
+                # The replaced pool was shut down; it no longer accepts work.
+                with self.assertRaises(RuntimeError):
+                    old_executor.submit(_ok_process_a)
+                # The fresh pool is usable.
+                self.assertEqual(new_executor.submit(_ok_process_a).result(timeout=15), "ok-process-a")
+            finally:
+                scheduler.shutdown(wait=True)
+                service.close()
+
+    def test_recovers_after_worker_kills_process_pool(self) -> None:
+        """A killed worker breaks the pool; the next plan must transparently restart it."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = StorageService(root_dir=tmp_dir)
+            scheduler = WorkScheduler(SchedulerConfig(_process_budget=3, _thread_budget=3), service)
+            try:
+                # Plan 1: a process unit that kills its worker, breaking the pool.
+                kill_unit = _make_work_unit(
+                    unit_id="kill_u1",
+                    stage_id="s00",
+                    priority=PriorityClass.INTERACTIVE,
+                    executor_kind="process",
+                    fn=_kill_worker_process,
+                )
+                kill_plan = TaskPlan(
+                    plan_id="plan-kill",
+                    semantic_task_id="semantic-kill",
+                    work_units={kill_unit.unit_id: kill_unit},
+                    stage_work_units={"s00": [kill_unit.unit_id]},
+                )
+                with self.assertRaises(Exception):
+                    scheduler.run_task_plan(kill_plan).result(timeout=30)
+
+                broken_executor = scheduler._process_executor
+
+                # Plan 2: ordinary process work that must succeed on a restarted pool.
+                recover_unit = _make_work_unit(
+                    unit_id="recover_u1",
+                    stage_id="s00",
+                    priority=PriorityClass.INTERACTIVE,
+                    executor_kind="process",
+                    fn=_ok_process_a,
+                )
+                recover_plan = TaskPlan(
+                    plan_id="plan-recover",
+                    semantic_task_id="semantic-recover",
+                    work_units={recover_unit.unit_id: recover_unit},
+                    stage_work_units={"s00": [recover_unit.unit_id]},
+                )
+                with self.assertLogs("wiser.utils.work_scheduler", level="WARNING") as log_ctx:
+                    scheduler.run_task_plan(recover_plan).result(timeout=30)
+
+                # The pool was replaced and the restart was logged.
+                self.assertIsNot(scheduler._process_executor, broken_executor)
+                self.assertTrue(any("restarted with a fresh pool" in message for message in log_ctx.output))
+            finally:
+                scheduler.shutdown(wait=True)
+                service.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/wiser/utils/work_scheduler.py
+++ b/src/wiser/utils/work_scheduler.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import logging
 import multiprocessing
 import os
 import sys
 
 from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass, field
 from collections import Counter, deque
 from threading import Lock, Semaphore
@@ -17,6 +19,8 @@ from matplotlib.pylab import Enum
 from .primitives import PriorityClass
 from .task_system import TaskPlan, WorkUnit
 from .worker_runtime import initialize_process_storage_client, initialize_thread_worker
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from wiser.utils.storage_service import StorageService
@@ -661,7 +665,10 @@ class WorkScheduler:
             raise ValueError("WorkScheduler requires a storage_service")
         self._storage_service = storage_service
 
-        service_address, service_authkey = storage_service.get_connection_bootstrap()
+        # Retain the bootstrap so a broken ProcessPoolExecutor can be rebuilt
+        # in place with an identical worker initializer (see
+        # `_restart_process_executor_locked`).
+        self._service_address, self._service_authkey = storage_service.get_connection_bootstrap()
 
         # On Linux, the default 'fork' start method is unsafe when Qt is
         # running: os.fork() triggers pthread_atfork handlers that try to
@@ -672,15 +679,10 @@ class WorkScheduler:
         # that has no Qt state, avoiding the deadlock entirely.
         # Issue # 526
         if sys.platform.startswith("linux"):
-            _mp_context = multiprocessing.get_context("forkserver")
+            self._mp_context = multiprocessing.get_context("forkserver")
         else:
-            _mp_context = multiprocessing.get_context("spawn")
-        self._process_executor = ProcessPoolExecutor(
-            max_workers=self._process_budget,
-            mp_context=_mp_context,
-            initializer=initialize_process_storage_client,
-            initargs=(service_address, service_authkey),
-        )
+            self._mp_context = multiprocessing.get_context("spawn")
+        self._process_executor = self._create_process_executor()
         self._thread_executor = ThreadPoolExecutor(
             max_workers=self._thread_budget,
             initializer=initialize_thread_worker,
@@ -758,6 +760,57 @@ class WorkScheduler:
         future = self._thread_executor.submit(fn, *args, **kwargs)
         future.add_done_callback(lambda _f: sem.release())
         return future
+
+    def _create_process_executor(self) -> ProcessPoolExecutor:
+        """Build a ProcessPoolExecutor with the scheduler's worker initializer.
+
+        Used both for the initial pool and when restarting a pool that has
+        broken (`_restart_process_executor_locked`).
+        """
+        return ProcessPoolExecutor(
+            max_workers=self._process_budget,
+            mp_context=self._mp_context,
+            initializer=initialize_process_storage_client,
+            initargs=(self._service_address, self._service_authkey),
+        )
+
+    def _restart_process_executor_locked(self) -> None:
+        """Replace a broken ProcessPoolExecutor with a fresh one.
+
+        A `ProcessPoolExecutor` becomes permanently unusable once any worker
+        process dies abruptly (OOM kill, segfault, native crash): every later
+        `submit()` raises `BrokenProcessPool`. We swap in a brand-new pool so
+        the scheduler keeps functioning.
+
+        Caller must hold `_state_lock` (every submit path does), which makes the
+        executor swap safe. Futures already dispatched to the dead pool keep
+        their `BrokenProcessPool` exception; their existing done-callbacks still
+        fire `_on_unit_done`, releasing semaphores and decrementing
+        `_in_flight_ram_bytes`, so capacity accounting self-heals.
+        """
+        broken_executor = self._process_executor
+        self._process_executor = self._create_process_executor()
+        logger.warning("ProcessPoolExecutor was broken; restarted with a fresh pool.")
+        try:
+            broken_executor.shutdown(wait=False, cancel_futures=True)
+        except Exception:
+            logger.exception("Error shutting down broken ProcessPoolExecutor")
+
+    def _submit_work_unit_with_recovery_locked(self, work_unit: WorkUnit, executor: Any) -> Future[Any]:
+        """Submit a work unit, restarting a broken process pool once on failure.
+
+        Caller must hold `_state_lock`. On the common case (a process pool that
+        broke once) the restart succeeds and the retried submit goes through
+        transparently. A second `BrokenProcessPool` on a freshly created pool
+        indicates a fatal environment problem and is propagated.
+        """
+        try:
+            return executor.submit(self._execute_work_unit, work_unit)
+        except BrokenProcessPool:
+            if work_unit.executor_kind != "process":
+                raise
+            self._restart_process_executor_locked()
+            return self._process_executor.submit(self._execute_work_unit, work_unit)
 
     def shutdown(self, wait: bool = True) -> None:
         self._thread_executor.shutdown(wait=wait)

--- a/src/wiser/utils/work_scheduler.py
+++ b/src/wiser/utils/work_scheduler.py
@@ -5,8 +5,13 @@ import multiprocessing
 import os
 import sys
 
-from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
-from concurrent.futures.process import BrokenProcessPool
+from concurrent.futures import (
+    BrokenExecutor,
+    Executor,
+    Future,
+    ProcessPoolExecutor,
+    ThreadPoolExecutor,
+)
 from dataclasses import dataclass, field
 from collections import Counter, deque
 from threading import Lock, Semaphore
@@ -634,6 +639,64 @@ def list_tracked_segments(smm):
         conn.close()
 
 
+class _RestartableExecutor:
+    """An executor that rebuilds itself when it breaks.
+
+    `concurrent.futures` executors can become permanently unusable: a
+    `ProcessPoolExecutor` raises `BrokenProcessPool` once a worker process dies
+    abruptly (OOM kill, segfault, native crash), and a `ThreadPoolExecutor`
+    raises `BrokenThreadPool` if a worker fails to initialize. In both cases
+    every subsequent `submit()` raises a `BrokenExecutor`, wedging the pool for
+    the rest of the process lifetime.
+
+    This wrapper builds a fresh executor from `factory` and retries the submit
+    once, so a single break is recovered transparently. A second `BrokenExecutor`
+    on a freshly built executor indicates a fatal environment problem and is
+    propagated to the caller.
+
+    Thread-safe on its own: submit and restart are serialized by an internal
+    lock, so callers do not need to hold any external lock.
+    """
+
+    def __init__(self, name: str, factory: Callable[[], Executor]) -> None:
+        self._name = name
+        self._factory = factory
+        self._lock = Lock()
+        self._executor = factory()
+
+    @property
+    def executor(self) -> Executor:
+        """The current underlying executor (primarily for tests/introspection)."""
+        return self._executor
+
+    def submit(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Future[Any]:
+        with self._lock:
+            try:
+                return self._executor.submit(fn, *args, **kwargs)
+            except BrokenExecutor:
+                self._restart_locked()
+                return self._executor.submit(fn, *args, **kwargs)
+
+    def shutdown(self, wait: bool = True) -> None:
+        with self._lock:
+            self._executor.shutdown(wait=wait)
+
+    def _restart_locked(self) -> None:
+        """Swap in a fresh executor and tear down the broken one. Caller holds `_lock`.
+
+        Futures already dispatched to the broken executor keep their
+        `BrokenExecutor` result; their existing done-callbacks still fire, so any
+        capacity accounting the owner attached to them self-heals.
+        """
+        broken_executor = self._executor
+        self._executor = self._factory()
+        logger.warning("%s was broken; restarted with a fresh executor.", self._name)
+        try:
+            broken_executor.shutdown(wait=False, cancel_futures=True)
+        except Exception:
+            logger.exception("Error shutting down broken %s", self._name)
+
+
 class WorkScheduler:
     def __init__(
         self,
@@ -667,7 +730,7 @@ class WorkScheduler:
 
         # Retain the bootstrap so a broken ProcessPoolExecutor can be rebuilt
         # in place with an identical worker initializer (see
-        # `_restart_process_executor_locked`).
+        # `_create_process_executor` / `_RestartableExecutor`).
         self._service_address, self._service_authkey = storage_service.get_connection_bootstrap()
 
         # On Linux, the default 'fork' start method is unsafe when Qt is
@@ -682,11 +745,10 @@ class WorkScheduler:
             self._mp_context = multiprocessing.get_context("forkserver")
         else:
             self._mp_context = multiprocessing.get_context("spawn")
-        self._process_executor = self._create_process_executor()
-        self._thread_executor = ThreadPoolExecutor(
-            max_workers=self._thread_budget,
-            initializer=initialize_thread_worker,
-        )
+        # Both pools are self-healing: if a worker dies (process) or fails to
+        # initialize (thread), the wrapper rebuilds the pool on the next submit.
+        self._process_pool = _RestartableExecutor("ProcessPoolExecutor", self._create_process_executor)
+        self._thread_pool = _RestartableExecutor("ThreadPoolExecutor", self._create_thread_executor)
 
         if self._config._process_priority_tokens is not None:
             self._process_tokens = _normalize_explicit_priority_tokens(
@@ -744,7 +806,7 @@ class WorkScheduler:
     ) -> Future[Any]:
         sem = self._process_semaphores[priority]
         sem.acquire()
-        future = self._process_executor.submit(fn, *args, **kwargs)
+        future = self._process_pool.submit(fn, *args, **kwargs)
         future.add_done_callback(lambda _f: sem.release())
         return future
 
@@ -757,15 +819,14 @@ class WorkScheduler:
     ) -> Future[Any]:
         sem = self._thread_semaphores[priority]
         sem.acquire()
-        future = self._thread_executor.submit(fn, *args, **kwargs)
+        future = self._thread_pool.submit(fn, *args, **kwargs)
         future.add_done_callback(lambda _f: sem.release())
         return future
 
     def _create_process_executor(self) -> ProcessPoolExecutor:
-        """Build a ProcessPoolExecutor with the scheduler's worker initializer.
+        """Factory for a ProcessPoolExecutor with the scheduler's worker initializer.
 
-        Used both for the initial pool and when restarting a pool that has
-        broken (`_restart_process_executor_locked`).
+        Used by `_process_pool` for both the initial pool and every restart.
         """
         return ProcessPoolExecutor(
             max_workers=self._process_budget,
@@ -774,47 +835,16 @@ class WorkScheduler:
             initargs=(self._service_address, self._service_authkey),
         )
 
-    def _restart_process_executor_locked(self) -> None:
-        """Replace a broken ProcessPoolExecutor with a fresh one.
-
-        A `ProcessPoolExecutor` becomes permanently unusable once any worker
-        process dies abruptly (OOM kill, segfault, native crash): every later
-        `submit()` raises `BrokenProcessPool`. We swap in a brand-new pool so
-        the scheduler keeps functioning.
-
-        Caller must hold `_state_lock` (every submit path does), which makes the
-        executor swap safe. Futures already dispatched to the dead pool keep
-        their `BrokenProcessPool` exception; their existing done-callbacks still
-        fire `_on_unit_done`, releasing semaphores and decrementing
-        `_in_flight_ram_bytes`, so capacity accounting self-heals.
-        """
-        broken_executor = self._process_executor
-        self._process_executor = self._create_process_executor()
-        logger.warning("ProcessPoolExecutor was broken; restarted with a fresh pool.")
-        try:
-            broken_executor.shutdown(wait=False, cancel_futures=True)
-        except Exception:
-            logger.exception("Error shutting down broken ProcessPoolExecutor")
-
-    def _submit_work_unit_with_recovery_locked(self, work_unit: WorkUnit, executor: Any) -> Future[Any]:
-        """Submit a work unit, restarting a broken process pool once on failure.
-
-        Caller must hold `_state_lock`. On the common case (a process pool that
-        broke once) the restart succeeds and the retried submit goes through
-        transparently. A second `BrokenProcessPool` on a freshly created pool
-        indicates a fatal environment problem and is propagated.
-        """
-        try:
-            return executor.submit(self._execute_work_unit, work_unit)
-        except BrokenProcessPool:
-            if work_unit.executor_kind != "process":
-                raise
-            self._restart_process_executor_locked()
-            return self._process_executor.submit(self._execute_work_unit, work_unit)
+    def _create_thread_executor(self) -> ThreadPoolExecutor:
+        """Factory for a ThreadPoolExecutor. Used by `_thread_pool` on init and restart."""
+        return ThreadPoolExecutor(
+            max_workers=self._thread_budget,
+            initializer=initialize_thread_worker,
+        )
 
     def shutdown(self, wait: bool = True) -> None:
-        self._thread_executor.shutdown(wait=wait)
-        self._process_executor.shutdown(wait=wait)
+        self._thread_pool.shutdown(wait=wait)
+        self._process_pool.shutdown(wait=wait)
 
     def process_tokens(self) -> Dict[PriorityClass, int]:
         return dict(self._process_tokens)
@@ -1158,16 +1188,15 @@ class WorkScheduler:
 
         required_ram_bytes = item.work_unit.ram_peak_est_bytes
         stage_state = plan_state.stage_states[item.stage_id]
-        executor = (
-            self._process_executor if item.work_unit.executor_kind == "process" else self._thread_executor
-        )
-        # Submit before mutating in-flight bookkeeping: a broken process pool is
-        # restarted and the submit retried, but if the retry still fails we must
-        # not leave phantom RAM/unit accounting behind. Release the held token
-        # and re-raise so the caller never accounts for work that never started.
+        pool = self._process_pool if item.work_unit.executor_kind == "process" else self._thread_pool
+        # Submit before mutating in-flight bookkeeping: a broken pool is restarted
+        # and the submit retried inside `pool.submit`, but if the retry still
+        # fails we must not leave phantom RAM/unit accounting behind. Release the
+        # held token and re-raise so the caller never accounts for work that
+        # never started.
         try:
-            future = self._submit_work_unit_with_recovery_locked(item.work_unit, executor)
-        except BrokenProcessPool:
+            future = pool.submit(self._execute_work_unit, item.work_unit)
+        except BrokenExecutor:
             sem.release()
             raise
         # Mark as submitted after dispatch so stage accounting reflects in-flight work.

--- a/src/wiser/utils/work_scheduler.py
+++ b/src/wiser/utils/work_scheduler.py
@@ -1158,7 +1158,19 @@ class WorkScheduler:
 
         required_ram_bytes = item.work_unit.ram_peak_est_bytes
         stage_state = plan_state.stage_states[item.stage_id]
-        # Mark as submitted before dispatch so stage accounting reflects in-flight work.
+        executor = (
+            self._process_executor if item.work_unit.executor_kind == "process" else self._thread_executor
+        )
+        # Submit before mutating in-flight bookkeeping: a broken process pool is
+        # restarted and the submit retried, but if the retry still fails we must
+        # not leave phantom RAM/unit accounting behind. Release the held token
+        # and re-raise so the caller never accounts for work that never started.
+        try:
+            future = self._submit_work_unit_with_recovery_locked(item.work_unit, executor)
+        except BrokenProcessPool:
+            sem.release()
+            raise
+        # Mark as submitted after dispatch so stage accounting reflects in-flight work.
         stage_state.submitted_unit_ids.add(item.work_unit.unit_id)
         self._in_flight_ram_bytes += required_ram_bytes
         if self._recorder is not None:
@@ -1169,10 +1181,6 @@ class WorkScheduler:
                 executor_kind=item.work_unit.executor_kind,
                 priority_class=item.work_unit.priority_class,
             )
-        executor = (
-            self._process_executor if item.work_unit.executor_kind == "process" else self._thread_executor
-        )
-        future = executor.submit(self._execute_work_unit, item.work_unit)
         # Defer callback attachment until after lock release to avoid immediate
         # callback re-entry (`add_done_callback` can invoke synchronously).
         self._pending_done_callbacks.append(


### PR DESCRIPTION
## What does this change do?
When a broken process pool error happens, this PR will make a new process pool executor and swap it in. This will also work for if a thread pool executor breaks.

Closes #550

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [x] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
If we get a BrokenExecutor error, then we can't use either our process pool executor or thread pool executor anymore and a lot of WISER functionality would no longer work. By reacting to this and substituting the broken executor out, we are able to easily fix the problem. This would happen on the main thread.

## Added tests?
- [X] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->