### PR TITLE
refac: K means run history dialog

### DIFF
--- a/src/tests/test_kmeans.py
+++ b/src/tests/test_kmeans.py
@@ -203,6 +203,8 @@ class TestKMeansSemanticTask(unittest.TestCase):
             input_ref=dataset_ref,
             params=params,
         )
+        # The dialog wires this in production; the test drives the task directly.
+        kmeans_task.run_recorded.connect(app_state.get_kmeans_history().add_record)
 
         task_plan = app_services.task_planner.plan_semantic_task(kmeans_task)
         future = app_services.task_manager.register_and_submit_task_plan(app_services.scheduler, task_plan)
@@ -252,9 +254,14 @@ class TestKMeansSemanticTask(unittest.TestCase):
             err_msg="Semantic task label image does not match sklearn reference.",
         )
 
-        # Verify centroids were stored in app_state under the correct key
-        stored_centroids = app_state.get_kmeans_centroids(params)
-        self.assertIsNotNone(stored_centroids, "KMeansCentroids were not stored in app_state")
+        # Verify the completed run was recorded in the K-Means history.
+        records = app_state.get_kmeans_history().get_records()
+        self.assertEqual(len(records), 1, "Expected exactly one K-Means run record")
+        record = records[-1]
+        self.assertEqual(record.params, params)
+        self.assertEqual(record.effective_seed, _SEED)
+        stored_centroids = record.centroids
+        self.assertIsNotNone(stored_centroids, "KMeansCentroids were not stored in the run record")
         self.assertEqual(stored_centroids.num_centroids(), _K)
         ref_centroids = ref_kmeans.cluster_centers_.astype(np.float32)
         np.testing.assert_allclose(
@@ -355,6 +362,8 @@ class TestKMeansSemanticTaskParameters(unittest.TestCase):
             input_ref=dataset_ref,
             params=params,
         )
+        # The dialog wires this in production; the test drives the task directly.
+        kmeans_task.run_recorded.connect(app_state.get_kmeans_history().add_record)
 
         task_plan = app_services.task_planner.plan_semantic_task(kmeans_task)
         future = app_services.task_manager.register_and_submit_task_plan(app_services.scheduler, task_plan)
@@ -369,7 +378,7 @@ class TestKMeansSemanticTaskParameters(unittest.TestCase):
         )
 
         labels_ds = datasets_after[-1]
-        centroids = app_state.get_kmeans_centroids(params)
+        centroids = app_state.get_kmeans_history().get_records()[-1].centroids
         return labels_ds, centroids
 
     def _assert_output(self, dataset, labels_ds, centroids, k=_K):

--- a/src/wiser/gui/app_state.py
+++ b/src/wiser/gui/app_state.py
@@ -44,7 +44,7 @@ from wiser.gui.util import StateChange
 
 if TYPE_CHECKING:
     from wiser.gui.reference_creator_dialog import CrsCreatorState
-    from wiser.gui.kmeans import KMeansParameters, KMeansCentroids
+    from wiser.gui.kmeans import KMeansRunHistoryManager
     from wiser.gui.linear_unmixing import LinearUnmixingHistoryManager
     from wiser.gui.permanent_plugins.pca_plugin import PCAHistoryManager
     from wiser.gui.mnf import MNFHistoryManager
@@ -100,9 +100,6 @@ class ApplicationState(QObject):
     # TODO(donnie):  collected_spectra_changed = Signal(StateChange, int)
     collected_spectra_changed = Signal(object, int, int)
 
-    # Signal: a KMeans centroid result was added or updated in app state
-    kmeans_centroids_changed = Signal()
-
     # TODO(donnie):  Signals for config changes and color changes!
 
     def __init__(self, app, config: Optional[ApplicationConfig] = None):
@@ -140,10 +137,6 @@ class ApplicationState(QObject):
         # All regions of interest in the application.  The key is the numeric ID
         # of the ROI, and the value is a RegionOfInterest object.
         self._regions_of_interest: Dict[int, RegionOfInterest] = {}
-
-        # K-Means centroid results, keyed by KMeansParameters (which includes
-        # dataset_id).  Last write wins for identical parameter sets.
-        self._kmeans_centroids: Dict["KMeansParameters", "KMeansCentroids"] = {}
 
         # A collection of all spectra in the application state, so that we can
         # look them up by ID.
@@ -210,6 +203,13 @@ class ApplicationState(QObject):
         self._pca_history = PCAHistoryManager(self)
         self._mnf_history = MNFHistoryManager(self)
 
+        # K-Means run history — same application-state pattern.  Replaces the
+        # legacy KMeansParameters-keyed centroid dict so every completed run is
+        # an independent, timestamped, deletable record (see issue #613).
+        from wiser.gui.kmeans import KMeansRunHistoryManager
+
+        self._kmeans_history = KMeansRunHistoryManager(self)
+
     def get_linear_unmix_history(self) -> "LinearUnmixingHistoryManager":
         """Return the application-wide linear-unmixing run history manager."""
         return self._linear_unmix_history
@@ -221,6 +221,10 @@ class ApplicationState(QObject):
     def get_mnf_history(self) -> "MNFHistoryManager":
         """Return the application-wide MNF run history manager."""
         return self._mnf_history
+
+    def get_kmeans_history(self) -> "KMeansRunHistoryManager":
+        """Return the application-wide K-Means run history manager."""
+        return self._kmeans_history
 
     def add_running_process(self, process_manager: ProcessManager):
         process_manager_id = process_manager.get_process_manager_id()
@@ -445,25 +449,6 @@ class ApplicationState(QObject):
 
         self.dataset_removed.emit(ds_id)
         # self.state_changed.emit(tuple(ObjectType.DATASET, ActionType.REMOVED, dataset))
-
-    # ------------------------------------------------------------------
-    # K-Means centroids
-    # ------------------------------------------------------------------
-
-    def add_kmeans_centroids(self, params: "KMeansParameters", centroids: "KMeansCentroids") -> None:
-        """Store *centroids* under *params*.  Overwrites any previous entry for the same key."""
-        self._kmeans_centroids[params] = centroids
-        self.kmeans_centroids_changed.emit()
-
-    def get_kmeans_centroids(self, params: "KMeansParameters") -> "Optional[KMeansCentroids]":
-        """Return the centroids stored under *params*, or ``None`` if not found."""
-        return self._kmeans_centroids.get(params)
-
-    def get_all_kmeans_centroids(
-        self,
-    ) -> "Dict[KMeansParameters, KMeansCentroids]":
-        """Return a shallow copy of the full centroids mapping."""
-        return dict(self._kmeans_centroids)
 
     def multiple_datasets_same_size(self):
         """

--- a/src/wiser/gui/kmeans.py
+++ b/src/wiser/gui/kmeans.py
@@ -23,6 +23,7 @@ from PySide2.QtWidgets import (
 from wiser.gui.app_services import AppServices
 from wiser.gui.app_state import ApplicationState
 from wiser.gui.generated.kmeans_dialog_ui import Ui_KMeansDialog
+from wiser.gui.run_history import RunHistoryManagerBase
 from wiser.gui.spectra_table import SpectraTableController
 from wiser.utils.primitives import (
     AllocationRequest,
@@ -203,6 +204,61 @@ class KMeansCentroids:
     def num_centroids(self) -> int:
         """Return k, the number of cluster centroids."""
         return self._centroids.shape[0]
+
+
+# ---------------------------------------------------------------------------
+# Run history (application state) — record + manager
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KMeansRunRecord:
+    """Immutable record of one completed K-Means run.
+
+    Mirrors the run records used by PCA, MNF, and linear unmixing so that all
+    four past-run histories share the :class:`RunHistoryManagerBase`
+    infrastructure.  Unlike the legacy ``KMeansParameters``-keyed dict, every
+    completed run is its own record: re-running with identical settings (or an
+    unseeded run that draws a fresh random state) produces a second,
+    independently viewable and deletable entry rather than silently
+    overwriting the first.
+
+    The record snapshots its own small, self-contained payload — the
+    ``centroids`` array and the resolved ``effective_seed`` — and only
+    *references* the heavy input cube by ``input_dataset_id``.  If that dataset
+    is later closed, the run moves into the past-runs viewer's "closed" section
+    instead of being lost.
+
+    ``params`` carries the full run configuration, including any manual-init
+    seed spectra (already captured as plain ``numpy`` arrays on
+    ``KMeansParameters._manual_spectra``), so the record stays dependency-free
+    on the live spectrum/dataset layer.
+
+    ``effective_seed`` is the integer random state actually handed to
+    scikit-learn.  When the user leaves the seed blank it is drawn explicitly
+    before the run (rather than letting sklearn pull from numpy's global state)
+    so that even unseeded runs are exactly reproducible.
+    """
+
+    run_id: int
+    timestamp: datetime.datetime
+    input_dataset_id: int
+    # Snapshotted name so the table can still show something meaningful after
+    # the live input dataset is closed.
+    input_dataset_name_snapshot: str
+    params: KMeansParameters
+    centroids: KMeansCentroids
+    effective_seed: Optional[int]
+
+
+class KMeansRunHistoryManager(RunHistoryManagerBase[KMeansRunRecord]):
+    """Owns the in-memory list of completed K-Means runs.
+
+    Lives on :class:`~wiser.gui.app_state.ApplicationState` so the history
+    persists across closing and reopening the K-Means dialog.  K-Means tracks
+    only input-dataset liveness (its centroids are snapshotted into the
+    record), so the shared base needs no overrides.
+    """
 
 
 # region KMeans TaskStage

--- a/src/wiser/gui/kmeans.py
+++ b/src/wiser/gui/kmeans.py
@@ -556,6 +556,10 @@ class KMeansSemanticTask(QObject, SemanticTask):
     """Semantic task that runs K-means clustering and loads the label image into WISER."""
 
     result_ready = Signal(object, object, object)
+    # Emitted from _load_result_into_wiser once the centroids are in hand.
+    # Payload is a KMeansRunRecord; the K-Means dialog connects this to
+    # app_state.get_kmeans_history().add_record at task creation.
+    run_recorded = Signal(object)
 
     def __init__(
         self,
@@ -567,11 +571,26 @@ class KMeansSemanticTask(QObject, SemanticTask):
         centroids_ref_name: str = "kmeans_centroids",
     ):
         QObject.__init__(self)
+
+        # Resolve the effective random state before the run.  When the user
+        # leaves the seed blank, sklearn would pull from numpy's global state
+        # and never tell us what it used, making the run unreproducible.  We
+        # draw an explicit integer here instead, pass it to the clustering, and
+        # store it in the run record.  ``run_params`` carries that seed into the
+        # worker; ``params`` (the user's original config, seed possibly None) is
+        # kept verbatim for the record.
+        effective_seed = params.get_seed()
+        if effective_seed is None:
+            effective_seed = int(np.random.randint(0, 2**31 - 1))
+        run_params = replace(params, seed=effective_seed)
+
         SemanticTask.__init__(
             self,
             priority_class=PriorityClass.BACKGROUND,
             input_ref=input_ref,
-            algorithm_pipeline=get_kmeans_pipeline(input_ref, params, labels_ref_name, centroids_ref_name),
+            algorithm_pipeline=get_kmeans_pipeline(
+                input_ref, run_params, labels_ref_name, centroids_ref_name
+            ),
             task_title="K-Means Clustering",
             task_variables={
                 "K": params.get_k(),
@@ -583,6 +602,7 @@ class KMeansSemanticTask(QObject, SemanticTask):
         self._app_state = app_state
         self._source_dataset = source_dataset
         self._params = params
+        self._effective_seed = effective_seed
         self._labels_ref_name = labels_ref_name
         self._centroids_ref_name = centroids_ref_name
         self.result_ready.connect(self._load_result_into_wiser)
@@ -611,7 +631,6 @@ class KMeansSemanticTask(QObject, SemanticTask):
         self, labels_data: object, labels_meta: object, centroids_data: object
     ) -> None:
         centroids_obj = KMeansCentroids(np.asarray(centroids_data))
-        self._app_state.add_kmeans_centroids(self._params, centroids_obj)
 
         labels_array = np.asarray(labels_data)  # (y, x, 1)
         labels_by_band = labels_array.transpose(2, 0, 1)  # (1, y, x)
@@ -632,6 +651,22 @@ class KMeansSemanticTask(QObject, SemanticTask):
 
         self._app_state.add_dataset(labels_dataset, view_dataset=False)
 
+        # Record the completed run in the application-level history so the
+        # past-runs dialog can revisit it.  The manager is shared and outlives
+        # this task; the dialog connects run_recorded to add_record at task
+        # creation.
+        self.run_recorded.emit(
+            KMeansRunRecord(
+                run_id=self.id,
+                timestamp=datetime.datetime.now(),
+                input_dataset_id=self._source_dataset.get_id(),
+                input_dataset_name_snapshot=source_name,
+                params=self._params,
+                centroids=centroids_obj,
+                effective_seed=self._effective_seed,
+            )
+        )
+
 
 class KMeansCentroidsDialog(QDialog):
     """Lists all stored K-Means centroid results.
@@ -649,7 +684,7 @@ class KMeansCentroidsDialog(QDialog):
         self.resize(620, 400)
         self._scroll: Optional[QScrollArea] = None
         self._build_ui()
-        app_state.kmeans_centroids_changed.connect(self._rebuild_content)
+        app_state.get_kmeans_history().records_changed.connect(self._rebuild_content)
 
     # ------------------------------------------------------------------
     # UI construction
@@ -668,11 +703,13 @@ class KMeansCentroidsDialog(QDialog):
         layout = QVBoxLayout(container)
         layout.setAlignment(Qt.AlignTop)
 
-        all_centroids = self._app_state.get_all_kmeans_centroids()
-        if not all_centroids:
+        records = self._app_state.get_kmeans_history().get_records()
+        if not records:
             layout.addWidget(QLabel("No K-Means centroids have been stored yet."))
         else:
-            for params, centroids in all_centroids.items():
+            for record in records:
+                params = record.params
+                centroids = record.centroids
                 btn_text = self._format_params(params)
                 btn = QPushButton(btn_text)
                 btn.setToolTip(btn_text)
@@ -1081,6 +1118,7 @@ class KMeansDialog(QDialog):
             input_ref=dataset_ref,
             params=params,
         )
+        kmeans_task.run_recorded.connect(self._app_state.get_kmeans_history().add_record)
 
         task_plan = self._app_services.task_planner.plan_semantic_task(kmeans_task)
         future = self._app_services.task_manager.register_and_submit_task_plan(


### PR DESCRIPTION
## What does this change do?
Refactors k means to make it use `RunRecord` and `RunHistoryManager` instead of its own custom data structure. `RunRecord` and `RunHistoryManager` are used by PCA, MNF, and other data analysis tools. K Means is the only one that doesn't. Closes #613 

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [x] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
To make the data analysis tool's saved state use the same data structures. This will be useful when we do the save to project file feature and we need to keep track of state.

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed
