### PR TITLE
feat: Remove input spectrum from mtmf

### DIFF
--- a/src/wiser/gui/mtmf.py
+++ b/src/wiser/gui/mtmf.py
@@ -1419,9 +1419,6 @@ class MTMFSemanticTask(QObject, SemanticTask):
 # MTMF dialog
 # ---------------------------------------------------------------------------
 
-_INPUT_TYPE_SPECTRUM = 0
-_INPUT_TYPE_IMAGE_CUBE = 1
-
 
 class _NoiseMethodType(IntEnum):
     ROI_BASED = 0
@@ -1446,10 +1443,6 @@ class MTMFDialog(QDialog):
         self._ui = Ui_MTMF_Dialog()
         self._ui.setupUi(self)
 
-        self._ui.cbox_input_type.addItem(self.tr("Spectrum"), _INPUT_TYPE_SPECTRUM)
-        self._ui.cbox_input_type.addItem(self.tr("Image Cube"), _INPUT_TYPE_IMAGE_CUBE)
-        self._ui.cbox_input_type.currentIndexChanged.connect(lambda _i: self._populate_input_combo())
-
         self._ui.cbox_noise_method_type.addItem(self.tr("ROI Based"), _NoiseMethodType.ROI_BASED)
         self._ui.cbox_noise_method_type.addItem(
             self.tr("Dark Image Based"), _NoiseMethodType.DARK_IMAGE_BASED
@@ -1464,7 +1457,6 @@ class MTMFDialog(QDialog):
         self._populate_noise_combo()
         self._on_noise_method_type_changed()
         self._populate_target_combo()
-        self._ui.cbox_input_type.setCurrentIndex(1)
         self._populate_input_combo()
 
     def showEvent(self, event) -> None:
@@ -1513,16 +1505,9 @@ class MTMFDialog(QDialog):
                 self._ui.cbox_shift_diff_method.setCurrentIndex(idx)
 
     def _on_spectra_changed(self, *_args) -> None:
-        """Refresh spectrum-backed combos, preserving current selections."""
-        prev_input = self._ui.cbox_input.currentData()
+        """Refresh the target combo, preserving the current selection."""
         prev_target = self._ui.cbox_target.currentData()
         self._populate_target_combo()
-        if self._ui.cbox_input_type.currentData() == _INPUT_TYPE_SPECTRUM:
-            self._populate_input_combo()
-            if prev_input is not None:
-                idx = self._ui.cbox_input.findData(prev_input)
-                if idx >= 0:
-                    self._ui.cbox_input.setCurrentIndex(idx)
         if prev_target is not None:
             idx = self._ui.cbox_target.findData(prev_target)
             if idx >= 0:
@@ -1571,31 +1556,12 @@ class MTMFDialog(QDialog):
                 self._ui.cbox_shift_diff_method.setCurrentIndex(idx)
 
     def select_image_cube_dataset(self, dataset_id: Optional[int]) -> None:
-        """Prefer Image Cube mode and select ``dataset_id`` when present."""
-        idx = self._ui.cbox_input_type.findData(_INPUT_TYPE_IMAGE_CUBE)
-        if idx >= 0:
-            self._ui.cbox_input_type.setCurrentIndex(idx)
+        """Select ``dataset_id`` in the input combo when present."""
         self._populate_input_combo()
         if dataset_id is not None:
             in_idx = self._ui.cbox_input.findData(dataset_id)
             if in_idx >= 0:
                 self._ui.cbox_input.setCurrentIndex(in_idx)
-
-    def _spectra_for_plot_input(self) -> List[Spectrum]:
-        """Active spectrum first, then collected spectra (unique by id)."""
-        seen: set = set()
-        out: List[Spectrum] = []
-        active = self._app_state.get_active_spectrum()
-        if active is not None and active.get_id() is not None:
-            seen.add(active.get_id())
-            out.append(active)
-        for s in self._app_state.get_collected_spectra():
-            sid = s.get_id()
-            if sid is None or sid in seen:
-                continue
-            seen.add(sid)
-            out.append(s)
-        return out
 
     def _populate_combo_with_separator(self, combo, entries: List[tuple]) -> None:
         """Fill combo with (label, userData) pairs, then separator and (no data)."""
@@ -1606,24 +1572,13 @@ class MTMFDialog(QDialog):
         combo.addItem(self.tr("(no data)"), None)
 
     def _populate_input_combo(self) -> None:
-        mode = self._ui.cbox_input_type.currentData()
-        if mode == _INPUT_TYPE_SPECTRUM:
-            pairs = []
-            for sp in self._spectra_for_plot_input():
-                sid = sp.get_id()
-                if sid is None:
-                    continue
-                name = sp.get_name() or self.tr("<unnamed>")
-                pairs.append((name, sid))
-            self._populate_combo_with_separator(self._ui.cbox_input, pairs)
-        else:
-            pairs = []
-            for ds in self._app_state.get_datasets():
-                did = ds.get_id()
-                if did is None:
-                    continue
-                pairs.append((ds.get_name() or self.tr("<unnamed>"), did))
-            self._populate_combo_with_separator(self._ui.cbox_input, pairs)
+        pairs = []
+        for ds in self._app_state.get_datasets():
+            did = ds.get_id()
+            if did is None:
+                continue
+            pairs.append((ds.get_name() or self.tr("<unnamed>"), did))
+        self._populate_combo_with_separator(self._ui.cbox_input, pairs)
 
     def _add_section_header(self, combo, label: str) -> None:
         """Insert a bold, non-selectable section-header item into *combo*."""
@@ -1739,16 +1694,13 @@ class MTMFDialog(QDialog):
         return direction
 
     def _resolve_source_dataset(self) -> RasterDataSet:
-        mode = self._ui.cbox_input_type.currentData()
         data = self._ui.cbox_input.currentData()
         if data is None:
             raise ValueError(self.tr('Select an input source (not "(no data)").'))
-        if mode == _INPUT_TYPE_IMAGE_CUBE:
-            ds = self._app_state.get_dataset(int(data))
-            if ds is None:
-                raise ValueError(self.tr("Selected input dataset is no longer available."))
-            return ds
-        raise ValueError(self.tr("We currently don't support selecting an input spectra."))
+        ds = self._app_state.get_dataset(int(data))
+        if ds is None:
+            raise ValueError(self.tr("Selected input dataset is no longer available."))
+        return ds
 
     def _resolve_shift_diff_direction(self) -> ShiftDiffNoiseDirection:
         direction = self.get_extra_shift_diff_direction()

--- a/src/wiser/gui/ui_files/mtmf_dialog.ui
+++ b/src/wiser/gui/ui_files/mtmf_dialog.ui
@@ -41,7 +41,11 @@
     <widget class="QComboBox" name="cbox_input"/>
    </item>
    <item row="0" column="0">
-    <widget class="QComboBox" name="cbox_input_type"/>
+    <widget class="QLabel" name="lbl_input_type">
+     <property name="text">
+      <string>Select Image Cube</string>
+     </property>
+    </widget>
    </item>
    <item row="4" column="2">
     <widget class="QComboBox" name="cbox_target"/>


### PR DESCRIPTION
## What does this change do?
The MTMF dialog has an input option for an image cube and a spectrum. We don't support the option for the spectrum so we want to delete it. I am not sure that we want to support this in the future.

Closes #559

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [x] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->