### PR TITLE
feat: Infra to make RasterDataSet objects GDAL backed geotiffs 

### DIFF
--- a/src/tests/mosaic_fixtures.py
+++ b/src/tests/mosaic_fixtures.py
@@ -1,0 +1,163 @@
+"""
+Reusable test fixtures for the Seamless Mosaic feature.
+
+These small, overlapping, georeferenced scene builders are shared across the
+mosaic test suite (materialization adapter here, plus scene ingestion, common
+grid/CRS resolution, compositor, and export in the follow-on issues). Keeping
+them in one place avoids each test re-inventing georeferenced scenes.
+
+Builders return :class:`~wiser.raster.dataset.RasterDataSet` objects:
+
+* :func:`make_numpy_scene` -- an in-RAM ``NumPyRasterDataImpl``-backed scene.
+* :func:`make_gtiff_scene` -- a disk-backed GeoTIFF scene (GDAL impl).
+* :func:`make_overlapping_scene_pair` -- two scenes whose footprints partially
+  overlap, one NumPy-backed and one GeoTIFF-backed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
+from osgeo import gdal, gdal_array, osr
+
+from wiser.raster.dataset import RasterDataSet
+from wiser.raster.dataset_impl import GTiff_GDALRasterDataImpl, NumPyRasterDataImpl
+
+# Default UTM zone 11N (EPSG:32611) - a metric CRS that makes overlap geometry
+# easy to reason about in meters.
+DEFAULT_EPSG = 32611
+
+
+def wkt_for_epsg(epsg: int) -> str:
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(epsg)
+    return srs.ExportToWkt()
+
+
+def _build_cube(num_bands: int, height: int, width: int, dtype: np.dtype, base: float) -> np.ndarray:
+    """Deterministic [band][y][x] cube so reads are easy to assert against."""
+    n = num_bands * height * width
+    arr = (np.arange(n, dtype=np.float64) + base).reshape(num_bands, height, width)
+    return arr.astype(dtype)
+
+
+def _wavelength_band_info(wavelengths: Sequence[float], units: str) -> List[dict]:
+    info: List[dict] = []
+    for i, wl in enumerate(wavelengths):
+        info.append(
+            {
+                "index": i,
+                "description": f"Band {i}",
+                "wavelength_name": f"{wl} {units}",
+                "wavelength_str": str(wl),
+                "wavelength_units": units,
+            }
+        )
+    return info
+
+
+def make_numpy_scene(
+    *,
+    width: int = 8,
+    height: int = 6,
+    num_bands: int = 3,
+    dtype: np.dtype = np.dtype(np.float32),
+    origin: Tuple[float, float] = (300000.0, 4000000.0),
+    pixel_size: Tuple[float, float] = (10.0, -10.0),
+    epsg: int = DEFAULT_EPSG,
+    nodata: Optional[float] = -9999.0,
+    wavelengths: Optional[Sequence[float]] = None,
+    wavelength_units: str = "nm",
+    base_value: float = 0.0,
+) -> RasterDataSet:
+    """
+    Build an in-RAM, georeferenced ``NumPyRasterDataImpl``-backed scene.
+
+    The geotransform is north-up: ``(origin_x, px_w, 0, origin_y, 0, px_h)``
+    (``px_h`` is typically negative). Spatial reference, nodata, and optional
+    per-band wavelength metadata are stamped onto the ``RasterDataSet`` object.
+    """
+    cube = _build_cube(num_bands, height, width, np.dtype(dtype), base_value)
+    dataset = RasterDataSet(NumPyRasterDataImpl(cube))
+
+    geo_transform = (origin[0], pixel_size[0], 0.0, origin[1], 0.0, pixel_size[1])
+    dataset._set_geo_transform(geo_transform)
+    dataset._set_wkt(wkt_for_epsg(epsg))
+
+    if nodata is not None:
+        dataset.set_data_ignore_value(nodata)
+
+    if wavelengths is not None:
+        if len(wavelengths) != num_bands:
+            raise ValueError("wavelengths must have one entry per band")
+        dataset.set_band_list(_wavelength_band_info(wavelengths, wavelength_units))
+
+    return dataset
+
+
+def write_gtiff(
+    dest_path: Path,
+    *,
+    width: int = 8,
+    height: int = 6,
+    num_bands: int = 3,
+    dtype: np.dtype = np.dtype(np.float32),
+    origin: Tuple[float, float] = (300100.0, 3999900.0),
+    pixel_size: Tuple[float, float] = (10.0, -10.0),
+    epsg: int = DEFAULT_EPSG,
+    nodata: Optional[float] = -9999.0,
+    base_value: float = 1000.0,
+) -> np.ndarray:
+    """
+    Write a small GeoTIFF to ``dest_path`` and return its [band][y][x] cube.
+
+    Used both to seed disk-backed scenes and to assert that on-disk metadata is
+    correctly overridden by a wrapping ``RasterDataSet``.
+    """
+    cube = _build_cube(num_bands, height, width, np.dtype(dtype), base_value)
+    gdal_type = gdal_array.NumericTypeCodeToGDALTypeCode(np.dtype(dtype))
+
+    driver = gdal.GetDriverByName("GTiff")
+    ds = driver.Create(str(dest_path), width, height, num_bands, gdal_type)
+    ds.SetGeoTransform((origin[0], pixel_size[0], 0.0, origin[1], 0.0, pixel_size[1]))
+    ds.SetProjection(wkt_for_epsg(epsg))
+    for b in range(num_bands):
+        band = ds.GetRasterBand(b + 1)
+        if nodata is not None:
+            band.SetNoDataValue(float(nodata))
+        band.WriteArray(cube[b])
+    ds.FlushCache()
+    ds = None
+    return cube
+
+
+def make_gtiff_scene(dest_path: Path, **kwargs) -> RasterDataSet:
+    """
+    Write a small GeoTIFF to ``dest_path`` and load it as a GDAL-backed
+    ``RasterDataSet``. Accepts the same keyword arguments as :func:`write_gtiff`.
+    """
+    write_gtiff(dest_path, **kwargs)
+    impls = GTiff_GDALRasterDataImpl.try_load_file(str(dest_path), interactive=False)
+    if not impls:
+        raise RuntimeError(f"Failed to load GeoTIFF scene from {dest_path}")
+    return RasterDataSet(impls[0], data_cache=None)
+
+
+def make_overlapping_scene_pair(tmp_dir: Path) -> Tuple[RasterDataSet, RasterDataSet]:
+    """
+    Return two georeferenced scenes (one NumPy-backed, one GeoTIFF-backed) in
+    the same CRS whose footprints partially overlap.
+
+    Scene A origin (300000, 4000000); Scene B origin shifted by +40m east and
+    -40m south (4 pixels at 10 m), so the 8x6 footprints overlap but are not
+    identical.
+    """
+    scene_a = make_numpy_scene(origin=(300000.0, 4000000.0), base_value=0.0)
+    scene_b = make_gtiff_scene(
+        tmp_dir / "scene_b.tif",
+        origin=(300040.0, 3999960.0),
+        base_value=1000.0,
+    )
+    return scene_a, scene_b

--- a/src/tests/mosaic_fixtures.py
+++ b/src/tests/mosaic_fixtures.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
+from astropy import units as u
 from osgeo import gdal, gdal_array, osr
 
 from wiser.raster.dataset import RasterDataSet
@@ -44,6 +45,7 @@ def _build_cube(num_bands: int, height: int, width: int, dtype: np.dtype, base: 
 
 
 def _wavelength_band_info(wavelengths: Sequence[float], units: str) -> List[dict]:
+    unit = u.Unit(units)
     info: List[dict] = []
     for i, wl in enumerate(wavelengths):
         info.append(
@@ -51,6 +53,7 @@ def _wavelength_band_info(wavelengths: Sequence[float], units: str) -> List[dict
                 "index": i,
                 "description": f"Band {i}",
                 "wavelength_name": f"{wl} {units}",
+                "wavelength": wl * unit,
                 "wavelength_str": str(wl),
                 "wavelength_units": units,
             }
@@ -70,14 +73,17 @@ def make_numpy_scene(
     nodata: Optional[float] = -9999.0,
     wavelengths: Optional[Sequence[float]] = None,
     wavelength_units: str = "nm",
+    bad_bands: Optional[Sequence[int]] = None,
+    default_display_bands: Optional[Sequence[int]] = None,
     base_value: float = 0.0,
 ) -> RasterDataSet:
     """
     Build an in-RAM, georeferenced ``NumPyRasterDataImpl``-backed scene.
 
     The geotransform is north-up: ``(origin_x, px_w, 0, origin_y, 0, px_h)``
-    (``px_h`` is typically negative). Spatial reference, nodata, and optional
-    per-band wavelength metadata are stamped onto the ``RasterDataSet`` object.
+    (``px_h`` is typically negative). Spatial reference, nodata, optional
+    per-band wavelength metadata, bad-band list, and default display bands are
+    stamped onto the ``RasterDataSet`` object.
     """
     cube = _build_cube(num_bands, height, width, np.dtype(dtype), base_value)
     dataset = RasterDataSet(NumPyRasterDataImpl(cube))
@@ -93,6 +99,12 @@ def make_numpy_scene(
         if len(wavelengths) != num_bands:
             raise ValueError("wavelengths must have one entry per band")
         dataset.set_band_list(_wavelength_band_info(wavelengths, wavelength_units))
+
+    if bad_bands is not None:
+        dataset.set_bad_bands(list(bad_bands))
+
+    if default_display_bands is not None:
+        dataset.set_default_display_bands(tuple(default_display_bands))
 
     return dataset
 

--- a/src/tests/test_mosaic_materialize.py
+++ b/src/tests/test_mosaic_materialize.py
@@ -1,0 +1,154 @@
+"""
+Tests for the Seamless Mosaic materialization adapter
+(:mod:`wiser.raster.mosaic_materialize`).
+
+Covers:
+* metadata fidelity + tiled layout of the materialized GeoTIFF,
+* window-read correctness (block-level laziness, no full-array dependence),
+* the RasterDataSet object overriding its GDAL backing's metadata,
+* dedup (one write per scene per session),
+* temp-dir lifecycle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from osgeo import gdal, osr
+
+import tests.context  # noqa: F401  (sets up sys.path for `wiser` imports)
+
+from tests.mosaic_fixtures import make_numpy_scene, wkt_for_epsg, write_gtiff
+from wiser.raster.dataset import RasterDataSet
+from wiser.raster.dataset_impl import GTiff_GDALRasterDataImpl
+from wiser.raster.mosaic_materialize import SceneMaterializer, materialize_to_tiled_geotiff
+
+pytestmark = [pytest.mark.unit]
+
+
+def _srs_same(wkt_a: str, wkt_b: str) -> bool:
+    a = osr.SpatialReference()
+    a.ImportFromWkt(wkt_a)
+    b = osr.SpatialReference()
+    b.ImportFromWkt(wkt_b)
+    return bool(a.IsSame(b))
+
+
+def test_numpy_scene_round_trip_metadata_and_tiled(tmp_path: Path) -> None:
+    wavelengths = [450.0, 550.0, 650.0]
+    scene = make_numpy_scene(
+        width=8,
+        height=6,
+        num_bands=3,
+        origin=(300000.0, 4000000.0),
+        pixel_size=(10.0, -10.0),
+        epsg=32611,
+        nodata=-9999.0,
+        wavelengths=wavelengths,
+    )
+
+    dest = tmp_path / "numpy_scene.tif"
+    materialize_to_tiled_geotiff(scene, dest)
+
+    ds = gdal.Open(str(dest))
+    try:
+        assert (ds.RasterXSize, ds.RasterYSize, ds.RasterCount) == (8, 6, 3)
+
+        np.testing.assert_allclose(ds.GetGeoTransform(), (300000.0, 10.0, 0.0, 4000000.0, 0.0, -10.0))
+        assert _srs_same(ds.GetProjection(), wkt_for_epsg(32611))
+
+        band1 = ds.GetRasterBand(1)
+        assert band1.GetNoDataValue() == pytest.approx(-9999.0)
+        # Tiled with the requested 256-pixel blocks (independent of image size).
+        assert band1.GetBlockSize() == [256, 256]
+        assert band1.GetMetadataItem("wavelength_units") == "nm"
+
+        for b in range(3):
+            expected = np.asarray(scene.get_band_data(b, filter_data_ignore_value=False))
+            np.testing.assert_array_equal(ds.GetRasterBand(b + 1).ReadAsArray(), expected)
+    finally:
+        ds = None
+
+
+def test_window_read_matches_source(tmp_path: Path) -> None:
+    scene = make_numpy_scene(width=10, height=9, num_bands=2, base_value=5.0)
+    dest = tmp_path / "window.tif"
+    materialize_to_tiled_geotiff(scene, dest)
+
+    xoff, yoff, xsize, ysize = 3, 2, 4, 5
+    ds = gdal.Open(str(dest))
+    try:
+        for b in range(scene.num_bands()):
+            window = ds.GetRasterBand(b + 1).ReadAsArray(xoff, yoff, xsize, ysize)
+            full = np.asarray(scene.get_band_data(b, filter_data_ignore_value=False))
+            expected = full[yoff : yoff + ysize, xoff : xoff + xsize]
+            np.testing.assert_array_equal(window, expected)
+    finally:
+        ds = None
+
+
+def test_rasterdataset_metadata_overrides_gdal_backing(tmp_path: Path) -> None:
+    """A GDAL-backed scene is re-materialized from the RasterDataSet object, so
+    metadata the object carries wins over the (stale) on-disk backing."""
+    backing = tmp_path / "backing.tif"
+    # On-disk metadata ("set A").
+    write_gtiff(
+        backing,
+        width=8,
+        height=6,
+        num_bands=2,
+        origin=(300000.0, 4000000.0),
+        pixel_size=(10.0, -10.0),
+        epsg=32611,
+        nodata=-9999.0,
+    )
+    impls = GTiff_GDALRasterDataImpl.try_load_file(str(backing), interactive=False)
+    scene = RasterDataSet(impls[0], data_cache=None)
+
+    # Diverge the wrapping object's metadata from the backing ("set B").
+    new_geo_transform = (500000.0, 5.0, 0.0, 3900000.0, 0.0, -5.0)
+    new_nodata = -1234.0
+    new_epsg = 4326
+    scene._set_geo_transform(new_geo_transform)
+    scene._set_wkt(wkt_for_epsg(new_epsg))
+    scene.set_data_ignore_value(new_nodata)
+
+    with SceneMaterializer() as materializer:
+        out_path = materializer.gdal_source(scene)
+        ds = gdal.Open(out_path)
+        try:
+            # Output reflects set B (the object), not set A (the backing file).
+            np.testing.assert_allclose(ds.GetGeoTransform(), new_geo_transform)
+            assert _srs_same(ds.GetProjection(), wkt_for_epsg(new_epsg))
+            assert ds.GetRasterBand(1).GetNoDataValue() == pytest.approx(new_nodata)
+        finally:
+            ds = None
+
+
+def test_dedup_single_write() -> None:
+    scene = make_numpy_scene()
+    with SceneMaterializer() as materializer:
+        first = materializer.gdal_source(scene)
+        second = materializer.gdal_source(scene)
+
+        assert first == second
+        tifs = list(materializer.temp_path.glob("*.tif"))
+        assert len(tifs) == 1
+
+
+def test_temp_dir_lifecycle() -> None:
+    materializer = SceneMaterializer()
+    temp_path = materializer.temp_path
+    assert temp_path.exists()
+
+    materializer.close()
+    assert not temp_path.exists()
+
+
+def test_temp_dir_lifecycle_context_manager() -> None:
+    with SceneMaterializer() as materializer:
+        temp_path = materializer.temp_path
+        assert temp_path.exists()
+    assert not temp_path.exists()

--- a/src/tests/test_mosaic_materialize.py
+++ b/src/tests/test_mosaic_materialize.py
@@ -23,7 +23,11 @@ import tests.context  # noqa: F401  (sets up sys.path for `wiser` imports)
 from tests.mosaic_fixtures import make_numpy_scene, wkt_for_epsg, write_gtiff
 from wiser.raster.dataset import RasterDataSet
 from wiser.raster.dataset_impl import GTiff_GDALRasterDataImpl
-from wiser.raster.mosaic_materialize import SceneMaterializer, materialize_to_tiled_geotiff
+from wiser.raster.mosaic_materialize import (
+    SceneMaterializer,
+    materialize_to_tiled_geotiff,
+    read_materialized_geotiff,
+)
 
 pytestmark = [pytest.mark.unit]
 
@@ -70,6 +74,38 @@ def test_numpy_scene_round_trip_metadata_and_tiled(tmp_path: Path) -> None:
             np.testing.assert_array_equal(ds.GetRasterBand(b + 1).ReadAsArray(), expected)
     finally:
         ds = None
+
+
+def test_read_materialized_geotiff_reconstructs_metadata(tmp_path: Path) -> None:
+    """A materialize -> read_materialized_geotiff round trip restores the
+    metadata we had to encode in the GDAL object: wavelength value + units,
+    bad bands, default display bands, and nodata."""
+    wavelengths = [450.0, 550.0, 650.0]
+    scene = make_numpy_scene(
+        width=8,
+        height=6,
+        num_bands=3,
+        epsg=32611,
+        nodata=-9999.0,
+        wavelengths=wavelengths,
+        wavelength_units="nm",
+        bad_bands=[1, 0, 1],
+        default_display_bands=(2, 1, 0),
+    )
+
+    dest = tmp_path / "round_trip.tif"
+    materialize_to_tiled_geotiff(scene, dest)
+
+    restored = read_materialized_geotiff(dest)
+
+    assert restored.get_bad_bands() == [1, 0, 1]
+    assert tuple(restored.default_display_bands()) == (2, 1, 0)
+    assert restored.get_data_ignore_value() == pytest.approx(-9999.0)
+
+    restored_wavelengths = restored.get_wavelengths()
+    assert restored_wavelengths is not None
+    assert [q.value for q in restored_wavelengths] == pytest.approx(wavelengths)
+    assert all(str(q.unit) == "nm" for q in restored_wavelengths)
 
 
 def test_window_read_matches_source(tmp_path: Path) -> None:

--- a/src/wiser/raster/mosaic_materialize.py
+++ b/src/wiser/raster/mosaic_materialize.py
@@ -1,0 +1,230 @@
+"""
+Materialization adapter for the Seamless Mosaic pipeline.
+
+The mosaic pixel pipeline (footprints, warp-to-grid, compositing, export) is
+GDAL-native and wants a warpable GDAL source per scene. WISER scenes are
+:class:`~wiser.raster.dataset.RasterDataSet` objects with several backings
+(GDAL handles, NumPy arrays, PDR-backed, NetCDF/JP2 subdatasets), and the
+``RasterDataSet`` object is the source of truth for metadata and data -- it may
+carry edits/metadata that its on-disk backing lacks.
+
+This module provides:
+
+* :func:`materialize_to_tiled_geotiff` -- a stateless converter that writes a
+  ``RasterDataSet`` to a disk-backed, tiled GeoTIFF, stamping spatial and
+  spectral metadata from the ``RasterDataSet`` object (not its impl).
+* :class:`SceneMaterializer` -- a session-scoped adapter that owns a temporary
+  directory and a per-scene dedup cache, and returns a warpable GDAL source
+  path for any scene by always materializing it.
+
+The output is disk-backed (not ``/vsimem``, which is RAM-backed) so GDAL reads
+only the requested windows, and tiled so window reads do not pull whole rows.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Dict, Optional
+
+import numpy as np
+from osgeo import gdal, gdal_array
+
+from wiser.raster.dataset import RasterDataSet
+from wiser.utils.primitives import temp_dir
+
+logger = logging.getLogger(__name__)
+
+# Tiled-GeoTIFF block size. 256 keeps window reads from pulling whole rows while
+# staying friendly to GDAL's default block cache.
+_BLOCK_SIZE = 256
+
+
+def _gdal_type_and_write_dtype(elem_type: np.dtype) -> tuple[int, np.dtype]:
+    """
+    Map an in-memory per-pixel dtype to a GDAL band type and the NumPy dtype to
+    use for ``WriteArray``. GDAL has no native boolean band type, so boolean
+    cubes are written as ``GDT_Byte`` with 0/1 values.
+    """
+    et = np.dtype(elem_type)
+    if np.issubdtype(et, np.bool_):
+        return gdal.GDT_Byte, np.dtype(np.uint8)
+    gdal_type = gdal_array.NumericTypeCodeToGDALTypeCode(et)
+    if gdal_type is None:
+        raise TypeError(f"Unsupported NumPy dtype for GDAL materialization: {et}")
+    return gdal_type, et
+
+
+def _stamp_metadata_from_dataset(gdal_dataset: gdal.Dataset, source_dataset: RasterDataSet) -> None:
+    """
+    Stamp spatial and spectral metadata onto ``gdal_dataset`` sourced from the
+    ``RasterDataSet`` object (the source of truth), not from its impl.
+
+    Mirrors the band-metadata conventions of
+    :func:`wiser.raster.utils.copy_metadata_to_gdal_dataset` but additionally
+    stamps SRS and geotransform, and never closes the handle (the caller owns
+    flush/close).
+    """
+    geo_transform = source_dataset.get_geo_transform()
+    if geo_transform is not None:
+        gdal_dataset.SetGeoTransform([float(v) for v in geo_transform])
+
+    wkt = source_dataset.get_wkt_spatial_reference()
+    if wkt:
+        gdal_dataset.SetProjection(wkt)
+
+    nodata = source_dataset.get_data_ignore_value()
+    if nodata is not None:
+        for i in range(1, gdal_dataset.RasterCount + 1):
+            gdal_dataset.GetRasterBand(i).SetNoDataValue(float(nodata))
+
+    band_info = source_dataset.band_list()
+
+    # Band descriptions follow the established ENVI/GDAL convention of using the
+    # "wavelength_name" entry when present.
+    if band_info and band_info[0].get("wavelength_name"):
+        for i, info in enumerate(band_info):
+            name = info.get("wavelength_name")
+            if name is not None:
+                gdal_dataset.GetRasterBand(i + 1).SetDescription(str(name))
+
+    defaults = source_dataset.default_display_bands()
+    if defaults:
+        gdal_dataset.SetMetadataItem("DEFAULT_BANDS", ",".join(str(b) for b in defaults))
+
+    bad = source_dataset.get_bad_bands()
+    if bad:
+        gdal_dataset.SetMetadataItem("BAD_BANDS", ",".join(str(b) for b in bad))
+
+    if band_info and band_info[0].get("wavelength_str") is not None:
+        for i, info in enumerate(band_info):
+            wl_str = info.get("wavelength_str")
+            if wl_str is not None:
+                gdal_dataset.GetRasterBand(i + 1).SetMetadataItem("wavelength", str(wl_str))
+
+    if band_info and band_info[0].get("wavelength_units") is not None:
+        for i, info in enumerate(band_info):
+            wl_units = info.get("wavelength_units")
+            if wl_units is not None:
+                gdal_dataset.GetRasterBand(i + 1).SetMetadataItem("wavelength_units", str(wl_units))
+
+
+def materialize_to_tiled_geotiff(dataset: RasterDataSet, dest_path: Path) -> None:
+    """
+    Write ``dataset`` to a disk-backed, tiled GeoTIFF at ``dest_path``.
+
+    Stateless converter: it does not cache, register, or track the output. The
+    caller decides whether to call it and owns the resulting file's lifetime
+    (see :class:`SceneMaterializer`).
+
+    Data and metadata are sourced from the ``RasterDataSet`` object, so the
+    output reflects the up-to-date dataset even when the dataset diverges from
+    its on-disk backing. Bands are written one at a time to bound peak memory,
+    and unmasked raw values are written (nodata sentinels are preserved and
+    recorded as the band NoData value).
+    """
+    gdal.UseExceptions()
+
+    width = dataset.get_width()
+    height = dataset.get_height()
+    num_bands = dataset.num_bands()
+    gdal_type, write_dtype = _gdal_type_and_write_dtype(dataset.get_elem_type())
+
+    driver = gdal.GetDriverByName("GTiff")
+    options = [
+        "TILED=YES",
+        f"BLOCKXSIZE={_BLOCK_SIZE}",
+        f"BLOCKYSIZE={_BLOCK_SIZE}",
+    ]
+
+    out_ds: Optional[gdal.Dataset] = driver.Create(
+        str(dest_path), width, height, num_bands, gdal_type, options=options
+    )
+    if out_ds is None:
+        raise RuntimeError(f"GDAL failed to create tiled GeoTIFF at {dest_path}")
+
+    try:
+        for band_index in range(num_bands):
+            # filter_data_ignore_value=False keeps the raw values (including the
+            # nodata sentinel) so the materialized file mirrors the source.
+            band_arr = dataset.get_band_data(band_index, filter_data_ignore_value=False)
+            band_arr = np.asarray(band_arr, dtype=write_dtype)
+            out_ds.GetRasterBand(band_index + 1).WriteArray(band_arr)
+
+        _stamp_metadata_from_dataset(out_ds, dataset)
+        out_ds.FlushCache()
+    finally:
+        out_ds = None
+
+    logger.info(
+        "Materialized dataset id=%s to tiled GeoTIFF %s (%dx%d, %d bands)",
+        dataset.get_id(),
+        dest_path,
+        width,
+        height,
+        num_bands,
+    )
+
+
+class SceneMaterializer:
+    """
+    Session-scoped adapter that turns any :class:`RasterDataSet` scene into a
+    warpable GDAL source path.
+
+    Every scene -- GDAL-backed or not -- is materialized to a disk-backed tiled
+    GeoTIFF, because the ``RasterDataSet`` object is the source of truth and may
+    carry metadata/data its backing file lacks. A per-scene dedup cache keeps
+    this to one write per scene per session.
+
+    Lifetime: owns a :class:`tempfile.TemporaryDirectory` created under WISER's
+    shared temp root (:func:`wiser.utils.primitives.temp_dir`). The directory is
+    removed on :meth:`close` / context-manager exit; ``TemporaryDirectory``'s
+    own finalizer is the backstop on GC / interpreter exit.
+    """
+
+    def __init__(self) -> None:
+        root = temp_dir()
+        root.mkdir(parents=True, exist_ok=True)
+        self._tmp = tempfile.TemporaryDirectory(dir=str(root), prefix="mosaic_")
+        # Maps a scene key (dataset id, else object identity) to its temp .tif.
+        self._cache: Dict[int, Path] = {}
+
+    @property
+    def temp_path(self) -> Path:
+        """The session temporary directory holding materialized scenes."""
+        return Path(self._tmp.name)
+
+    @staticmethod
+    def _scene_key(dataset: RasterDataSet) -> int:
+        # Prefer the app-assigned dataset id. Fall back to object identity, which
+        # is stable for the session lifetime -- exactly the temp dir's lifetime.
+        ds_id = dataset.get_id()
+        return ds_id if ds_id is not None else id(dataset)
+
+    def gdal_source(self, dataset: RasterDataSet) -> str:
+        """
+        Return a filesystem path to a warpable, disk-backed tiled GeoTIFF for
+        ``dataset``, materializing it on first request and reusing the cached
+        result thereafter.
+        """
+        key = self._scene_key(dataset)
+        cached = self._cache.get(key)
+        if cached is not None and cached.exists():
+            return str(cached)
+
+        dest = self.temp_path / f"scene_{key}.tif"
+        materialize_to_tiled_geotiff(dataset, dest)
+        self._cache[key] = dest
+        return str(dest)
+
+    def close(self) -> None:
+        """Deterministically remove the session temporary directory."""
+        self._cache.clear()
+        self._tmp.cleanup()
+
+    def __enter__(self) -> "SceneMaterializer":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()

--- a/src/wiser/raster/mosaic_materialize.py
+++ b/src/wiser/raster/mosaic_materialize.py
@@ -32,6 +32,7 @@ import numpy as np
 from osgeo import gdal, gdal_array
 
 from wiser.raster.dataset import RasterDataSet
+from wiser.raster.dataset_impl import GTiff_GDALRasterDataImpl
 from wiser.utils.primitives import temp_dir
 
 logger = logging.getLogger(__name__)
@@ -54,6 +55,24 @@ def _gdal_type_and_write_dtype(elem_type: np.dtype) -> tuple[int, np.dtype]:
     if gdal_type is None:
         raise TypeError(f"Unsupported NumPy dtype for GDAL materialization: {et}")
     return gdal_type, et
+
+
+def _band_wavelength_value_and_units(info: dict) -> tuple[Optional[object], Optional[str]]:
+    """
+    Extract a band's numeric wavelength value and unit string from a band-info
+    dict, preferring the canonical astropy ``Quantity`` under "wavelength" and
+    falling back to the "wavelength_str"/"wavelength_units" string fields.
+    Returns ``(None, None)`` when no wavelength is present.
+    """
+    quantity = info.get("wavelength")
+    if quantity is not None and hasattr(quantity, "value") and hasattr(quantity, "unit"):
+        return quantity.value, str(quantity.unit)
+
+    wl_str = info.get("wavelength_str")
+    if wl_str is None:
+        return None, None
+    wl_units = info.get("wavelength_units")
+    return wl_str, (str(wl_units) if wl_units is not None else None)
 
 
 def _stamp_metadata_from_dataset(gdal_dataset: gdal.Dataset, source_dataset: RasterDataSet) -> None:
@@ -81,13 +100,24 @@ def _stamp_metadata_from_dataset(gdal_dataset: gdal.Dataset, source_dataset: Ras
 
     band_info = source_dataset.band_list()
 
-    # Band descriptions follow the established ENVI/GDAL convention of using the
-    # "wavelength_name" entry when present.
-    if band_info and band_info[0].get("wavelength_name"):
-        for i, info in enumerate(band_info):
-            name = info.get("wavelength_name")
-            if name is not None:
-                gdal_dataset.GetRasterBand(i + 1).SetDescription(str(name))
+    # Per-band spectral metadata. We write the numeric wavelength value under
+    # "wavelength" and its units under "wavelength_units" -- the exact pair that
+    # GDALRasterDataImpl.read_band_info reads back to rebuild the wavelength
+    # Quantity, so a normal reload reconstructs wavelengths automatically.
+    for i, info in enumerate(band_info):
+        band = gdal_dataset.GetRasterBand(i + 1)
+
+        # Band descriptions follow the established ENVI/GDAL convention of using
+        # the "wavelength_name" entry when present.
+        name = info.get("wavelength_name")
+        if name is not None:
+            band.SetDescription(str(name))
+
+        value, units = _band_wavelength_value_and_units(info)
+        if value is not None:
+            band.SetMetadataItem("wavelength", str(value))
+        if units is not None:
+            band.SetMetadataItem("wavelength_units", str(units))
 
     defaults = source_dataset.default_display_bands()
     if defaults:
@@ -96,18 +126,6 @@ def _stamp_metadata_from_dataset(gdal_dataset: gdal.Dataset, source_dataset: Ras
     bad = source_dataset.get_bad_bands()
     if bad:
         gdal_dataset.SetMetadataItem("BAD_BANDS", ",".join(str(b) for b in bad))
-
-    if band_info and band_info[0].get("wavelength_str") is not None:
-        for i, info in enumerate(band_info):
-            wl_str = info.get("wavelength_str")
-            if wl_str is not None:
-                gdal_dataset.GetRasterBand(i + 1).SetMetadataItem("wavelength", str(wl_str))
-
-    if band_info and band_info[0].get("wavelength_units") is not None:
-        for i, info in enumerate(band_info):
-            wl_units = info.get("wavelength_units")
-            if wl_units is not None:
-                gdal_dataset.GetRasterBand(i + 1).SetMetadataItem("wavelength_units", str(wl_units))
 
 
 def materialize_to_tiled_geotiff(dataset: RasterDataSet, dest_path: Path) -> None:
@@ -145,12 +163,18 @@ def materialize_to_tiled_geotiff(dataset: RasterDataSet, dest_path: Path) -> Non
         raise RuntimeError(f"GDAL failed to create tiled GeoTIFF at {dest_path}")
 
     try:
+        # Write one band at a time (rather than the whole cube) to keep peak
+        # memory low: at most a single (height, width) band is resident per
+        # iteration, and it is released before the next band is read.
         for band_index in range(num_bands):
             # filter_data_ignore_value=False keeps the raw values (including the
             # nodata sentinel) so the materialized file mirrors the source.
             band_arr = dataset.get_band_data(band_index, filter_data_ignore_value=False)
             band_arr = np.asarray(band_arr, dtype=write_dtype)
             out_ds.GetRasterBand(band_index + 1).WriteArray(band_arr)
+            # Drop the reference so the band can be reclaimed now instead of
+            # lingering until it is reassigned on the next iteration.
+            del band_arr
 
         _stamp_metadata_from_dataset(out_ds, dataset)
         out_ds.FlushCache()
@@ -165,6 +189,41 @@ def materialize_to_tiled_geotiff(dataset: RasterDataSet, dest_path: Path) -> Non
         height,
         num_bands,
     )
+
+
+def read_materialized_geotiff(path: Path) -> RasterDataSet:
+    """
+    Reconstruct a :class:`RasterDataSet` from a GeoTIFF written by
+    :func:`materialize_to_tiled_geotiff`, restoring all stamped metadata.
+
+    Loading through ``GTiff_GDALRasterDataImpl`` already recovers the
+    geotransform, spatial reference, nodata value, and per-band wavelength
+    value/units (the GDAL band reader rebuilds the wavelength ``Quantity`` from
+    the "wavelength" / "wavelength_units" items). This function additionally
+    restores the dataset-level metadata GDAL does not interpret on its own --
+    the bad-band list and the default display bands -- so the returned object
+    matches the source ``RasterDataSet`` that was materialized.
+    """
+    impls = GTiff_GDALRasterDataImpl.try_load_file(str(path), interactive=False)
+    if not impls:
+        raise RuntimeError(f"Failed to load materialized GeoTIFF from {path}")
+    dataset = RasterDataSet(impls[0], data_cache=None)
+
+    metadata = impls[0].gdal_dataset.GetMetadata()
+
+    bad_bands_str = metadata.get("BAD_BANDS")
+    if bad_bands_str:
+        bad_bands = [int(v) for v in bad_bands_str.split(",")]
+        if len(bad_bands) == dataset.num_bands():
+            dataset.set_bad_bands(bad_bands)
+
+    default_bands_str = metadata.get("DEFAULT_BANDS")
+    if default_bands_str:
+        default_bands = tuple(int(v) for v in default_bands_str.split(","))
+        if len(default_bands) in (1, 3):
+            dataset.set_default_display_bands(default_bands)
+
+    return dataset
 
 
 class SceneMaterializer:

--- a/src/wiser/raster/utils.py
+++ b/src/wiser/raster/utils.py
@@ -876,9 +876,8 @@ def copy_metadata_to_gdal_dataset(gdal_dataset: gdal.Dataset, source_dataset: "R
             wl_units = band_info[i].get("wavelength_units")
             gdal_dataset.GetRasterBand(i + 1).SetMetadataItem("wavelength_units", str(wl_units))
 
-    # Flush and close when done
-    gdal_dataset.FlushCache()
-    gdal_dataset = None
+    # Note: the caller owns the handle's lifetime. We intentionally do not flush
+    # or close here so callers can keep stamping/reading before closing.
 
 
 def get_bbox(gt, width, height):


### PR DESCRIPTION
## What does this change do?
Adds functionality for going from a RasterDataSet object to a GDAL backed and disk backed geotiff and back. Adds tests for this functionality. This will be needed when we do mosaicking through GDAL.

Closes #632

## What type of PR is this? (check all applicable) 
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [X] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed
