### PR TITLE
feat: Migrate info from wiser.caltech.edu to github pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ Read _CODE_OF_CONDUCT.md_ for more information.
 |------|------|-------------|
 | Project Lead [(BDFL)](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) | [Bethany Ehlmann](https://www.linkedin.com/in/bethany-ehlmann-1112b81/) | CU Boulder
 | Maintainer | [Joshua Garcia-Kimble](https://www.linkedin.com/in/joshua-garcia-kimble-45211a16b/) | Caltech |
+| Maintainer | Matthew Maclay | LASP |
 
 ## Where can I ask for help?
 

--- a/doc/sphinx-general-wiser-docs/source/contributing.md
+++ b/doc/sphinx-general-wiser-docs/source/contributing.md
@@ -3,7 +3,7 @@
 Questions, bugs, and feature requests can be submitted as
 [GitHub Issues](https://github.com/Ehlmann-research-group/WISER/issues),
 or via the [WISER feedback form](https://forms.gle/eqkdnv9b2ogEUbPp6)
-if you prefer not to use GitHub.
+if you prefer not to use GitHub. For other help, email us at wiser_AT_caltech.edu.
 
 ## Reporting a Bug
 
@@ -67,4 +67,3 @@ Want to contribute a fix or feature? Start here:
    [Testing & QA](developer-content/testing-and-qa) guide.
 5. **Open a pull request** — link it to your issue. The PR description is the
    merge commit body, so write it clearly.
-

--- a/doc/sphinx-general-wiser-docs/source/contributing.md
+++ b/doc/sphinx-general-wiser-docs/source/contributing.md
@@ -5,6 +5,13 @@ Questions, bugs, and feature requests can be submitted as
 or via the [WISER feedback form](https://forms.gle/eqkdnv9b2ogEUbPp6)
 if you prefer not to use GitHub. For other help, email us at wiser_AT_caltech.edu.
 
+## Becoming a Tester
+
+To become a WISER tester, fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSfzNRkk7Pp19eaoa1u2qM0rezIAqQK7sIQl518hMqzDD3daqQ/viewform?usp=header).
+
+As a tester, you will receive pre-release builds of WISER in order to help
+us find any bugs or issues with the software before the release.
+
 ## Reporting a Bug
 
 Thank you for helping make WISER better!

--- a/doc/sphinx-general-wiser-docs/source/index.rst
+++ b/doc/sphinx-general-wiser-docs/source/index.rst
@@ -16,7 +16,8 @@ at Caltech & CU Boulder.
 - Regions of Interest (ROIs) for area-averaged spectra and pixel exports
 - Contrast stretch and color mapping for display control
 - Band math with custom expressions and plugin-defined functions
-- Analysis tools: PCA, Spectral Angle Mapper, Continuum Removal, Scatter Plot
+- Analysis tools: PCA, Spectral Angle Mapper, Continuum Removal, Scatter Plot,
+ Minimum Noise Fraction, K-means, and more
 - Georeferencing and coordinate system management
 - Extensible plugin system (Tools Menu, Context Menu, Band Math)
 
@@ -64,6 +65,24 @@ WISER builds currently target:
 - **macOS 15** --- ARM (Apple Silicon) and Intel
 - **Windows 10/11**
 - **Linux** --- Ubuntu 20.04+, Debian 11+, Fedora 39+ (amd64 and aarch64)
+
+System Requirements
+^^^^^^^^^^^^^^^^^^^
+
+The minimum and recommended specifications for running WISER are:
+
+**Operating system**
+
+- **Windows:** Windows 10 or 11 (64-bit)
+- **macOS:** macOS 15 or newer (Intel and Apple Silicon)
+- **Linux:** Ubuntu 20.04+, Debian 11+, or Fedora 39+ (amd64 and aarch64)
+
+**Hardware**
+
+- **CPU architecture:** x86_64 (Intel/AMD) or arm64 (Apple Silicon / aarch64)
+- **Memory:** 8 GB minimum; 16--32 GB recommended for large datasets
+- **Storage:** ~1 GB for installation; SSD strongly recommended
+- **GPU:** Not required
 
 If you encounter issues building or running WISER, please
 `open a GitHub Issue <https://github.com/Ehlmann-research-group/WISER/issues>`_.

--- a/doc/sphinx-general-wiser-docs/source/index.rst
+++ b/doc/sphinx-general-wiser-docs/source/index.rst
@@ -23,6 +23,36 @@ at Caltech & CU Boulder.
 
 ----
 
+Sample Datasets
+---------------
+
+WISER natively opens several hyperspectral and spectral-library formats, and
+can fall back to any format supported by GDAL for additional coverage.
+
+**Natively supported formats**
+
+- **ENVI raster** (``*.img``, ``*.hdr``)
+- **TIFF / GeoTIFF** (``*.tiff``, ``*.tif``, ``*.tfw``)
+- **NetCDF** (``*.nc``)
+- **JPEG 2000** (``*.JP2``)
+- **PDS raster** (``*.PDS``, ``*.img``, ``*.lbl``, ``*.xml``)
+- **ENVI spectral libraries** (``*.sli``, ``*.hdr``)
+- **GDAL-readable formats** --- any format that GDAL can open (e.g. HDF4/5,
+  GRIdded Binary, COG, and more)
+
+**Example datasets to try**
+
+The following publicly available datasets are good starting points for
+exploring WISER:
+
+- `Sample AVIRIS-NG image of Caltech <https://avng.jpl.nasa.gov/pub/DThompson/istutor/ang20171108t184227_corr_v2p13_subset_bil>`_
+  (also download the matching
+  `header file <https://avng.jpl.nasa.gov/pub/DThompson/istutor/ang20171108t184227_corr_v2p13_subset_bil.hdr>`_)
+- `AVIRIS Data Portal <https://aviris.jpl.nasa.gov/dataportal/>`_ --- archive of airborne imaging-spectrometer scenes
+- `PDS Geosciences Node <https://pds-geosciences.wustl.edu/>`_ --- planetary hyperspectral datasets (CRISM, OMEGA, and more)
+- `Ehlmann Lab datasets <https://ehlmann.caltech.edu/publications/datasets.html>`_ --- laboratory and field imaging-spectroscopy data
+
+
 Installation
 ------------
 

--- a/doc/sphinx-general-wiser-docs/source/index.rst
+++ b/doc/sphinx-general-wiser-docs/source/index.rst
@@ -17,7 +17,7 @@ at Caltech & CU Boulder. For any questions, contact wiser_AT_caltech.edu.
 - Contrast stretch and color mapping for display control
 - Band math with custom expressions and plugin-defined functions
 - Analysis tools: PCA, Spectral Angle Mapper, Continuum Removal, Scatter Plot,
- Minimum Noise Fraction, K-means, and more
+Minimum Noise Fraction, K-means, and more
 - Georeferencing and coordinate system management
 - Extensible plugin system (Tools Menu, Context Menu, Band Math)
 

--- a/doc/sphinx-general-wiser-docs/source/index.rst
+++ b/doc/sphinx-general-wiser-docs/source/index.rst
@@ -7,7 +7,7 @@ imagery. Built in Python on Qt/PySide2, it runs on **macOS, Windows, and
 Linux** with no commercial license required.
 
 Developed and maintained by the `Ehlmann Research Group <https://github.com/Ehlmann-research-group>`_
-at Caltech & CU Boulder.
+at Caltech & CU Boulder. For any questions, contact wiser_AT_caltech.edu.
 
 **Key capabilities:**
 

--- a/doc/sphinx-general-wiser-docs/source/index.rst
+++ b/doc/sphinx-general-wiser-docs/source/index.rst
@@ -52,6 +52,15 @@ exploring WISER:
 - `PDS Geosciences Node <https://pds-geosciences.wustl.edu/>`_ --- planetary hyperspectral datasets (CRISM, OMEGA, and more)
 - `Ehlmann Lab datasets <https://ehlmann.caltech.edu/publications/datasets.html>`_ --- laboratory and field imaging-spectroscopy data
 
+----
+
+Subscribe to Email Updates
+--------------------------
+
+To receive notifications about new WISER releases, send an email to
+``wiser-announce-request@caltech.edu`` with the subject line **Subscribe**.
+Follow the instructions in the reply to confirm your subscription.
+
 
 Installation
 ------------

--- a/doc/sphinx-general-wiser-docs/source/index.rst
+++ b/doc/sphinx-general-wiser-docs/source/index.rst
@@ -16,8 +16,7 @@ at Caltech & CU Boulder. For any questions, contact wiser_AT_caltech.edu.
 - Regions of Interest (ROIs) for area-averaged spectra and pixel exports
 - Contrast stretch and color mapping for display control
 - Band math with custom expressions and plugin-defined functions
-- Analysis tools: PCA, Spectral Angle Mapper, Continuum Removal, Scatter Plot,
-Minimum Noise Fraction, K-means, and more
+- Analysis tools: PCA, Spectral Angle Mapper, Continuum Removal, Scatter Plot, Minimum Noise Fraction, K-means, and more
 - Georeferencing and coordinate system management
 - Extensible plugin system (Tools Menu, Context Menu, Band Math)
 


### PR DESCRIPTION
## What does this change do?
We are trying to trim down the website wiser.caltech.edu and put more on our github.io docs page. This PR puts more on our github.io docs page. Simultaneously, we have trimmed wiser.caltech.edu.

Closes #580

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [X] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
We need to centralize our docs so we only need change things in one place.

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->