### PR TITLE
fix: Pre-import cv2 to prevent recursion errors during test mode

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/contributing.md
+++ b/doc/sphinx-general-wiser-docs/source/contributing.md
@@ -18,8 +18,7 @@ Thank you for helping make WISER better!
 If you find a problem or unexpected behavior, you can report it in two ways:
 
 - **[Submit via the feedback form](https://forms.gle/eqkdnv9b2ogEUbPp6)** — no GitHub account required.
-- **[Submit a GitHub Issue](https://github.com/Ehlmann-research-group/WISER/issues/new/choose)** — use the **Bug report
-  ** template.
+- **[Submit a GitHub Issue](https://github.com/Ehlmann-research-group/WISER/issues/new/choose)** — use the **Bug report** template.
 
 When filling out the issue form:
 

--- a/src/wiser/__main__.py
+++ b/src/wiser/__main__.py
@@ -151,6 +151,17 @@ def qt_debug_callback(*args, **kwargs):
 
 
 def run_tests(tests: list[str]) -> int:
+    # Pre-import cv2 while sys.path is still in the order established by the
+    # pyi_rth_cv2 runtime hook (the bundled cv2/python-* native folder first).
+    # pytest.main() below mutates sys.path during collection, which otherwise
+    # makes the first cv2 import resolve to the package's __init__.py bootstrap
+    # and raise "recursion is detected during loading of cv2 binary extensions"
+    # in the frozen build. Loading it once here caches it in sys.modules so
+    # later imports during collection are no-ops. Normal startup already works
+    # because it imports cv2 lazily before any such mutation.
+    # prevents distributable --test_mode failure.
+    import cv2  # noqa: F401
+
     import pytest
 
     os.environ["WISER_LOW_CONCURRENCY_SCHEDULER"] = "1"

--- a/src/wiser/__main__.py
+++ b/src/wiser/__main__.py
@@ -164,7 +164,7 @@ def run_tests(tests: list[str]) -> int:
     # Normal startup already works because it imports cv2 at the start, so paths can't
     # be reordered.
 
-    # prevents distributable --test_mode failure.
+    # TLDR: Prevent distributable --test_mode failure.
     import cv2  # noqa: F401
 
     import pytest

--- a/src/wiser/__main__.py
+++ b/src/wiser/__main__.py
@@ -153,12 +153,17 @@ def qt_debug_callback(*args, **kwargs):
 def run_tests(tests: list[str]) -> int:
     # Pre-import cv2 while sys.path is still in the order established by the
     # pyi_rth_cv2 runtime hook (the bundled cv2/python-* native folder first).
-    # pytest.main() below mutates sys.path during collection, which otherwise
-    # makes the first cv2 import resolve to the package's __init__.py bootstrap
+    # This order is important because it ensures that the cv2 dll is found before
+    # the cv2 python module so the recursion error doesn't happen.
+    # However, pytest.main() below mutates sys.path during collection, which messes
+    # up this order, causing the first cv2 import (which is cv2's python module)
+    # to resolve to the package's __init__.py bootstrap (cv2's python module)
     # and raise "recursion is detected during loading of cv2 binary extensions"
     # in the frozen build. Loading it once here caches it in sys.modules so
-    # later imports during collection are no-ops. Normal startup already works
-    # because it imports cv2 lazily before any such mutation.
+    # later imports during collection don't cause any triggers after importing.
+    # Normal startup already works because it imports cv2 at the start, so paths can't
+    # be reordered.
+
     # prevents distributable --test_mode failure.
     import cv2  # noqa: F401
 

--- a/src/wiser/version.py
+++ b/src/wiser/version.py
@@ -1,5 +1,5 @@
-VERSION = "2.1b2"
-RELEASE_DATE = "2026-04-21"
+VERSION = "2.2b1"
+RELEASE_DATE = "2026-06-11"
 
 if __name__ == "__main__":
     print(f"{VERSION}")

--- a/src/wiser/version.py
+++ b/src/wiser/version.py
@@ -1,5 +1,5 @@
 VERSION = "2.2b1"
-RELEASE_DATE = "2026-06-11"
+RELEASE_DATE = "2026-06-12"
 
 if __name__ == "__main__":
     print(f"{VERSION}")


### PR DESCRIPTION
## What does this change do?
This change pre-imports cv2 in __main__.py in order to prevent pytest import recursion errors when running `./WISER.bin --test-mode` as part of the release process verifying the pre-built distributables.

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [x] Hot Fix
- [x] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
test_mode does not accurately represent the packaging quality of the build with false positives during pytest 

## How did you implement the change?
import cv explicitly in _Main_.py test-mode, before importing pytest

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [ ] No new lint/style issues introduced
- [ ] Branch is up-to-date with main/master
- [ ] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->