### PR TITLE
feat: fix unmasked nans breaking pca and mnf

### DIFF
--- a/src/tests/test_mnf.py
+++ b/src/tests/test_mnf.py
@@ -18,6 +18,13 @@ from wiser.utils.storage_client import StorageClient
 from wiser.utils.primitives import ExternalRasterHandle
 from wiser.utils.task_system import AlgorithmPipeline, SemanticTask
 
+from tests.utils import (
+    NAN_INF_BAD_BANDS,
+    NAN_INF_DATA_IGNORE_VALUE,
+    assert_reduction_drops_invalid_pixels,
+    build_unmasked_nan_inf_cube,
+)
+
 pytestmark = [
     pytest.mark.integration,
 ]
@@ -292,6 +299,52 @@ class TestMnf(unittest.TestCase):
                 # I can't find the actual problem because the divisor is the same and the
                 # X data should be the same
                 self.assertTrue(np.allclose(np.abs(ours), np.abs(theirs), atol=3e-1))
+        finally:
+            if storage_client is not None:
+                storage_client.close()
+            release_kept_refs(app_services)
+            app_services.scheduler.shutdown(wait=True)
+            app_services.storage_service.close()
+
+    def test_get_mnf_pipeline_handles_unmasked_nan_and_inf(self) -> None:
+        # Synthetic cube with a bad band, a nodata sentinel, and unmasked
+        # NaN/+Inf/-Inf in good bands. MNF must drop those spectra (via the shared
+        # finite_unmasked_row_mask cleaning) and write the nodata fill at them.
+        dataset = RasterDataLoader().dataset_from_numpy_array(build_unmasked_nan_inf_cube())
+        dataset.set_bad_bands(NAN_INF_BAD_BANDS)
+        dataset.set_data_ignore_value(NAN_INF_DATA_IGNORE_VALUE)
+
+        app_services = self.test_model.app_services
+        storage_client = None
+        try:
+            dataset_ref = app_services.storage_service.register_external(
+                ExternalRasterHandle(dataset_obj=dataset)
+            )
+            num_components = 2
+            output_ref_name = "mnf_nan_output"
+            mnf_pipeline = get_mnf_pipeline(
+                dataset_ref, num_components=num_components, output_ref_name=output_ref_name
+            )
+            mnf_pipeline.stages[-1].set_output_delete_policy(output_ref_name, DeletePolicy.KEEP)
+            task = SemanticTask(
+                priority_class=PriorityClass.BACKGROUND,
+                input_ref=dataset_ref,
+                algorithm_pipeline=mnf_pipeline,
+            )
+            task.id = 2005
+
+            task_plan = app_services.task_planner.plan_semantic_task(task)
+            future = app_services.scheduler.run_task_plan(task_plan)
+            future.result(timeout=180)
+
+            listener_address, listener_authkey = app_services.storage_service.get_connection_bootstrap()
+            storage_client = StorageClient(
+                service=None,  # type: ignore[arg-type]
+                service_address=listener_address,
+                service_authkey=listener_authkey,
+            )
+            output, _ = storage_client.read_data(task_plan.bindings[output_ref_name])
+            assert_reduction_drops_invalid_pixels(self, output, num_components)
         finally:
             if storage_client is not None:
                 storage_client.close()

--- a/src/tests/test_pca_task.py
+++ b/src/tests/test_pca_task.py
@@ -15,12 +15,20 @@ from wiser.gui.permanent_plugins.pca_plugin import (
     PCAPluginTask,
     compute_max_pca_components,
 )
+from wiser.raster.loader import RasterDataLoader
 from wiser.raster.utils import compute_PCA_on_image
 from wiser.utils.primitives import DeletePolicy, PriorityClass
 from wiser.utils.storage_client import StorageClient
 from wiser.utils.primitives import ExternalRasterHandle
 from wiser.utils.task_stage_utils import get_pca_pipeline
 from wiser.utils.task_system import SemanticTask
+
+from tests.utils import (
+    NAN_INF_BAD_BANDS,
+    NAN_INF_DATA_IGNORE_VALUE,
+    assert_reduction_drops_invalid_pixels,
+    build_unmasked_nan_inf_cube,
+)
 
 
 class TestPcaTask(unittest.TestCase):
@@ -202,6 +210,58 @@ class TestPcaTask(unittest.TestCase):
             self.assertTrue(hasattr(plugin, "_last_pca_task"))
             self.assertTrue(hasattr(plugin._last_pca_task, "_pca_widget"))
         finally:
+            release_kept_refs(app_services)
+            app_services.scheduler.shutdown(wait=True)
+            app_services.storage_service.close()
+
+    def test_pca_pipeline_handles_unmasked_nan_and_inf(self) -> None:
+        # Synthetic cube with a bad band, a nodata sentinel, and unmasked
+        # NaN/+Inf/-Inf in good bands. Before the shared finite_unmasked_row_mask
+        # cleaning fix, the PCA pipeline fed those into sklearn and raised
+        # "Input X contains NaN".
+        dataset = RasterDataLoader().dataset_from_numpy_array(build_unmasked_nan_inf_cube())
+        dataset.set_bad_bands(NAN_INF_BAD_BANDS)
+        dataset.set_data_ignore_value(NAN_INF_DATA_IGNORE_VALUE)
+
+        app_services = self.test_model.app_services
+        storage_client = None
+        try:
+            dataset_ref = app_services.storage_service.register_external(
+                ExternalRasterHandle(dataset_obj=dataset)
+            )
+            num_components = 3
+            output_ref_name = "pca_nan_output"
+            pca_json_ref_name = "pca_nan_model"
+            pca_pipeline = get_pca_pipeline(
+                dataset_ref=dataset_ref,
+                num_components=num_components,
+                output_ref_name=output_ref_name,
+                pca_json_ref_name=pca_json_ref_name,
+            )
+            pca_pipeline.stages[-1].set_output_delete_policy(output_ref_name, DeletePolicy.KEEP)
+            pca_pipeline.stages[-1].set_output_delete_policy(pca_json_ref_name, DeletePolicy.KEEP)
+            task = SemanticTask(
+                priority_class=PriorityClass.BACKGROUND,
+                input_ref=dataset_ref,
+                algorithm_pipeline=pca_pipeline,
+            )
+            task.id = 3002
+
+            task_plan = app_services.task_planner.plan_semantic_task(task)
+            future = app_services.scheduler.run_task_plan(task_plan)
+            future.result(timeout=180)
+
+            listener_address, listener_authkey = app_services.storage_service.get_connection_bootstrap()
+            storage_client = StorageClient(
+                service=None,  # type: ignore[arg-type]
+                service_address=listener_address,
+                service_authkey=listener_authkey,
+            )
+            output, _ = storage_client.read_data(task_plan.bindings[output_ref_name])
+            assert_reduction_drops_invalid_pixels(self, output, num_components)
+        finally:
+            if storage_client is not None:
+                storage_client.close()
             release_kept_refs(app_services)
             app_services.scheduler.shutdown(wait=True)
             app_services.storage_service.close()

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -4,19 +4,13 @@ from PySide2.QtCore import *
 from PySide2.QtGui import *
 from PySide2.QtWidgets import *
 
-from PySide2 import QtCore, QtWidgets, QtTest, QtGui
-
 
 # Shared fixture for the PCA/MNF "unmasked NaN/Inf" regression tests in
-# test_pca_task.py and test_mnf.py. The cube carries one bad band, a nodata
-# sentinel at fully-masked pixels, and unmasked NaN/+Inf/-Inf in good bands —
-# the case that made PCA feed NaN into sklearn before the cleaning fix.
+# test_pca_task.py and test_mnf.py
 NAN_INF_BANDS, NAN_INF_HEIGHT, NAN_INF_WIDTH = 5, 12, 12
 NAN_INF_DATA_IGNORE_VALUE = -9999.0
-# Band 2 is bad -> 4 good bands remain.
 NAN_INF_BAD_BANDS = [1, 1, 0, 1, 1]
-# (y, x) pixels cleaning must drop; the reduction output must carry the nodata
-# fill at exactly these locations.
+# (y, x) pixels cleaning must drop by nodata value
 NAN_INF_INVALID_YX = [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
 
 

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -1,8 +1,64 @@
+import numpy as np
+
 from PySide2.QtCore import *
 from PySide2.QtGui import *
 from PySide2.QtWidgets import *
 
 from PySide2 import QtCore, QtWidgets, QtTest, QtGui
+
+
+# Shared fixture for the PCA/MNF "unmasked NaN/Inf" regression tests in
+# test_pca_task.py and test_mnf.py. The cube carries one bad band, a nodata
+# sentinel at fully-masked pixels, and unmasked NaN/+Inf/-Inf in good bands —
+# the case that made PCA feed NaN into sklearn before the cleaning fix.
+NAN_INF_BANDS, NAN_INF_HEIGHT, NAN_INF_WIDTH = 5, 12, 12
+NAN_INF_DATA_IGNORE_VALUE = -9999.0
+# Band 2 is bad -> 4 good bands remain.
+NAN_INF_BAD_BANDS = [1, 1, 0, 1, 1]
+# (y, x) pixels cleaning must drop; the reduction output must carry the nodata
+# fill at exactly these locations.
+NAN_INF_INVALID_YX = [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
+
+
+def build_unmasked_nan_inf_cube() -> np.ndarray:
+    """Return a ``[b][y][x]`` float32 cube for the NaN/Inf regression tests.
+
+    Pixels (0,0) and (1,1) are fully nodata (every band is the sentinel, so they
+    are masked at read time). Good-band pixels (2,2)/(3,3)/(4,4) carry an unmasked
+    NaN/+Inf/-Inf respectively, so neither bad-band nor nodata masking removes
+    them. Pair with :data:`NAN_INF_BAD_BANDS` and :data:`NAN_INF_DATA_IGNORE_VALUE`
+    via ``dataset.set_bad_bands`` / ``dataset.set_data_ignore_value``.
+    """
+    rng = np.random.default_rng(0)
+    cube = (
+        rng.standard_normal((NAN_INF_BANDS, NAN_INF_HEIGHT, NAN_INF_WIDTH)).astype(np.float32) * 50.0 + 1000.0
+    )
+    cube[:, 0, 0] = NAN_INF_DATA_IGNORE_VALUE
+    cube[:, 1, 1] = NAN_INF_DATA_IGNORE_VALUE
+    cube[0, 2, 2] = np.nan
+    cube[1, 3, 3] = np.inf
+    cube[3, 4, 4] = -np.inf
+    return cube
+
+
+def assert_reduction_drops_invalid_pixels(test_case, output, num_components: int) -> None:
+    """Assert a PCA/MNF reduction wrote the nodata fill at every invalid pixel and
+    finite components everywhere else.
+
+    ``output`` is the ``[y][x][component]`` cube read back from the pipeline.
+    """
+    out = np.asarray(np.ma.getdata(output))
+    test_case.assertEqual(out.shape, (NAN_INF_HEIGHT, NAN_INF_WIDTH, num_components))
+
+    valid_mask = np.ones((NAN_INF_HEIGHT, NAN_INF_WIDTH), dtype=bool)
+    for y, x in NAN_INF_INVALID_YX:
+        valid_mask[y, x] = False
+        test_case.assertTrue(
+            np.allclose(out[y, x, :], NAN_INF_DATA_IGNORE_VALUE),
+            f"Invalid pixel {(y, x)} should carry the nodata fill, got {out[y, x, :]}",
+        )
+    # Every surviving pixel produced finite components (no NaN/Inf leaked through).
+    test_case.assertTrue(np.all(np.isfinite(out[valid_mask])))
 
 
 def are_pixels_close(pixel1, pixel2) -> bool:

--- a/src/wiser/gui/mnf.py
+++ b/src/wiser/gui/mnf.py
@@ -582,7 +582,7 @@ class MNFSemanticTask(QObject, SemanticTask):
                 input_dataset_name_snapshot=source_name,
                 num_components_chosen=self._num_components_chosen,
                 max_components_available=self._max_components_available,
-                eigenvalues=np.asarray(eigenvalues, dtype=np.float64),
+                eigenvalues=np.asarray(eigenvalues, dtype=np.float64)[: self._num_components_chosen],
             )
         )
 

--- a/src/wiser/gui/permanent_plugins/pca_plugin.py
+++ b/src/wiser/gui/permanent_plugins/pca_plugin.py
@@ -357,6 +357,7 @@ class PCAPlugin(plugins.ContextMenuPlugin):
             app = getattr(app_state, "_app", None)
             app_services = getattr(app, "_app_services", None)
 
+        # Fall back to synchronous calculation
         if test_mode or app_services is None:
             image_arr = dataset.get_image_data()
             masked_arr, pca = compute_PCA_on_image(

--- a/src/wiser/raster/utils.py
+++ b/src/wiser/raster/utils.py
@@ -216,6 +216,27 @@ def create_pca_metadata_widget(pca, dataset, parent=None) -> QWidget:
     return PcaMetadataWidget(pca, dataset, parent)
 
 
+def finite_unmasked_row_mask(
+    flattened_data: np.ndarray,
+    flattened_mask: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    """Boolean ``[N]`` selecting usable rows of a ``[N][bands]`` spectra list.
+
+    A row is usable iff every band is finite (no NaN/Inf) and — when a mask is
+    supplied — every band is unmasked. A single bad feature invalidates the whole
+    spectrum, so callers (PCA fit, MNF mean/covariance) drop the entire row.
+
+    This is the single source of truth for "is this spectrum analysis-ready",
+    shared by :func:`compute_PCA_on_image` and the pipeline's
+    ``_flatten_valid_dataset_rows`` so PCA and MNF clean identically.
+    """
+    data = np.asarray(flattened_data)
+    valid = np.all(np.isfinite(data), axis=1)
+    if flattened_mask is not None:
+        valid &= ~np.any(np.asarray(flattened_mask, dtype=bool), axis=1)
+    return valid
+
+
 def compute_PCA_on_image(
     image_arr: Union[np.ndarray, np.ma.masked_array],
     num_components: int,
@@ -268,14 +289,17 @@ def compute_PCA_on_image(
     # [y][x][2] --> [y*x][2]
     coords = coords.reshape((coords.shape[0] * coords.shape[1], coords.shape[2]))
 
-    if isinstance(image_arr, np.ma.MaskedArray):
-        # It is possible for the masked array to not have a mask
-        if image_arr.mask is not np.ma.nomask:
-            mask_1d = ~np.all(image_arr.mask == True, axis=1)  # noqa: E712
-            image_arr = image_arr.data[mask_1d, :]
-            coords = coords[mask_1d, :]
-            if not np.isfinite(image_arr).all():
-                raise ValueError("Array contains a non-numeric value after cleaning!")
+    # Drop any spectrum that is masked (nodata / bad-band sentinel) or holds a
+    # non-finite value (NaN/Inf) in any kept band before fitting. sklearn's PCA
+    # rejects NaN/Inf outright, and a single bad feature makes the whole spectrum
+    # unusable.
+    row_data = np.asarray(np.ma.getdata(image_arr))
+    row_mask = np.ma.getmaskarray(image_arr) if isinstance(image_arr, np.ma.MaskedArray) else None
+    valid_rows = finite_unmasked_row_mask(row_data, row_mask)
+    image_arr = row_data[valid_rows, :]
+    coords = coords[valid_rows, :]
+    if image_arr.shape[0] == 0:
+        raise ValueError("No valid spectra remain for PCA after removing masked/non-finite pixels")
 
     pca = PCA(n_components=num_components)
 

--- a/src/wiser/utils/task_stage_utils.py
+++ b/src/wiser/utils/task_stage_utils.py
@@ -39,7 +39,10 @@ from wiser.utils.task_system import (
     WriteSpec,
 )
 from wiser.utils.worker_runtime import get_process_storage_client
-from wiser.raster.utils import compute_PCA_on_image
+from wiser.raster.utils import (
+    compute_PCA_on_image,
+    finite_unmasked_row_mask,
+)
 from wiser.utils.numba_wrapper import convert_to_float32_if_needed
 
 PCA_MEMORY_CUTOFF_BYTES = 4 * 1024**3
@@ -2417,10 +2420,11 @@ def _flatten_valid_dataset_rows(
     filtered_data = data_raw[:, :, good_band_mask]
     filtered_mask = data_mask[:, :, good_band_mask]
     flattened = filtered_data.reshape(-1, filtered_data.shape[2])
+    flattened_mask = filtered_mask.reshape(-1, filtered_mask.shape[2])
     # Drop any pixel whose surviving bands still contain masked, NaN, or Inf values.
-    invalid_rows = np.any(filtered_mask.reshape(-1, filtered_mask.shape[2]), axis=1)
-    invalid_rows |= np.any(~np.isfinite(flattened), axis=1)
-    return flattened[~invalid_rows]
+    # Shared with compute_PCA_on_image so PCA and MNF apply identical row validity.
+    valid_rows = finite_unmasked_row_mask(flattened, flattened_mask)
+    return flattened[valid_rows]
 
 
 def count_valid_dataset_pixels(dataset_ref: DataRef) -> int:


### PR DESCRIPTION
## What does this change do?
If a dataset doesn't properly mask out their NaNs then it would not be able to go through PCA or MNF.  We get the error in #553. This change fixes that and writes tests for it. 

Closes #553 

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [X] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
So people can do PCA on images that they did not properly mask.

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->