### PR TITLE
feat: make decorrelation stretch resistant to datasets with unmasked NaNs

### DIFF
--- a/src/tests/test_decorrelation_stretch.py
+++ b/src/tests/test_decorrelation_stretch.py
@@ -13,6 +13,8 @@ from wiser.raster.decorrelation_stretch import (
     compute_decorrelation_stretch,
     compute_decorrelation_stretch_numba,
     compute_decorrelation_stretch_numpy,
+    decor_numba,
+    decor_numpy,
 )
 from wiser.utils.task_stage_utils import (
     EigenVectorsAndValues,
@@ -146,6 +148,49 @@ class TestDecorrelationStretchStage(unittest.TestCase):
             release_kept_refs(app_services)
             app_services.scheduler.shutdown(wait=True)
             app_services.storage_service.close()
+
+
+class TestDecorrelationStretchNanResistance(unittest.TestCase):
+    """The kernels must tolerate unmasked NaN/Inf pixels: one bad pixel must not
+    poison the transform for every other pixel. Pre-fix, the covariance went
+    non-finite and numba's eigh raised LinAlgError (aborting the GUI render);
+    the NumPy path produced all-NaN output (black image)."""
+
+    @staticmethod
+    def _make_correlated_bands():
+        rng = np.random.default_rng(0)
+        height, width = 8, 9
+        b0 = rng.standard_normal((height, width)) * 10.0 + 100.0
+        # Correlate b1/b2 with b0 so the covariance is non-degenerate.
+        b1 = 0.5 * b0 + rng.standard_normal((height, width)) * 5.0 + 50.0
+        b2 = 0.3 * b0 + rng.standard_normal((height, width)) * 2.0 + 20.0
+        return b0, b1, b2
+
+    def test_kernels_tolerate_unmasked_nan_and_inf(self) -> None:
+        b0, b1, b2 = self._make_correlated_bands()
+        # Inject non-finite values at distinct pixels across the three bands.
+        invalid_pixels = [(0, 0), (3, 4), (7, 8)]
+        b0[0, 0] = np.nan
+        b1[3, 4] = np.inf
+        b2[7, 8] = -np.inf
+
+        result_numpy = decor_numpy(b0, b1, b2)
+        result_numba = decor_numba(b0, b1, b2)
+
+        self.assertEqual(result_numpy.shape, (8, 9, 3))
+        self.assertEqual(result_numba.shape, (8, 9, 3))
+
+        # A pixel is valid iff all three input bands are finite there.
+        valid = np.isfinite(b0) & np.isfinite(b1) & np.isfinite(b2)
+        for y, x in invalid_pixels:
+            self.assertFalse(valid[y, x])
+
+        # Every valid pixel produced finite output (pre-fix: all-NaN / LinAlgError).
+        self.assertTrue(np.all(np.isfinite(result_numpy[valid])))
+        self.assertTrue(np.all(np.isfinite(result_numba[valid])))
+
+        # numba and numpy agree at the valid pixels.
+        self.assertTrue(np.allclose(result_numpy[valid], result_numba[valid], atol=1e-10))
 
 
 if __name__ == "__main__":

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -4,19 +4,13 @@ from PySide2.QtCore import *
 from PySide2.QtGui import *
 from PySide2.QtWidgets import *
 
-from PySide2 import QtCore, QtWidgets, QtTest, QtGui
-
 
 # Shared fixture for the PCA/MNF "unmasked NaN/Inf" regression tests in
-# test_pca_task.py and test_mnf.py. The cube carries one bad band, a nodata
-# sentinel at fully-masked pixels, and unmasked NaN/+Inf/-Inf in good bands —
-# the case that made PCA feed NaN into sklearn before the cleaning fix.
+# test_pca_task.py and test_mnf.py
 NAN_INF_BANDS, NAN_INF_HEIGHT, NAN_INF_WIDTH = 5, 12, 12
 NAN_INF_DATA_IGNORE_VALUE = -9999.0
-# Band 2 is bad -> 4 good bands remain.
 NAN_INF_BAD_BANDS = [1, 1, 0, 1, 1]
-# (y, x) pixels cleaning must drop; the reduction output must carry the nodata
-# fill at exactly these locations.
+# (y, x) pixels cleaning must drop by nodata value
 NAN_INF_INVALID_YX = [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
 
 

--- a/src/wiser/raster/decorrelation_stretch.py
+++ b/src/wiser/raster/decorrelation_stretch.py
@@ -296,21 +296,35 @@ def decor_numpy(band0: np.ndarray, band1: np.ndarray, band2: np.ndarray) -> np.n
     """
     Pure NumPy decorrelation stretch on three [y][x] float64 band arrays.
     Returns [y][x][3] float64.
+
+    Fits the transform (mean, covariance, eigendecomposition) on the finite
+    pixels only: a single NaN/Inf pixel otherwise poisons the mean/covariance and
+    makes ``eigh`` fail. This mirrors how the PCA/MNF pipelines drop non-finite
+    spectra before building their covariance (see
+    ``_flatten_valid_dataset_rows`` in task_stage_utils.py). The transform is then
+    applied to every pixel; non-finite inputs yield non-finite outputs, which the
+    caller (``StretchDecorrelation.apply_multi``) already zeroes out.
     """
     height, width = band0.shape
     flat = np.stack([band0.ravel(), band1.ravel(), band2.ravel()], axis=1)
 
-    mean = flat.mean(axis=0)
-    centered = flat - mean
-    n = flat.shape[0]
+    # A pixel is usable only if all three bands are finite there.
+    valid = np.all(np.isfinite(flat), axis=1)
+    valid_flat = flat[valid]
+    n = valid_flat.shape[0]
+    if n < 2:
+        # Too few finite pixels to estimate a covariance; nothing to stretch.
+        return np.zeros((height, width, 3), dtype=np.float64)
 
-    cov = centered.T @ centered / (n - 1)
+    mean = valid_flat.mean(axis=0)
+    centered_valid = valid_flat - mean
+    cov = centered_valid.T @ centered_valid / (n - 1)
     eigenvalues, eigenvectors = np.linalg.eigh(cov)
     R = eigenvectors.T
     reciprocal_sqrt = np.where(eigenvalues > 0.0, 1.0 / np.sqrt(eigenvalues), 0.0)
     T = R.T @ (reciprocal_sqrt[:, np.newaxis] * R)
 
-    return (centered @ T + mean).reshape(height, width, 3)
+    return ((flat - mean) @ T + mean).reshape(height, width, 3)
 
 
 _decor_sig = types.float64[:, :, :](types.float64[:, :], types.float64[:, :], types.float64[:, :])
@@ -337,15 +351,48 @@ def decor_numba(band0: np.ndarray, band1: np.ndarray, band2: np.ndarray) -> np.n
             flat[k, 2] = band2[i, j]
             k += 1
 
+    # Accumulate the mean over finite pixels only -- a single NaN/Inf pixel
+    # otherwise poisons the mean/covariance and makes eigh raise LinAlgError.
+    # Mirrors the finite-row masking in decor_numpy (kept inline so the kernel
+    # stays njit-compilable and bit-compatible with the NumPy fallback).
     mean = np.zeros(3, dtype=np.float64)
+    n_valid = 0
     for i in range(n):
-        mean[0] += flat[i, 0]
-        mean[1] += flat[i, 1]
-        mean[2] += flat[i, 2]
-    mean /= n
+        v0 = flat[i, 0]
+        v1 = flat[i, 1]
+        v2 = flat[i, 2]
+        if np.isfinite(v0) and np.isfinite(v1) and np.isfinite(v2):
+            mean[0] += v0
+            mean[1] += v1
+            mean[2] += v2
+            n_valid += 1
 
-    centered = flat - mean
-    cov = np.dot(centered.T, centered) / (n - 1)
+    if n_valid < 2:
+        # Too few finite pixels to estimate a covariance; nothing to stretch.
+        return np.zeros((height, width, 3), dtype=np.float64)
+
+    mean /= n_valid
+
+    # Covariance over finite pixels only.
+    cov = np.zeros((3, 3), dtype=np.float64)
+    for i in range(n):
+        v0 = flat[i, 0]
+        v1 = flat[i, 1]
+        v2 = flat[i, 2]
+        if np.isfinite(v0) and np.isfinite(v1) and np.isfinite(v2):
+            c0 = v0 - mean[0]
+            c1 = v1 - mean[1]
+            c2 = v2 - mean[2]
+            cov[0, 0] += c0 * c0
+            cov[0, 1] += c0 * c1
+            cov[0, 2] += c0 * c2
+            cov[1, 0] += c1 * c0
+            cov[1, 1] += c1 * c1
+            cov[1, 2] += c1 * c2
+            cov[2, 0] += c2 * c0
+            cov[2, 1] += c2 * c1
+            cov[2, 2] += c2 * c2
+    cov /= n_valid - 1
 
     eigenvalues, eigenvectors = np.linalg.eigh(cov)
     R = eigenvectors.T  # one eigenvector per row
@@ -358,6 +405,9 @@ def decor_numba(band0: np.ndarray, band1: np.ndarray, band2: np.ndarray) -> np.n
     scaled_R = recip_sqrt.reshape(3, 1) * R
     T = np.dot(R.T, scaled_R)
 
+    # Apply to every pixel; non-finite inputs propagate to non-finite outputs,
+    # which the caller zeroes. eigh above only saw the clean covariance.
+    centered = flat - mean
     result_flat = np.dot(centered, T) + mean
     return result_flat.reshape(height, width, 3)
 


### PR DESCRIPTION
## What does this change do?
This allows decorrelation stretch to work  on datasets with unmasked NaNs.

Closes #555

## What type of PR is this? (check all applicable) 
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->