### PR TITLE
refac: Adding better unmasked NaN handling to K means

### DIFF
--- a/src/tests/test_kmeans.py
+++ b/src/tests/test_kmeans.py
@@ -24,6 +24,13 @@ from wiser.utils.primitives import DeletePolicy, ExternalRasterHandle, PriorityC
 from wiser.utils.storage_client import StorageClient
 from wiser.utils.task_system import SemanticTask
 
+from tests.utils import (
+    NAN_INF_BAD_BANDS,
+    NAN_INF_DATA_IGNORE_VALUE,
+    NAN_INF_INVALID_YX,
+    build_unmasked_nan_inf_cube,
+)
+
 pytestmark = [
     pytest.mark.integration,
 ]
@@ -534,6 +541,92 @@ class TestKMeansSemanticTaskParameters(unittest.TestCase):
         params = self._make_params(dataset, algorithm=KMeansAlgorithm.ELKAN)
         labels_ds, centroids = self._submit_task(dataset, params)
         self._assert_output(dataset, labels_ds, centroids)
+
+
+class TestKMeansNanResistance(unittest.TestCase):
+    """KMeans must drop unmasked NaN/Inf pixels (and nodata) and label them as
+    data-ignore (-1), instead of erroring. Pre-fix, `_run_kmeans` raised
+    ValueError on any non-finite value in a valid (non-nodata) pixel."""
+
+    def setUp(self):
+        self.test_model = WiserTestModel()
+
+    def tearDown(self):
+        self.test_model.close_app()
+        del self.test_model
+
+    def test_kmeans_tolerates_unmasked_nan_and_inf(self) -> None:
+        # Synthetic cube with a bad band, two all-nodata pixels, and unmasked
+        # NaN/+Inf/-Inf in good bands at distinct pixels (NAN_INF_INVALID_YX).
+        dataset = RasterDataLoader().dataset_from_numpy_array(build_unmasked_nan_inf_cube())
+        dataset.set_bad_bands(NAN_INF_BAD_BANDS)
+        dataset.set_data_ignore_value(NAN_INF_DATA_IGNORE_VALUE)
+
+        app_services = self.test_model.app_services
+        storage_client = None
+        try:
+            dataset_ref = app_services.storage_service.register_external(
+                ExternalRasterHandle(dataset_obj=dataset)
+            )
+            k = 3
+            params = KMeansParameters(
+                dataset_id=0,  # dataset not registered in app_state; use sentinel
+                k=k,
+                init_method=KMeansInitMethod.KMEANS_PLUS_PLUS,
+                num_inits=3,
+                max_iter=100,
+                tol=1e-4,
+                seed=_SEED,
+                algorithm=KMeansAlgorithm.LLOYD,
+            )
+
+            pipeline = get_kmeans_pipeline(dataset_ref, params)
+            pipeline.stages[0].set_output_delete_policy("kmeans_labels", DeletePolicy.KEEP)
+            pipeline.stages[0].set_output_delete_policy("kmeans_centroids", DeletePolicy.KEEP)
+
+            task = SemanticTask(
+                priority_class=PriorityClass.BACKGROUND,
+                input_ref=dataset_ref,
+                algorithm_pipeline=pipeline,
+            )
+            task.id = 5101
+
+            task_plan = app_services.task_planner.plan_semantic_task(task)
+            future = app_services.scheduler.run_task_plan(task_plan)
+            # Pre-fix this raised "KMeans input contains NaN or infinite values...".
+            future.result(timeout=60)
+
+            listener_address, listener_authkey = app_services.storage_service.get_connection_bootstrap()
+            storage_client = StorageClient(
+                service=None,  # type: ignore[arg-type]
+                service_address=listener_address,
+                service_authkey=listener_authkey,
+            )
+            labels_out, _ = storage_client.read_data(task_plan.bindings["kmeans_labels"])
+            labels = np.asarray(labels_out).astype(np.int32)  # (y, x, 1)
+
+            self.assertEqual(labels.shape, (12, 12, 1))
+
+            # Every nodata / NaN / Inf pixel is dropped and labelled data-ignore.
+            invalid_mask = np.zeros((12, 12), dtype=bool)
+            for yy, xx in NAN_INF_INVALID_YX:
+                invalid_mask[yy, xx] = True
+                self.assertEqual(
+                    labels[yy, xx, 0],
+                    -1,
+                    f"Invalid pixel {(yy, xx)} should be labelled data-ignore (-1)",
+                )
+
+            # Every surviving pixel got a real cluster label in [0, k-1].
+            valid_labels = labels[~invalid_mask][:, 0]
+            self.assertTrue(np.all(valid_labels >= 0))
+            self.assertTrue(np.all(valid_labels < k))
+        finally:
+            if storage_client is not None:
+                storage_client.close()
+            release_kept_refs(app_services)
+            app_services.scheduler.shutdown(wait=True)
+            app_services.storage_service.close()
 
 
 if __name__ == "__main__":

--- a/src/wiser/gui/kmeans.py
+++ b/src/wiser/gui/kmeans.py
@@ -52,7 +52,11 @@ from wiser.utils.task_system import (
 from wiser.utils.worker_runtime import get_process_storage_client
 
 from wiser.raster.spectrum import NumPyArraySpectrum, Spectrum
-from wiser.raster.utils import convert_spectrum_wavelengths, get_band_values
+from wiser.raster.utils import (
+    convert_spectrum_wavelengths,
+    finite_unmasked_row_mask,
+    get_band_values,
+)
 
 if TYPE_CHECKING:
     from wiser.raster.dataset import RasterDataSet
@@ -256,24 +260,34 @@ def _run_kmeans(
     # Flatten to (n_pixels, b_good) while preserving the flat index -> (y, x) mapping
     flat = image_good.reshape(y * x, b_good)
 
-    # Remove rows that contain the data ignore value
+    # A pixel is unusable if it holds any non-finite value (NaN/Inf) in a good
+    # band, or it hits the nodata sentinel. Both kinds of row are dropped before
+    # clustering and get the data-ignore label in the output -- the same approach
+    # PCA/MNF/decorrelation use to stay NaN-resistant, instead of erroring out.
+    # finite_unmasked_row_mask is the shared row-validity helper: it drops the
+    # NaN/Inf rows (which also covers the nodata-is-NaN case) and AND-s out the
+    # finite-sentinel nodata rows passed via its optional mask.
     nodata = region_meta.nodata
-    if nodata is not None:
-        if np.isnan(nodata):
-            nodata_row_mask = np.any(np.isnan(flat), axis=1)
-        else:
-            nodata_row_mask = np.any(flat == nodata, axis=1)
-        valid_indices = np.where(~nodata_row_mask)[0]
-    else:
-        valid_indices = np.arange(y * x)
+    nodata_mask = None
+    if nodata is not None and not np.isnan(nodata):
+        nodata_mask = flat == nodata
+    valid_indices = np.where(finite_unmasked_row_mask(flat, nodata_mask))[0]
 
     flat_valid = flat[valid_indices]  # (n_valid, b_good)
 
-    # Error out on any remaining NaN or infinite values
+    # Defensive sanity check: after dropping non-finite/nodata rows, nothing
+    # non-finite should remain. If it does, the cleaning above missed something.
     if not np.all(np.isfinite(flat_valid)):
         raise ValueError(
-            "KMeans input contains NaN or infinite values in valid (non-nodata) pixels. "
-            "Check your dataset for corrupt values."
+            "KMeans input still contains NaN or infinite values after removing "
+            "nodata and NaN/Inf pixels. Check your dataset for corrupt values."
+        )
+
+    k = params.get_k()
+    if flat_valid.shape[0] < k:
+        raise ValueError(
+            f"KMeans needs at least k={k} valid (finite, non-nodata) pixels, but only "
+            f"{flat_valid.shape[0]} remain after removing nodata and NaN/Inf pixels."
         )
 
     # Build the init argument

--- a/src/wiser/utils/work_scheduler.py
+++ b/src/wiser/utils/work_scheduler.py
@@ -1631,7 +1631,8 @@ class WorkScheduler:
             f"RAM admission {queued.defer_count} times "
             f"(ram_peak_est_bytes={queued.work_unit.ram_peak_est_bytes}, "
             f"scheduler_ram_cap_bytes={self._ram_budget_bytes}, "
-            f"max_defer_count={MAX_DEFER_COUNT})."
+            f"max_defer_count={MAX_DEFER_COUNT}).\n\n"
+            f"Try to submit the task as the only task running."
         )
         self._abort_plan_locked(
             queued.plan_id,


### PR DESCRIPTION
## What does this change do?
Making sure kmeans can still run even when datasets have unmasked non numerical values.

Closes #573

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [X] Code Refactor
- [ ] Performance Improvements
- [X] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
So people can easily use k means without having to alter their data in WISER.

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->