### PR TITLE
test: Adding back smoke tests to windows and mac builds

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -39,12 +39,12 @@ jobs:
           ls -la dist/WISER || true
         timeout-minutes: 15
 
-      # - name: Smoke Test (Windows)
-      #   if: runner.os == 'Windows'
-      #   shell: bash -leo pipefail {0}
-      #   run: |
-      #     cd dist/WISER
-      #     ./WISER.exe --test_mode
+      - name: Smoke Test (Windows)
+        if: runner.os == 'Windows'
+        shell: bash -leo pipefail {0}
+        run: |
+          cd dist/WISER
+          ./WISER.exe --test_mode
       
       - name: Package Windows + checksum
         if: runner.os == 'Windows'
@@ -85,12 +85,12 @@ jobs:
           ls -la dist/WISER || true
         timeout-minutes: 25
 
-      # - name: Smoke Test (macOS)
-      #   if: runner.os == 'macOS'
-      #   shell: bash -leo pipefail {0}
-      #   run: |
-      #     cd dist/WISER
-      #     ./WISER_Bin --test_mode
+      - name: Smoke Test (macOS)
+        if: runner.os == 'macOS'
+        shell: bash -leo pipefail {0}
+        run: |
+          cd dist/WISER
+          ./WISER_Bin --test_mode
 
       - name: Pack macOS .app (preserve symlinks & modes)
         if: runner.os == 'macOS'


### PR DESCRIPTION
## What does this change do?
As the title says. Closes #594

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [x] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
We need to test that #591 really works for windows and macos (it didn't work for these platforms before)

## Added tests?
- [ ] yes
- [X] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [X] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->