### PR TITLE
ci: attach installers as release assets with normalized names

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -189,12 +189,14 @@ jobs:
             ubuntu2004) distro_key="ubuntu_2004" ;;
             debian11)   distro_key="debian_11" ;;
             fedora39)   distro_key="fedora_39" ;;
+            *) echo "Unknown distro: ${{ matrix.distro }}" >&2; exit 1 ;;
           esac
 
           # Normalize the arch token to the web-friendly x64/arm64 form.
           case "${{ matrix.target_arch }}" in
             amd64) arch="x64" ;;
             arm64) arch="arm64" ;;
+            *) echo "Unknown target_arch: ${{ matrix.target_arch }}" >&2; exit 1 ;;
           esac
 
           src="linux_build_output/${distro_key}_${{ matrix.target_arch }}/WISER.tar.gz"

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,11 +1,11 @@
 name: Build and Smoke Test WISER
 
 on:
-  release:
-    types: [created]
   workflow_dispatch:
 
-# Least privilege by default; only the release-upload job is elevated to write.
+# This workflow only builds and smoke/test-checks WISER; it never writes to the repo or to
+# a release. Publishing the built assets to a release is a separate, manually triggered
+# workflow (publish-release-assets.yml).
 permissions:
   contents: read
 
@@ -178,12 +178,9 @@ jobs:
           set -euxo pipefail
           mkdir -p dist/linux
 
-          # On a release the tag is the version; otherwise read it from source.
-          if [ "${{ github.event_name }}" = "release" ]; then
-            version="${GITHUB_REF_NAME#v}"
-          else
-            version="$(python3 src/wiser/version.py)"
-          fi
+          # The build is always dispatched from the commit being released, so version.py
+          # is the source of truth for the version baked into the asset name.
+          version="$(python3 src/wiser/version.py)"
 
           # Source folder key matches build_linux_multistage.sh output layout.
           case "${{ matrix.distro }}" in
@@ -213,40 +210,3 @@ jobs:
           name: wiser-linux-${{ matrix.distro }}-${{ matrix.target_arch }}
           path: dist/linux/*.tar.gz
           if-no-files-found: error
-
-  # Linux builds are unsigned, so the CI output is the final asset. Attaching the
-  # tarballs to the release is isolated in its own job so the build matrix (which
-  # runs third-party container builds) stays read-only; only this job holds
-  # contents: write. !cancelled() lets it upload whatever legs succeeded even if a
-  # sibling leg failed. Windows/macOS are signed locally and uploaded via
-  # src/devtools/sign_*.py --release-tag.
-  linux_release_upload:
-    name: Attach Linux assets to the release
-    needs: linux_build
-    if: ${{ !cancelled() && github.event_name == 'release' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Download Linux build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: wiser-linux-*
-          path: dist/linux
-          merge-multiple: true
-
-      - name: Attach to the release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          set -euxo pipefail
-          shopt -s nullglob
-          assets=(dist/linux/*.tar.gz)
-          if [ ${#assets[@]} -eq 0 ]; then
-            echo "No Linux tarballs found to upload." >&2
-            exit 1
-          fi
-          ls -lah dist/linux
-          gh release upload "${GITHUB_REF_NAME}" "${assets[@]}" --clobber

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -5,6 +5,10 @@ on:
     types: [created]
   workflow_dispatch:
 
+# Least privilege by default; only the release-upload job is elevated to write.
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -111,9 +115,6 @@ jobs:
 
   linux_build:
     name: Linux build (${{ matrix.distro }} / ${{ matrix.target_arch }})
-    # Needed so the release-upload step can attach assets to the release.
-    permissions:
-      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -213,14 +214,39 @@ jobs:
           path: dist/linux/*.tar.gz
           if-no-files-found: error
 
-      # Linux builds are unsigned, so the CI output is the final asset and can be
-      # attached to the release directly. Windows/macOS are signed locally and
-      # uploaded via src/devtools/sign_*.py --release-tag.
-      - name: Attach Linux asset to the release
-        if: github.event_name == 'release'
+  # Linux builds are unsigned, so the CI output is the final asset. Attaching the
+  # tarballs to the release is isolated in its own job so the build matrix (which
+  # runs third-party container builds) stays read-only; only this job holds
+  # contents: write. !cancelled() lets it upload whatever legs succeeded even if a
+  # sibling leg failed. Windows/macOS are signed locally and uploaded via
+  # src/devtools/sign_*.py --release-tag.
+  linux_release_upload:
+    name: Attach Linux assets to the release
+    needs: linux_build
+    if: ${{ !cancelled() && github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download Linux build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wiser-linux-*
+          path: dist/linux
+          merge-multiple: true
+
+      - name: Attach to the release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euxo pipefail
-          gh release upload "${GITHUB_REF_NAME}" dist/linux/*.tar.gz --clobber
+          shopt -s nullglob
+          assets=(dist/linux/*.tar.gz)
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "No Linux tarballs found to upload." >&2
+            exit 1
+          fi
+          ls -lah dist/linux
+          gh release upload "${GITHUB_REF_NAME}" "${assets[@]}" --clobber

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -111,6 +111,9 @@ jobs:
 
   linux_build:
     name: Linux build (${{ matrix.distro }} / ${{ matrix.target_arch }})
+    # Needed so the release-upload step can attach assets to the release.
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -174,15 +177,28 @@ jobs:
           set -euxo pipefail
           mkdir -p dist/linux
 
-          # Map distro -> your output folder key
+          # On a release the tag is the version; otherwise read it from source.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="$(python3 src/wiser/version.py)"
+          fi
+
+          # Source folder key matches build_linux_multistage.sh output layout.
           case "${{ matrix.distro }}" in
             ubuntu2004) distro_key="ubuntu_2004" ;;
             debian11)   distro_key="debian_11" ;;
             fedora39)   distro_key="fedora_39" ;;
           esac
 
+          # Normalize the arch token to the web-friendly x64/arm64 form.
+          case "${{ matrix.target_arch }}" in
+            amd64) arch="x64" ;;
+            arm64) arch="arm64" ;;
+          esac
+
           src="linux_build_output/${distro_key}_${{ matrix.target_arch }}/WISER.tar.gz"
-          dst="dist/linux/WISER-${distro_key}-${{ matrix.target_arch }}.tar.gz"
+          dst="dist/linux/WISER-${version}-linux-${{ matrix.distro }}-${arch}.tar.gz"
 
           test -f "$src"
           cp "$src" "$dst"
@@ -194,3 +210,15 @@ jobs:
           name: wiser-linux-${{ matrix.distro }}-${{ matrix.target_arch }}
           path: dist/linux/*.tar.gz
           if-no-files-found: error
+
+      # Linux builds are unsigned, so the CI output is the final asset and can be
+      # attached to the release directly. Windows/macOS are signed locally and
+      # uploaded via src/devtools/sign_*.py --release-tag.
+      - name: Attach Linux asset to the release
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euxo pipefail
+          gh release upload "${GITHUB_REF_NAME}" dist/linux/*.tar.gz --clobber

--- a/.github/workflows/publish-release-assets.yml
+++ b/.github/workflows/publish-release-assets.yml
@@ -38,6 +38,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Validate the shape of the dispatch inputs up front so a typo fails fast with a
+          # clear message (they are passed via env, so they cannot inject shell in any case).
+          [[ "${RUN_ID}" =~ ^[0-9]+$ ]] || { echo "::error::run_id must be a positive integer."; exit 1; }
+          [[ "${TAG}" =~ ^[A-Za-z0-9._/-]+$ ]] || { echo "::error::tag has unexpected characters."; exit 1; }
+
           # The build run must have finished successfully. For Linux that already implies
           # every distro's in-container --test_mode passed, since a failed suite yields no
           # tarball and fails the leg.

--- a/.github/workflows/publish-release-assets.yml
+++ b/.github/workflows/publish-release-assets.yml
@@ -1,0 +1,81 @@
+name: Publish release assets
+
+# Attaches the Linux tarballs from a specific "Build and Smoke Test WISER" run to an
+# existing release, instead of rebuilding them at release time. The build already ran the
+# full --test_mode suite per distro (a Linux leg only produces a tarball if its tests
+# passed), so this promotes those exact, already-tested artifacts. Windows/macOS are signed
+# locally and uploaded separately via the sign scripts' RELEASE_TAG option.
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Build run ID (from 'Build and Smoke Test WISER') to promote"
+        required: true
+      tag:
+        description: "Release tag to attach the Linux assets to (the release must already exist)"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-release-assets-${{ github.event.inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish-linux:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # upload assets to the release
+      actions: read     # download artifacts from the build run
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      RUN_ID: ${{ github.event.inputs.run_id }}
+      TAG: ${{ github.event.inputs.tag }}
+    steps:
+      - name: Verify the build run succeeded and matches the tag
+        run: |
+          set -euo pipefail
+
+          # The build run must have finished successfully. For Linux that already implies
+          # every distro's in-container --test_mode passed, since a failed suite yields no
+          # tarball and fails the leg.
+          read -r conclusion run_sha < <(gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
+            --jq '(.conclusion // "pending") + " " + .head_sha')
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::Build run ${RUN_ID} concluded '${conclusion}', not 'success'. Refusing to promote."
+            exit 1
+          fi
+
+          # The tag must point at the exact commit that was built. A draft release has no
+          # tag ref yet, so we warn instead of failing; a published (pre-)release gives the
+          # strong check.
+          tag_sha="$(gh api "repos/${REPO}/commits/${TAG}" --jq '.sha' 2>/dev/null || true)"
+          if [ -z "$tag_sha" ]; then
+            echo "::warning::Tag ${TAG} has no commit yet (draft release?). Skipping tag==build-commit check."
+          elif [ "$tag_sha" != "$run_sha" ]; then
+            echo "::error::Tag ${TAG} points at ${tag_sha} but run ${RUN_ID} built ${run_sha}. Refusing to promote."
+            exit 1
+          fi
+          echo "Verified run ${RUN_ID} (success, ${run_sha})."
+
+      - name: Download the Linux tarballs from the build run
+        run: |
+          set -euo pipefail
+          mkdir -p promote
+          gh run download "${RUN_ID}" -R "${REPO}" --pattern 'wiser-linux-*' --dir promote
+          find promote -type f -name 'WISER-*-linux-*.tar.gz' | sort
+
+      - name: Attach the tarballs to the release
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+          assets=(promote/**/WISER-*-linux-*.tar.gz)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "::error::No Linux tarballs found in run ${RUN_ID} artifacts."
+            exit 1
+          fi
+          printf '%s\n' "${assets[@]}"
+          gh release upload "${TAG}" "${assets[@]}" --clobber -R "${REPO}"
+          echo "Attached ${#assets[@]} Linux asset(s) to ${TAG}."

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ MYPY_OPTS=
 
 OSX_BUNDLE_ID=edu.caltech.gps.WISER
 
+# Web-friendly arch token for the .dmg filename (x64 / arm64).
+MAC_ARCH := $(shell uname -m | sed 's/x86_64/x64/')
+
 #======================================================
 # WINDOWS SETTINGS
 
@@ -59,11 +62,11 @@ dist-mac : build-mac
 	hdiutil create dist/tmp.dmg -ov -volname "$(APP_NAME)" -fs HFS+ \
 		-srcfolder dist/$(APP_NAME).app
 	hdiutil convert dist/tmp.dmg -format UDZO \
-		-o dist/$(APP_NAME)-$(APP_VERSION).dmg
+		-o dist/$(APP_NAME)-$(APP_VERSION)-macos-$(MAC_ARCH).dmg
 	rm dist/tmp.dmg
 
 	# Submit the disk image to Apple for notarization
-	xcrun notarytool submit dist/$(APP_NAME)-$(APP_VERSION).dmg \
+	xcrun notarytool submit dist/$(APP_NAME)-$(APP_VERSION)-macos-$(MAC_ARCH).dmg \
 		--apple-id $(AD_USERNAME) --team-id $(AD_TEAM_ID) --password $(AD_PASSWORD)
 
 build-win : generated
@@ -118,12 +121,13 @@ sign-mac:
 	@python src/devtools/sign_mac.py --link "$(LINK)" --app-version "$(APP_VERSION)" \
 			--apple-id "$(AD_USERNAME)" --team-id "$(AD_TEAM_ID)" \
 			--app-password "$(AD_PASSWORD)" --app-name "$(APP_NAME)" \
-			--artifact-name "$(MAC_DIST_GITHUB_NAME)" --notarize
+			--artifact-name "$(MAC_DIST_GITHUB_NAME)" --notarize \
+			$(if $(RELEASE_TAG),--release-tag "$(RELEASE_TAG)",)
 
 sign-windows:  # Usage `make sign-windows LINK=https://github.com/Ehlmann-research-group/WISER/actions/runs/18478361575/artifacts/4259044563`
 	@rem Fail if LINK is missing
 	@if "$(LINK)"=="" ( echo ERROR: Provide LINK=<artifact URL> ; exit 1 )
 	@rem Call Python script with args
-	@python src\devtools\sign_windows.py --link "$(LINK)" --nsis $(NSIS) --app-version "$(APP_VERSION)" --sha1 "$(SHA1_THUMBPRINT)"
+	@python src\devtools\sign_windows.py --link "$(LINK)" --nsis $(NSIS) --app-version "$(APP_VERSION)" --sha1 "$(SHA1_THUMBPRINT)" $(if $(RELEASE_TAG),--release-tag "$(RELEASE_TAG)",)
 
 .PHONY: generated lint typecheck build-mac build-win clean sign-windows

--- a/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
@@ -70,11 +70,12 @@ infeasible for developers to run on each push to a pull
 request. We need to look into a way to speed up our builds
 (<10 minutes would be good).
 
-The deployment code is in the github action `prod-deploy.yml`. It
-builds WISER on all three platforms (windows, macos arm, macos intel)
-then runs tests inside of each WISER distributable. Running these tests
-ensures that WISER actually starts up and that core WISER functionality
-has been properly packaged up.
+The deployment code is in the github action `prod-deploy.yml`. It builds WISER on every
+platform (Windows, macOS arm/intel, and the six Linux distro/arch targets). The Linux legs
+run the full `--test_mode` suite inside each distributable (a hard gate — a failing suite
+produces no tarball); Windows and macOS run a fast `--smoke` launch check in CI and the full
+`--test_mode` locally. Running these checks ensures WISER actually starts up and that core
+functionality was packaged correctly.
 
 It is important to note that these build artifacts still
 need some more work done to them in order to become our
@@ -92,6 +93,13 @@ test that JP2OpenJPEG.dll was properly packaged into the
 build, we would have a test that would try opening up a very
 small JP2 file that we can run with a command like `./WISER_Bin --mode test`. So you can see how it is important
 to run tests on the build artifact.
+
+Note that "smoke test" means two different things in our pipeline. The **Linux** builds run
+the full `--test_mode` suite in-container via `install-linux/run_smoke.sh` (despite the
+name) — a failing suite fails the build and no tarball is produced. **Windows/macOS** run
+only a lightweight `--smoke` launch check in CI (start Qt, show the splash, exit) and rely
+on the full `--test_mode` being run locally before signing. Don't "standardize" the Linux
+path onto `--smoke` — that would silently drop the Linux test gate.
 
 We want to build these
 artifacts and run these tests on `main` and `rel/**` banches
@@ -165,11 +173,17 @@ step in `prod-deploy.yml` — not by hand on upload.
 
 ### How assets reach the release
 
-- **Linux** builds are unsigned, so `prod-deploy.yml` attaches them to the release
-  automatically when the workflow is triggered by a `release` event.
-- **Windows / macOS** are signed locally with the maintainer's certificates, then
-  uploaded with the canonical name via the sign scripts' `--release-tag <tag>` option
-  (see the Release Process below).
+Assets are **built once and promoted** — the release event never triggers a build, so the
+bits you ship are the exact bits you tested.
+
+- **Linux** builds are unsigned, so a CI tarball *is* the final asset. `prod-deploy.yml`
+  (run via `workflow_dispatch`) builds and tests each distro and uploads the tarballs as
+  run artifacts. When you are ready to release, `publish-release-assets.yml` attaches the
+  tarballs from that specific run to the release — it verifies the run succeeded and that
+  the tag points at the built commit, so nothing is rebuilt at release time.
+- **Windows / macOS** are signed locally with the maintainer's certificates, then uploaded
+  with the canonical name via the sign scripts' `--release-tag <tag>` option (see the
+  Release Process below).
 
 ### Pre-release flag
 
@@ -181,50 +195,66 @@ the latest release" on) so `latest` resolves to it.
 
 ## Release Process
 
-The process of creating a release is documented below.
+Assets are built once, tested, then **promoted** to the release — nothing is rebuilt at
+release time, so what ships is exactly what you tested.
 
-1. Create the GitHub release and tag the commit (see the Releases section for the
-   pre-release flag). Creating the release triggers `prod-deploy`, which builds every
-   platform and **automatically attaches the Linux assets** to the release. (You can
-   also run `prod-deploy` via `workflow_dispatch` to test a build without a release.)
-2. Sign and upload the Windows/macOS installers. Pass `RELEASE_TAG=<tag>` so the signed
-   installer is uploaded to the release with its canonical name in one step:
+1. **Bump the version** in `src/wiser/version.py` (and `RELEASE_DATE`) and commit it. The
+   Linux asset name is read from `version.py` at build time, so it must be correct
+   *before* you build.
+
+2. **Build and test** — run **Build and Smoke Test WISER** (`prod-deploy.yml`) via
+   `workflow_dispatch` on the commit you intend to release. Every platform builds; each
+   Linux distro runs the full `--test_mode` suite in-container (a leg only produces a
+   tarball if its tests pass), and Windows/macOS run a `--smoke` launch check. Note the
+   **run ID** — you will promote this exact run.
+
+3. **Verify locally** — download the Linux tarballs from the run and test if needed. Build,
+   `--test_mode`, code-sign, and clean-install-test the Windows/macOS installers locally
+   (CI does not produce the signed installers). See the signing certificate requirements
+   below.
+
+4. **Create the release** on the *same commit* you built. Publish it as a **pre-release**
+   (see the Pre-release flag section) so it stays out of `…/releases/latest` while you
+   attach and verify assets. A published pre-release also lets the publish workflow confirm
+   the tag matches the built commit.
+
+5. **Attach the Linux assets** — run **Publish release assets**
+   (`publish-release-assets.yml`) with the build **run ID** and the release **tag**. It
+   checks the run succeeded and that the tag points at the built commit, then attaches the
+   six Linux tarballs.
+
+6. **Upload the signed Windows/macOS installers** with `RELEASE_TAG=<tag>` so each is
+   uploaded to the release with its canonical name in one step:
 
    `make sign-mac LINK=<artifact-url> MAC_DIST_GITHUB_NAME=<artifact-name> RELEASE_TAG=<tag>`
    or `make sign-windows LINK=<artifact-url> RELEASE_TAG=<tag>`.
 
    For signing on macOS, you must have a valid Apple Developer signing certificate tied to
-   a paid Apple Developer Program account. For signing on Windows, you must have a
-   Windows code signing certificate. This is tied to an individual or a legal entity.
+   a paid Apple Developer Program account. For signing on Windows, you must have a Windows
+   code signing certificate, tied to an individual or a legal entity.
 
-   a. If you do code sign your own distribution, please do not
-   present it to others as a official WISER release unless you have
-   been explicitly allowed to do so for a specific release.
+   a. If you code-sign your own distribution, do not present it to others as an official
+   WISER release unless you have been explicitly allowed to for a specific release.
 
-   b. Note that WISER currently does not have a code
-   signing mechanism for Linux; the Linux assets are attached unsigned by `prod-deploy`.
+   b. WISER has no code-signing mechanism for Linux; the Linux assets are attached unsigned.
 
-3. If you are making an official release, you will need access to
-   the [WISER website](https://ehlmann.caltech.edu/wiser/index.html)
-   and a stable place to host the WISER distributable. When you have
-   access to this, you will add a download link to the website for the
-   new release.
+7. **Finalize the release notes** on the GitHub release. Point users at the attached
+   release assets — never a `…/actions/runs/<id>` URL.
 
-4. Finalize the release notes on the GitHub release (created in step 1). Point users at
-   the attached release assets — do not link to a `…/actions/runs/<id>` URL.
+8. **Go live** — once every asset is present with its canonical name, uncheck **"Set as a
+   pre-release"** (and keep "Set as the latest release" on) so `latest` resolves to it.
 
-5. You will then need to put the release on
-   the [website's release notes page](https://ehlmann.caltech.edu/wiser/release-notes.html).
+9. **Update the website** — if you are making an official release, add the download links on
+   the [WISER website](https://ehlmann.caltech.edu/wiser/index.html) and post the notes on
+   the [release notes page](https://ehlmann.caltech.edu/wiser/release-notes.html). (Once the
+   downloads page reads the release API, these per-release link edits go away.)
 
-6. Lastly, you will need to update the plugin API documentation in
-   `doc/sphinx-general-wiser-docs/source/extending-wiser/` to reflect any
-   changes to plugin interfaces or dependencies in the latest version.
+10. **Update the plugin API documentation** in
+    `doc/sphinx-general-wiser-docs/source/extending-wiser/` to reflect any changes to plugin
+    interfaces or dependencies in the latest version.
 
-7. Finally, if have the permissions to, then you should send an
-   email to wiser-announce@caltech.edu to announce a new release of
-   WISER with a summary of what is in the release. If you don't have
-   permission to, reach out to someone who does with the email you want
-   them to send.
+11. **Announce** — if you have permission, email wiser-announce@caltech.edu with a summary of
+    the release. If not, reach out to someone who does with the email you want sent.
 
 > **Note**: This process can only be done by a maintainer with
 > access to all of these resources. This intentionally limits who can

--- a/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
@@ -245,9 +245,9 @@ release time, so what ships is exactly what you tested.
    pre-release"** (and keep "Set as the latest release" on) so `latest` resolves to it.
 
 9. **Update the website** — if you are making an official release, add the download links on
-   the [WISER website](https://ehlmann.caltech.edu/wiser/index.html) and post the notes on
-   the [release notes page](https://ehlmann.caltech.edu/wiser/release-notes.html). (Once the
-   downloads page reads the release API, these per-release link edits go away.)
+   the [WISER website](https://ehlmann.caltech.edu/wiser/index.html). Release notes live on
+   the GitHub release itself (step 7) — there is no separate release-notes page to maintain.
+   (Once the downloads page reads the release API, these per-release link edits go away.)
 
 10. **Update the plugin API documentation** in
     `doc/sphinx-general-wiser-docs/source/extending-wiser/` to reflect any changes to plugin

--- a/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
@@ -70,7 +70,7 @@ infeasible for developers to run on each push to a pull
 request. We need to look into a way to speed up our builds
 (<10 minutes would be good).
 
-The deployment code is in the github action `prod-deploy.yml`. It builds WISER on every
+The deployment code is in the GitHub Actions workflow `prod-deploy.yml`. It builds WISER on every
 platform (Windows, macOS arm/intel, and the six Linux distro/arch targets). The Linux legs
 run the full `--test_mode` suite inside each distributable (a hard gate — a failing suite
 produces no tarball); Windows and macOS run a fast `--smoke` launch check in CI and the full

--- a/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
@@ -193,9 +193,9 @@ The process of creating a release is documented below.
    `make sign-mac LINK=<artifact-url> MAC_DIST_GITHUB_NAME=<artifact-name> RELEASE_TAG=<tag>`
    or `make sign-windows LINK=<artifact-url> RELEASE_TAG=<tag>`.
 
-   For signing on mac, you must have a valid Apple Developer signing certificate tied to
-   a paid Apple Developer Program account. For signing on windows, you must have a
-   windows code signing certificate. This is tied to an individual or a legal entity.
+   For signing on macOS, you must have a valid Apple Developer signing certificate tied to
+   a paid Apple Developer Program account. For signing on Windows, you must have a
+   Windows code signing certificate. This is tied to an individual or a legal entity.
 
    a. If you do code sign your own distribution, please do not
    present it to others as a official WISER release unless you have

--- a/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
@@ -137,31 +137,72 @@ command `gh`. The logic for this step is in the files /src/devtools/sign_mac.py 
 
 ## Releases
 
-WISER releases should always be made from a release branch. Release
-notes should accompany releases. Build artifacts
-should accompany releases. These build artifacts won't be
-signed due to how artifact creation works. Additionally, official
-releases should be made on the GitHub through
-the [Releases feature](https://github.com/Ehlmann-research-group/WISER/releases)
-and the release should be tagged.
+WISER releases should always be made from a release branch and tagged through the
+GitHub [Releases feature](https://github.com/Ehlmann-research-group/WISER/releases).
+Release notes should accompany every release.
+
+The installers are attached to the GitHub release as **release assets** (not linked
+from an Actions run — Actions artifacts expire, require a login, and are not counted
+in a release's download totals). Release notes should point users at the assets on the
+release page, never at a `…/actions/runs/<id>` URL.
+
+### Asset naming convention
+
+Asset filenames are normalized at build time so a platform + architecture is always
+identifiable from the name (the public downloads page groups assets by these tokens):
+
+```
+WISER-<version>-windows-x64-setup.exe
+WISER-<version>-macos-arm64.dmg
+WISER-<version>-macos-x64.dmg
+WISER-<version>-linux-<distro>-x64.tar.gz     # distro: ubuntu2004 | debian11 | fedora39
+WISER-<version>-linux-<distro>-arm64.tar.gz
+```
+
+`x64`/`arm64` are the canonical arch tokens (Intel/amd64 → `x64`). The names are set by
+`win-install.nsi` (Windows), `src/devtools/sign_mac.py` (macOS), and the Linux build
+step in `prod-deploy.yml` — not by hand on upload.
+
+### How assets reach the release
+
+- **Linux** builds are unsigned, so `prod-deploy.yml` attaches them to the release
+  automatically when the workflow is triggered by a `release` event.
+- **Windows / macOS** are signed locally with the maintainer's certificates, then
+  uploaded with the canonical name via the sign scripts' `--release-tag <tag>` option
+  (see the Release Process below).
+
+### Pre-release flag
+
+The web `…/releases/latest` and the API `latest` endpoint both **exclude** releases
+flagged `prerelease`. Our beta tags (e.g. `v2.2b1`) are *not* automatically treated as
+pre-releases — it is purely the checkbox at publish time. When publishing the release
+the public should download, leave **"Set as a pre-release" unchecked** (and keep "Set as
+the latest release" on) so `latest` resolves to it.
 
 ## Release Process
 
 The process of creating a release is documented below.
 
-1. Build WISER through the GitHub workflow `prod-deploy`.
-2. Do `make sign-mac` or `make sign-windows` to run the signing
-   logic. For signing on mac, you must have a valid Apple Developer
-   signing certificate tied to a paid Apple Developer Program account.
-   For signing on windows, you must have a windows code signing
-   certificate. This is tied to an individual or a legal entity.
+1. Create the GitHub release and tag the commit (see the Releases section for the
+   pre-release flag). Creating the release triggers `prod-deploy`, which builds every
+   platform and **automatically attaches the Linux assets** to the release. (You can
+   also run `prod-deploy` via `workflow_dispatch` to test a build without a release.)
+2. Sign and upload the Windows/macOS installers. Pass `RELEASE_TAG=<tag>` so the signed
+   installer is uploaded to the release with its canonical name in one step:
+
+   `make sign-mac LINK=<artifact-url> MAC_DIST_GITHUB_NAME=<artifact-name> RELEASE_TAG=<tag>`
+   or `make sign-windows LINK=<artifact-url> RELEASE_TAG=<tag>`.
+
+   For signing on mac, you must have a valid Apple Developer signing certificate tied to
+   a paid Apple Developer Program account. For signing on windows, you must have a
+   windows code signing certificate. This is tied to an individual or a legal entity.
 
    a. If you do code sign your own distribution, please do not
    present it to others as a official WISER release unless you have
    been explicitly allowed to do so for a specific release.
 
    b. Note that WISER currently does not have a code
-   signing mechanism for Linux.
+   signing mechanism for Linux; the Linux assets are attached unsigned by `prod-deploy`.
 
 3. If you are making an official release, you will need access to
    the [WISER website](https://ehlmann.caltech.edu/wiser/index.html)
@@ -169,8 +210,8 @@ The process of creating a release is documented below.
    access to this, you will add a download link to the website for the
    new release.
 
-4. You will need to make a release on GitHub with the release notes
-   and tag the release's commit.
+4. Finalize the release notes on the GitHub release (created in step 1). Point users at
+   the attached release assets — do not link to a `…/actions/runs/<id>` URL.
 
 5. You will then need to put the release on
    the [website's release notes page](https://ehlmann.caltech.edu/wiser/release-notes.html).

--- a/install-win/win-install.nsi
+++ b/install-win/win-install.nsi
@@ -82,7 +82,7 @@ Var SkipDirectoryPage
 
   ; Good.  Now we can carry on writing the real installer.
 
-  OutFile "Install-${APP_DIRNAME}.exe"
+  OutFile "WISER-${WISER_VERSION}-windows-x64-setup.exe"
   ; SetCompressor /SOLID lzma
 !endif
 

--- a/src/devtools/sign_mac.py
+++ b/src/devtools/sign_mac.py
@@ -248,7 +248,18 @@ def main():
         run(notary_cmd)
 
     if args.release_tag:
-        run(["gh", "release", "upload", args.release_tag, str(final_dmg), "--clobber"])
+        run(
+            [
+                "gh",
+                "release",
+                "upload",
+                args.release_tag,
+                str(final_dmg),
+                "-R",
+                f"{owner}/{repo}",
+                "--clobber",
+            ]
+        )
         print(f"Uploaded {final_dmg.name} to release {args.release_tag}")
 
     print("Done. Artifact downloaded, app signed, DMG built" + (" and notarized." if args.notarize else "."))

--- a/src/devtools/sign_mac.py
+++ b/src/devtools/sign_mac.py
@@ -87,6 +87,12 @@ def parse_args():
         "--app-version", default=os.environ.get("APP_VERSION"), help="Version string for DMG filename"
     )
     p.add_argument(
+        "--arch",
+        default=None,
+        choices=["x64", "arm64"],
+        help="Target arch for the DMG filename (default: inferred from --artifact-name)",
+    )
+    p.add_argument(
         "--sign-script",
         default=os.path.join(os.path.dirname(__file__), "..", "..", "install-mac", "sign_wiser.sh"),
         help="Codesign script to run (bash)",
@@ -102,6 +108,11 @@ def parse_args():
         help="App-specific password (or set AD_PASSWORD)",
     )
     p.add_argument("--notary-wait", action="store_true", help="Pass --wait to notarytool submit")
+    p.add_argument(
+        "--release-tag",
+        default=None,
+        help="If set, upload the finished DMG to this GitHub release tag (gh release upload --clobber)",
+    )
     return p.parse_args()
 
 
@@ -174,7 +185,11 @@ def main():
 
     # Create DMG (tmp then convert to compressed UDZO)
     tmp_dmg = dist_dir / "tmp.dmg"
-    final_name = f"{args.app_name}-{args.app_version}.dmg" if args.app_version else f"{args.app_name}.dmg"
+    arch = args.arch or ("arm64" if "ARM64" in args.artifact_name.upper() else "x64")
+    if args.app_version:
+        final_name = f"{args.app_name}-{args.app_version}-macos-{arch}.dmg"
+    else:
+        final_name = f"{args.app_name}-macos-{arch}.dmg"
     final_dmg = dist_dir / final_name
 
     # hdiutil create
@@ -228,6 +243,10 @@ def main():
         if args.notary_wait:
             notary_cmd.append("--wait")
         run(notary_cmd)
+
+    if args.release_tag:
+        run(["gh", "release", "upload", args.release_tag, str(final_dmg), "--clobber"])
+        print(f"Uploaded {final_dmg.name} to release {args.release_tag}")
 
     print("Done. Artifact downloaded, app signed, DMG built" + (" and notarized." if args.notarize else "."))
 

--- a/src/devtools/sign_mac.py
+++ b/src/devtools/sign_mac.py
@@ -119,6 +119,9 @@ def parse_args():
 def main():
     args = parse_args()
 
+    if args.release_tag and not args.app_version:
+        die("--release-tag requires --app-version so the uploaded DMG carries the version.")
+
     root = Path(args.root).resolve()
     dist_dir = prepare_dist(root, args.dist_name)
 

--- a/src/devtools/sign_windows.py
+++ b/src/devtools/sign_windows.py
@@ -39,6 +39,11 @@ def parse_args() -> argparse.Namespace:
         default=os.environ.get("SHA1_THUMBPRINT"),
         help="Windows signing SHA1 thumbprint",
     )
+    p.add_argument(
+        "--release-tag",
+        default=None,
+        help="If set, upload the finished installer to this GitHub release tag (gh release upload --clobber)",
+    )
     return p.parse_args()
 
 
@@ -127,6 +132,15 @@ def main():
     nsis_cmd.append(str(nsi_script))
 
     run(nsis_cmd)
+
+    if args.release_tag:
+        if not args.app_version:
+            die("--release-tag requires --app-version to locate the installer.")
+        installer = root / f"WISER-{args.app_version}-windows-x64-setup.exe"
+        if not installer.exists():
+            die(f"Installer not found for upload: {installer}")
+        run(["gh", "release", "upload", args.release_tag, str(installer), "--clobber"])
+        print(f"Uploaded {installer.name} to release {args.release_tag}")
 
     print("Done. Artifact downloaded and installer executed.")
 

--- a/src/devtools/sign_windows.py
+++ b/src/devtools/sign_windows.py
@@ -140,7 +140,18 @@ def main():
         installer = root / f"WISER-{args.app_version}-windows-x64-setup.exe"
         if not installer.exists():
             die(f"Installer not found for upload: {installer}")
-        run(["gh", "release", "upload", args.release_tag, str(installer), "--clobber"])
+        run(
+            [
+                "gh",
+                "release",
+                "upload",
+                args.release_tag,
+                str(installer),
+                "-R",
+                f"{owner}/{repo}",
+                "--clobber",
+            ]
+        )
         print(f"Uploaded {installer.name} to release {args.release_tag}")
 
     print("Done. Artifact downloaded and installer executed.")

--- a/src/devtools/sign_windows.py
+++ b/src/devtools/sign_windows.py
@@ -131,7 +131,8 @@ def main():
         nsis_cmd.append(f"/DSHA1_THUMBPRINT={args.sha1_thumbprint}")
     nsis_cmd.append(str(nsi_script))
 
-    run(nsis_cmd)
+    # Run makensis from --root so the relative OutFile lands where the upload looks.
+    run(nsis_cmd, cwd=str(root))
 
     if args.release_tag:
         if not args.app_version:


### PR DESCRIPTION
## What does this change do?
Normalizes WISER installer asset filenames so platform + architecture are identifiable
from the name, and moves release publishing to a **build-once / promote** model: the build
workflow no longer runs on `release` events, and a separate manually-triggered workflow
attaches a specific *tested* build's Linux tarballs to a release. Windows/macOS stay locally
signed and uploaded with canonical names.

## What type of PR is this? (check all applicable)
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [x] Build
- [x] CI
- [ ] Chore
- [ ] Revert

## Why is this change needed?
Two problems:
1. **Naming.** Installer names drift each release and don't reliably encode platform+arch,
   which breaks the API-driven downloads page that groups assets by name (e.g.
   `Install-WISER-2.2b1.exe` has no platform/arch token; `WISER-2.2b1-arm.dmg` has no
   `macos` and uses `arm`, not `arm64`).
2. **Rebuild-at-release.** Attaching assets on the `release` event meant the released Linux
   binaries were a *fresh* build, not the ones tested pre-release (PyInstaller/conda builds
   aren't reproducible bit-for-bit), and it doubled the build minutes. Linux is already fully
   gated in CI — each distro runs the full `--test_mode` suite in-container, and a failing
   suite produces no tarball — so the tested artifact should be the shipped artifact.

## How did you implement the change?
**Naming** (fixed at the source, scheme `WISER-<version>-<platform>-<arch>[-setup].<ext>`,
arch ∈ {x64, arm64}, Intel/amd64 → x64):
- `install-win/win-install.nsi` — `OutFile` → `WISER-<version>-windows-x64-setup.exe`.
- `src/devtools/sign_mac.py` — DMG → `WISER-<version>-macos-<arch>.dmg`; `--release-tag`
  uploads the signed/notarized DMG.
- `src/devtools/sign_windows.py` — `--release-tag` uploads the signed installer.
- `prod-deploy.yml` (linux_build) — tarballs `WISER-<version>-linux-<distro>-<arch>.tar.gz`,
  version from `src/wiser/version.py`.
- `Makefile` — canonical macOS DMG name; `RELEASE_TAG=` wiring for one-command sign+upload.

**Build-once / promote:**
- `prod-deploy.yml` is now **`workflow_dispatch`-only** and holds no write scope — it builds
  and tests every platform and uploads the Linux tarballs as run artifacts. The
  release-triggered attach job was removed.
- New `publish-release-assets.yml` (`workflow_dispatch`, inputs `run_id` + `tag`) verifies the
  build run concluded `success` and that the tag points at the built commit, then attaches
  that run's Linux tarballs. It is the only job with `contents: write`.
- `doc/.../ci-cd-and-releases.md` documents the naming convention, the promote flow, the
  updated release process, the pre-release guard, and the `run_smoke.sh` (full `--test_mode`)
  vs Windows/macOS `--smoke` distinction.

## Added tests?
- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

CI/build packaging. Manual validation: `prod-deploy` via workflow_dispatch produces
`WISER-*-linux-*.tar.gz` artifacts; a post-merge dry-run of `publish-release-assets` promotes
a known-good run onto a throwaway pre-release; local `make dist-win` / `dist-mac` produce the
canonical Windows/macOS names.

## Added to documentation?
- [x] yes
- [ ] no documentation needed

Updated `doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md`.

## Checklist
- [ ] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors (validated via workflow_dispatch build matrix)
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [ ] All CI checks passed

## Desktop Screenshots/Recordings
N/A — no UI changes.

## [optional] Are there any post-merge tasks we need to perform?
- **`publish-release-assets` is dispatchable only once it's on `main`** (workflow_dispatch
  needs the file on the default branch). After merge, dry-run it against a throwaway
  pre-release and confirm the six Linux assets attach with canonical names.
- **First release on the new flow:** bump `version.py` → dispatch build → test → create a
  **pre-release** on the built commit → run `publish-release-assets` (run_id + tag) → local
  sign+upload Windows/macOS → verify → uncheck pre-release. See the updated Release Process.
- **Companion:** #659 (`feat/download-count-telemetry`) for download-count snapshots.
- **Optional follow-up:** rename `install-linux/run_smoke.sh` — it runs the full `--test_mode`,
  not a light smoke check.