### PR TITLE
feat: Fix scheduler work queue logic

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/system-design.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/system-design.md
@@ -144,6 +144,11 @@ Dispatch order is:
 `QueuedWorkUnit.defer_count` is incremented when RAM admission fails. If this count exceeds a threshold, the unit is
 promoted into `ReservedTracker`.
 
+Dispatch is normally **edge-triggered**: queues are drained when a plan is submitted and when a unit completes. A
+periodic background **watchdog** thread (`_watchdog_loop`, interval configured by `SchedulerConfig._watchdog_interval_seconds`)
+re-drains the queues as a safety net, so work that was left parked cannot wedge forever if a normal drain trigger is
+missed. Draining when nothing is admissible is a cheap no-op.
+
 #### RAM and hold-byte model (high level)
 
 The scheduler tracks:
@@ -157,6 +162,12 @@ For reserved units, admission uses full cap (`cap`).
 This prevents non-reserved work from continually consuming all slack while still allowing reserved units to run once
 feasible.
 
+**Run-alone override:** when nothing is in flight (`in_flight == 0`), a unit that still does not fit — most importantly
+one whose `ram_peak_est_bytes` exceeds the whole budget — is admitted anyway, since waiting can never free more RAM.
+The over-budget admission is logged as a warning (running such a unit may exceed available memory). This guarantees a
+single oversized unit with no siblings (e.g. an unchunked stage over a large dataset) runs alone instead of hanging the
+plan forever.
+
 #### ReservedTracker (high level)
 
 `ReservedTracker` keeps per-priority FIFO queues and computes hold bytes from configurable windows (currently
@@ -164,7 +175,11 @@ interactive/render/background = 3/2/1).
 
 It provides:
 
-- deterministic reserved candidate selection,
+- weighted round-robin candidate selection across the priority windows, using a cursor that advances past each served
+  slot (so admission rotates fairly across priorities rather than always draining the highest priority first),
+- head-of-line avoidance: admission scans past an un-admittable head (e.g. an over-budget unit) to serve a fittable
+  candidate in another priority queue, while preserving FIFO order *within* a priority,
+- a run-alone override consistent with the scheduler's RAM model (admit the current head when nothing is in flight),
 - FIFO ownership for reserved units,
 - hold-byte totals used by scheduler RAM admission.
 
@@ -176,9 +191,12 @@ The main methods to understand runtime behavior are:
 - `_enqueue_stage_locked(...)` - places stage units into main queues.
 - `_drain_queues_locked(...)` - main dispatch loop (reserved, blocked, main).
 - `_attempt_submit_reserved_locked(...)` - reserved admission path.
+- `ReservedTracker.next_admissible_reserved_unit(...)` / `advance_reservation_cursor(...)` - round-robin reserved
+  selection (with head-of-line scan and run-alone override) and the cursor advance that keeps it fair.
 - `_submit_non_reserved_from_queues_locked(...)` - blocked/main admission path.
-- `_submit_runnable_item_locked(...)` - final executor submission + in-flight accounting.
+- `_submit_runnable_item_locked(...)` - final executor submission + in-flight accounting (logs over-budget run-alone admissions).
 - `_on_unit_done(...)` - completion accounting, stage progression, and re-dispatch.
+- `_watchdog_loop(...)` - periodic safety-net re-drain so parked work cannot wedge if a drain trigger is missed.
 
 ## Planning Flow
 

--- a/src/tests/test_work_scheduler.py
+++ b/src/tests/test_work_scheduler.py
@@ -530,6 +530,111 @@ class TestWorkScheduler(unittest.TestCase):
                 scheduler.shutdown(wait=True)
                 service.close()
 
+    def test_reserved_head_of_line_does_not_starve_fittable_lower_priority(self) -> None:
+        """An un-admittable (over-budget) reserved head must not starve a fittable
+        reserved unit in another priority queue.
+
+        Plan A holds 800/1000 bytes with a long + short holder. Plan B's oversized
+        INTERACTIVE unit (5000) and fittable RENDER unit (300) both fail admission
+        at in_flight=800 and land in the reserved queue. When the short holder
+        frees RAM (in_flight -> 400) the RENDER unit fits (400+300) but the
+        oversized INTERACTIVE head does not. The scan must look past the stuck head
+        and admit RENDER. The oversized unit only runs later, alone, once the long
+        holder finishes (in_flight -> 0, run-alone override).
+
+        Asserts RENDER is admitted from the reserved queue *before* the oversized
+        unit; before the head-of-line fix the head blocked the scan and RENDER was
+        starved until in_flight hit zero, reversing the order.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = StorageService(root_dir=tmp_dir)
+            scheduler = WorkScheduler(
+                SchedulerConfig(
+                    _process_budget=3,
+                    _thread_budget=15,
+                    _ram_budget=1_000,
+                    _defer_to_reserved_threshold=0,
+                    _thread_priority_tokens={
+                        PriorityClass.INTERACTIVE: 5,
+                        PriorityClass.RENDER: 5,
+                        PriorityClass.BACKGROUND: 5,
+                    },
+                ),
+                service,
+            )
+            try:
+                holder_keep = _make_work_unit(
+                    unit_id="holder-keep",
+                    stage_id="s00",
+                    priority=PriorityClass.INTERACTIVE,
+                    executor_kind="thread",
+                    fn=partial(_sleep_then_return, "holder-keep", 0.8),
+                    ram_peak_est_bytes=400,
+                )
+                holder_temp = _make_work_unit(
+                    unit_id="holder-temp",
+                    stage_id="s00",
+                    priority=PriorityClass.INTERACTIVE,
+                    executor_kind="thread",
+                    fn=partial(_sleep_then_return, "holder-temp", 0.4),
+                    ram_peak_est_bytes=400,
+                )
+                plan_a = TaskPlan(
+                    plan_id="plan-holders",
+                    semantic_task_id="semantic-holders",
+                    work_units={holder_keep.unit_id: holder_keep, holder_temp.unit_id: holder_temp},
+                    stage_work_units={"s00": [holder_keep.unit_id, holder_temp.unit_id]},
+                    fail_fast=True,
+                )
+
+                oversized = _make_work_unit(
+                    unit_id="oversized",
+                    stage_id="s00",
+                    priority=PriorityClass.INTERACTIVE,
+                    executor_kind="thread",
+                    fn=_ok_thread_a,
+                    ram_peak_est_bytes=5_000,
+                )
+                render = _make_work_unit(
+                    unit_id="render",
+                    stage_id="s00",
+                    priority=PriorityClass.RENDER,
+                    executor_kind="thread",
+                    fn=partial(_sleep_then_return, "render", 0.1),
+                    ram_peak_est_bytes=300,
+                )
+                plan_b = TaskPlan(
+                    plan_id="plan-headofline",
+                    semantic_task_id="semantic-headofline",
+                    work_units={oversized.unit_id: oversized, render.unit_id: render},
+                    stage_work_units={"s00": [oversized.unit_id, render.unit_id]},
+                    fail_fast=True,
+                )
+
+                # Plan A drains synchronously, so both holders are in flight
+                # (in_flight=800) before plan B is submitted.
+                future_a = scheduler.run_task_plan(plan_a)
+                future_b = scheduler.run_task_plan(plan_b)
+
+                with self.assertLogs("wiser.utils.work_scheduler", level="WARNING") as log_ctx:
+                    future_b.result(timeout=15)
+                    future_a.result(timeout=15)
+
+                self.assertTrue(
+                    any("exceeds the scheduler RAM budget" in message for message in log_ctx.output),
+                    "expected the oversized unit to be admitted run-alone with a warning",
+                )
+
+                reserved_admitted_order = [
+                    event.unit_id
+                    for event in scheduler.get_queue_transition_log()
+                    if event.reason == "reserved_admitted"
+                ]
+                self.assertEqual(reserved_admitted_order, ["render", "oversized"])
+            finally:
+                scheduler.shutdown(wait=True)
+                service.close()
+
     def test_oversized_lone_unit_runs_alone_instead_of_hanging(self) -> None:
         """A unit whose RAM estimate exceeds the whole budget, with no siblings to
         drive the defer/abort machinery, must be admitted to run alone (with a

--- a/src/tests/test_work_scheduler.py
+++ b/src/tests/test_work_scheduler.py
@@ -350,6 +350,9 @@ class TestWorkScheduler(unittest.TestCase):
                     _thread_budget=3,
                     _ram_budget=5_000,
                     _defer_to_reserved_threshold=2,
+                    # This test asserts the exact defer-count sequence, which extra
+                    # watchdog drains would perturb. Disable the watchdog here.
+                    _watchdog_interval_seconds=0,
                     _process_priority_tokens={
                         PriorityClass.INTERACTIVE: 5,
                         PriorityClass.RENDER: 1,
@@ -636,6 +639,87 @@ class TestWorkScheduler(unittest.TestCase):
                 # from reserved once the filler freed it (in_flight back to zero).
                 self.assertIn("defer_threshold_exceeded", reasons)
                 self.assertIn("reserved_admitted", reasons)
+            finally:
+                scheduler.shutdown(wait=True)
+                service.close()
+
+    def test_watchdog_periodically_drains_and_stops_on_shutdown(self) -> None:
+        """The watchdog re-drives the scheduler on its interval while running, and
+        stops doing so once the scheduler is shut down.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = StorageService(root_dir=tmp_dir)
+            scheduler = WorkScheduler(
+                SchedulerConfig(
+                    _process_budget=3,
+                    _thread_budget=3,
+                    _watchdog_interval_seconds=0.05,
+                ),
+                service,
+            )
+            real_drain = scheduler._drain_queues_locked
+            drain_calls = {"count": 0}
+
+            def counting_drain() -> None:
+                drain_calls["count"] += 1
+                real_drain()
+
+            try:
+                # No plans are submitted, so every drain observed here is the
+                # watchdog ticking (nothing else calls it on an idle scheduler).
+                with patch.object(scheduler, "_drain_queues_locked", counting_drain):
+                    time.sleep(0.3)  # ~6 intervals
+                    ticks_while_running = drain_calls["count"]
+
+                self.assertGreaterEqual(ticks_while_running, 2, "watchdog should re-drive on its interval")
+
+                scheduler.shutdown(wait=True)
+                self.assertIsNone(scheduler._watchdog_thread)
+            finally:
+                scheduler.shutdown(wait=True)
+                service.close()
+
+    def test_watchdog_recovers_stranded_plan_after_missed_drain(self) -> None:
+        """If the drain that `run_task_plan` normally performs is missed, the unit
+        is enqueued but never submitted. The watchdog must re-drive the stranded
+        queue so the plan still completes.
+
+        The missed drain is simulated by suppressing only the initial submit-time
+        drain; the real watchdog and real `_drain_queues_locked` then recover it.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = StorageService(root_dir=tmp_dir)
+            scheduler = WorkScheduler(
+                SchedulerConfig(
+                    _process_budget=3,
+                    _thread_budget=3,
+                    _watchdog_interval_seconds=0.05,
+                ),
+                service,
+            )
+            try:
+                unit = _make_work_unit(
+                    unit_id="u1",
+                    stage_id="s00",
+                    priority=PriorityClass.INTERACTIVE,
+                    executor_kind="thread",
+                    fn=_ok_thread_a,
+                )
+                plan = TaskPlan(
+                    plan_id="plan-stranded",
+                    semantic_task_id="semantic-stranded",
+                    work_units={unit.unit_id: unit},
+                    stage_work_units={"s00": [unit.unit_id]},
+                    fail_fast=True,
+                )
+
+                # Suppress the submit-time drain: the unit lands in the main queue
+                # with no drain scheduled, exactly like a lost wakeup.
+                with patch.object(scheduler, "_drain_queues_locked", lambda: None):
+                    future = scheduler.run_task_plan(plan)
+
+                # Only the watchdog can re-drive the stranded queue now.
+                future.result(timeout=5)
             finally:
                 scheduler.shutdown(wait=True)
                 service.close()

--- a/src/wiser/gui/ui_files/mtmf_dialog.ui
+++ b/src/wiser/gui/ui_files/mtmf_dialog.ui
@@ -60,13 +60,6 @@
    <item row="3" column="2">
     <widget class="QComboBox" name="cbox_shift_diff_method"/>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Input Image Cube</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/wiser/utils/work_scheduler.py
+++ b/src/wiser/utils/work_scheduler.py
@@ -220,6 +220,27 @@ class ReservedTracker:
         self._recompute_hold_bytes()
         return True
 
+    def _iter_candidate_slots(self):
+        """Yield ``(slot_index, head_candidate)`` for each populated slot in
+        round-robin scan order starting at the cursor.
+
+        Each populated slot yields the head of that priority's FIFO queue, so a
+        priority whose window spans multiple slots yields its head once per
+        populated slot; callers that only test admissibility can treat the
+        repeats idempotently. This is the iteration primitive behind both the
+        single-candidate `_next_candidate_with_slot` and the full
+        head-of-line-avoiding scan in `next_admissible_reserved_unit`.
+        """
+        if not self._reservation_slots_in_order:
+            return
+        total_slots = len(self._reservation_slots_in_order)
+        for scanned_slots in range(total_slots):
+            slot_index = (self._next_reservation_slot_index + scanned_slots) % total_slots
+            priority_class, slot_offset = self._reservation_slots_in_order[slot_index]
+            reserved_queue = self._reserved_queue_by_priority[priority_class]
+            if slot_offset < len(reserved_queue):
+                yield slot_index, reserved_queue[0]
+
     def _next_candidate_with_slot(self) -> Optional[tuple[int, QueuedWorkUnit]]:
         """
         Return current round-robin candidate.
@@ -227,18 +248,7 @@ class ReservedTracker:
         We scan at most one full slot cycle and pick the first slot that is
         currently populated in its class queue.
         """
-        if not self._reservation_slots_in_order:
-            return None
-        total_slots = len(self._reservation_slots_in_order)
-        for scanned_slots in range(total_slots):
-            slot_index = (self._next_reservation_slot_index + scanned_slots) % total_slots
-            priority_class, slot_offset = self._reservation_slots_in_order[slot_index]
-            reserved_queue = self._reserved_queue_by_priority[priority_class]
-            if slot_offset < len(reserved_queue):
-                # We use the slot_index to know what priority class to use. Then
-                # we just get the first item in the queue.
-                return slot_index, reserved_queue[0]
-        return None
+        return next(self._iter_candidate_slots(), None)
 
     def next_admissible_reserved_unit(
         self,
@@ -259,27 +269,39 @@ class ReservedTracker:
           3) then BACKGROUND slots 0..k-1,
         and the tracker remembers the last served slot to continue fairly.
 
-        Strict fairness rule:
-          - only the current round-robin candidate slot is eligible now.
-          - if that candidate does not fit, this method returns None (no fallback scanning).
+        Head-of-line avoidance:
+          - we scan candidates in round-robin order and return the first that
+            fits, so an un-admittable head (e.g. an over-budget unit) in one
+            priority queue does not starve fittable units in the others.
+          - FIFO within a priority is preserved: only each queue's head is a
+            candidate, never a unit behind a stuck head in the same queue.
 
-        The candidate is admissible when:
-            candidate.ram_peak_est_bytes + in_flight_ram_bytes < scheduler_ram_cap_bytes
+        Fallbacks when nothing fits:
+          - run-alone override: if nothing is in flight, waiting can never free
+            more RAM, so the current round-robin head is admitted anyway (the
+            scheduler logs a warning at submission).
+          - otherwise the head's defer counter is advanced (toward the eventual
+            plan abort) and None is returned.
+
+        A candidate is admissible when:
+            candidate.ram_peak_est_bytes + in_flight_ram_bytes <= scheduler_ram_cap_bytes
         """
-        candidate_with_slot = self._next_candidate_with_slot()
-        if candidate_with_slot is None:
+        head_with_slot: Optional[tuple[int, QueuedWorkUnit]] = None
+        for slot_index, candidate in self._iter_candidate_slots():
+            if head_with_slot is None:
+                head_with_slot = (slot_index, candidate)
+            if candidate.work_unit.ram_peak_est_bytes + in_flight_ram_bytes <= scheduler_ram_cap_bytes:
+                return slot_index, candidate
+
+        if head_with_slot is None:
             return None
-        slot_index, candidate = candidate_with_slot
-        candidate_ram_bytes = candidate.work_unit.ram_peak_est_bytes
-        if candidate_ram_bytes + in_flight_ram_bytes <= scheduler_ram_cap_bytes:
-            return slot_index, candidate
         if in_flight_ram_bytes == 0:
-            # Run-alone override: nothing else is using RAM, so waiting can never
-            # make this candidate fit. Admit it (the scheduler logs a warning at
-            # submission) instead of deferring forever toward a plan abort.
-            return slot_index, candidate
-        candidate.defer_count += 1
-        self._maybe_signal_defer_exceeded(candidate)
+            # Run-alone override on the current round-robin head: nothing else is
+            # using RAM, so no amount of waiting will make anything fit.
+            return head_with_slot
+        _, head_candidate = head_with_slot
+        head_candidate.defer_count += 1
+        self._maybe_signal_defer_exceeded(head_candidate)
         return None
 
     def advance_reservation_cursor(self, served_slot_index: int) -> None:

--- a/src/wiser/utils/work_scheduler.py
+++ b/src/wiser/utils/work_scheduler.py
@@ -14,7 +14,7 @@ from concurrent.futures import (
 )
 from dataclasses import dataclass, field
 from collections import Counter, deque
-from threading import Lock, Semaphore
+from threading import Event, Lock, Semaphore, Thread
 from time import perf_counter
 from typing import Any, Callable, Deque, Dict, Optional, TYPE_CHECKING
 from multiprocessing.managers import dispatch
@@ -36,6 +36,9 @@ SCHEDULER_PROCESS_BUDGET = min(12, available_cpus)
 SCHEDULER_RAM_BUDGET = 2_000_000_000
 SCHEDULER_THREAD_BUDGET = 32
 SCHEDULER_DEFER_TO_RESERVED_THRESHOLD = 4
+# How often the watchdog re-drives the scheduler as a safety net against parked
+# work that never gets a normal (edge-triggered) drain. Set <= 0 to disable.
+SCHEDULER_WATCHDOG_INTERVAL_SECONDS = 2.0
 PRIORITY_LANE_COUNT = 3
 # Max times a reserved unit may fail RAM admission before its plan is aborted.
 # Prevents indefinite hangs when a unit's `ram_peak_est_bytes` exceeds the
@@ -61,6 +64,7 @@ class SchedulerConfig:
     _defer_to_reserved_threshold: int = SCHEDULER_DEFER_TO_RESERVED_THRESHOLD
     _process_priority_tokens: Optional[Dict[PriorityClass, int]] = None
     _thread_priority_tokens: Optional[Dict[PriorityClass, int]] = None
+    _watchdog_interval_seconds: float = SCHEDULER_WATCHDOG_INTERVAL_SECONDS
 
 
 @dataclass
@@ -735,6 +739,7 @@ class WorkScheduler:
         self._ram_budget_bytes = int(self._config._ram_budget)
         self._in_flight_ram_bytes = 0
         self._defer_to_reserved_threshold = int(self._config._defer_to_reserved_threshold)
+        self._watchdog_interval_seconds = float(self._config._watchdog_interval_seconds)
         self._recorder = recorder
         self._task_manager = task_manager
 
@@ -821,6 +826,13 @@ class WorkScheduler:
         self._queue_transition_sequence_id = 0
         self._state_lock = Lock()
 
+        # Background safety net: periodically re-drive the scheduler so parked
+        # work cannot wedge forever if a normal (edge-triggered) drain is missed.
+        # Started last so every field it touches is already initialized.
+        self._watchdog_stop_event = Event()
+        self._watchdog_thread: Optional[Thread] = None
+        self._start_watchdog()
+
     def submit_process(
         self,
         priority: PriorityClass,
@@ -866,7 +878,39 @@ class WorkScheduler:
             initializer=initialize_thread_worker,
         )
 
+    def _start_watchdog(self) -> None:
+        """Spin up the periodic re-drain thread unless the interval disables it."""
+        if self._watchdog_interval_seconds <= 0:
+            return
+        self._watchdog_thread = Thread(
+            target=self._watchdog_loop,
+            name="WorkSchedulerWatchdog",
+            daemon=True,
+        )
+        self._watchdog_thread.start()
+
+    def _watchdog_loop(self) -> None:
+        """Re-drive the scheduler every interval until stopped.
+
+        The scheduler is otherwise edge-triggered: `_drain_queues_locked` runs
+        only on plan submit and unit completion. If work is left parked while the
+        system goes idle and no completion is pending to re-drive it, nothing
+        would make progress. This loop turns that into a level-triggered safety
+        net. Draining when there is nothing admissible is a cheap no-op.
+        """
+        while not self._watchdog_stop_event.wait(self._watchdog_interval_seconds):
+            try:
+                with self._state_lock:
+                    self._drain_queues_locked()
+                self._flush_pending_done_callbacks()
+            except Exception:
+                logger.exception("WorkScheduler watchdog drain failed; continuing.")
+
     def shutdown(self, wait: bool = True) -> None:
+        self._watchdog_stop_event.set()
+        if self._watchdog_thread is not None:
+            self._watchdog_thread.join(timeout=self._watchdog_interval_seconds + 5.0)
+            self._watchdog_thread = None
         self._thread_pool.shutdown(wait=wait)
         self._process_pool.shutdown(wait=wait)
 

--- a/src/wiser/utils/work_scheduler.py
+++ b/src/wiser/utils/work_scheduler.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from wiser.utils.task_system import TaskManager
 
 available_cpus = os.cpu_count() or 1
-SCHEDULER_PROCESS_BUDGET = min(12, available_cpus)
+SCHEDULER_PROCESS_BUDGET = min(6, available_cpus)
 SCHEDULER_RAM_BUDGET = 2_000_000_000
 SCHEDULER_THREAD_BUDGET = 32
 SCHEDULER_DEFER_TO_RESERVED_THRESHOLD = 4


### PR DESCRIPTION
## What does this change do?
This PR fixes several ways the work scheduler could deadlock or starve work. Over-budget units now run alone instead of hanging forever when nothing else is in flight. A periodic watchdog re-drains the queues so parked work can't wedge if a normal drain trigger is missed. Reserved-queue admission is now fair: the round-robin cursor actually advances, and admission scans past an un-admittable head so it no longer starves fittable lower-priority work.

I also squeezed in fixing mtmf dialog label. There were overlapping labels

I also reduced the PCU count. I think it was already too high to start with, especially since we are using spawn which will use more memory. The error seemed to be that we had too many spawned processes and they were taking up too much memory because they loaded in expensive libraries like GDAL.

Closes #575 
Closes #572 
Closes #549

## What type of PR is this? (check all applicable) 
- [X] Feature
- [X] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [X] Code Refactor
- [ ] Performance Improvements
- [X] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
This change is needed to make the work scheduler not indefinitely stall and error as much.

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->