### PR TITLE
ci: enable Windows/macOS smoke tests and harden release builds

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -29,7 +29,7 @@ jobs:
           cache-environment-key: wiser-prod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('etc/prod-conda-lock.yml') }}
           cache-downloads: true
           log-level: debug
-        timeout-minutes: 10
+        timeout-minutes: 20
 
       - name: Build (Windows)
         if: runner.os == 'Windows'
@@ -39,13 +39,13 @@ jobs:
           ls -la dist/WISER || true
         timeout-minutes: 15
 
-      # - name: Smoke Test (Windows)
-      #   if: runner.os == 'Windows'
-      #   shell: bash -leo pipefail {0}
-      #   run: |
-      #     cd dist/WISER
-      #     ./WISER.exe --test_mode
-      
+      - name: Smoke test (Windows)
+        if: runner.os == 'Windows'
+        shell: bash -leo pipefail {0}
+        run: |
+          ./dist/WISER/WISER.exe --smoke
+        timeout-minutes: 5
+
       - name: Package Windows + checksum
         if: runner.os == 'Windows'
         shell: pwsh
@@ -83,14 +83,14 @@ jobs:
         run: |
           make build-mac
           ls -la dist/WISER || true
-        timeout-minutes: 25
+        timeout-minutes: 40
 
-      # - name: Smoke Test (macOS)
-      #   if: runner.os == 'macOS'
-      #   shell: bash -leo pipefail {0}
-      #   run: |
-      #     cd dist/WISER
-      #     ./WISER_Bin --test_mode
+      - name: Smoke test (macOS)
+        if: runner.os == 'macOS'
+        shell: bash -leo pipefail {0}
+        run: |
+          ./dist/WISER/WISER_Bin --smoke
+        timeout-minutes: 5
 
       - name: Pack macOS .app (preserve symlinks & modes)
         if: runner.os == 'macOS'

--- a/build_linux_multistage.sh
+++ b/build_linux_multistage.sh
@@ -57,14 +57,33 @@ echo "→ Target: ${tgt}"
 echo "→ Platform: linux/${target_arch}"
 echo "→ Image tag: ${img}"
 
-# Bake override pattern (platform/output) :contentReference[oaicite:6]{index=6}
-docker buildx bake -f "${BAKE_FILE}" \
-  --set "${tgt}.platform=linux/${target_arch}" \
-  --set "${tgt}.output=type=docker" \
-  --set '*.cache-from=type=gha' \
-  --set '*.cache-to=type=gha,mode=max' \
-  --progress=plain \
-  "${tgt}"
+# Give each distro/arch its own cache scope so the six matrix legs don't evict
+# each other's layers out of the shared, space-limited GHA cache.
+scope="${base_name}_${target_arch}"
+
+# Base-image pulls and the GHA cache are the flakiest part of the build, so retry
+# the bake a few times instead of forcing a manual re-run of the whole job.
+bake() {
+  docker buildx bake -f "${BAKE_FILE}" \
+    --set "${tgt}.platform=linux/${target_arch}" \
+    --set "${tgt}.output=type=docker" \
+    --set "*.cache-from=type=gha,scope=${scope}" \
+    --set "*.cache-to=type=gha,mode=max,scope=${scope}" \
+    --progress=plain \
+    "${tgt}"
+}
+
+attempt=1
+max_attempts=3
+until bake; do
+  if (( attempt >= max_attempts )); then
+    echo "ERROR: 'docker buildx bake' failed after ${max_attempts} attempts"
+    exit 1
+  fi
+  echo "buildx bake failed (attempt ${attempt}/${max_attempts}); retrying in 30s..."
+  sleep 30
+  attempt=$(( attempt + 1 ))
+done
 
 echo "=== SMOKE TEST (PHASE C via docker run) ==="
 docker run --rm --platform "linux/${target_arch}" "${img}"

--- a/src/wiser/__main__.py
+++ b/src/wiser/__main__.py
@@ -229,9 +229,19 @@ def main():
         are specified, tests will be run on the full test directory."
         ),
     )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Launch check: start Qt and show the splash, then exit 0 without opening the app.",
+    )
     # TODO(donnie):  Provide a way to specify Qt arguments
 
     args = parser.parse_args()
+
+    if args.smoke:
+        # Headless launch check: use the offscreen Qt platform unless one is set,
+        # so the frozen bundle can be verified on a runner with no display.
+        os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
     # Load the WISER configuration file.  If the user specifies a config file,
     # load it and exit if we can't load it.  Otherwise, if we see a WISER-config
@@ -304,6 +314,10 @@ def main():
         splash = StartupSplash(pixmap, icon)
         splash.show()
         app.processEvents()
+
+        if args.smoke:
+            logger.info("Smoke check passed: Qt started and splash shown; exiting 0.")
+            sys.exit(0)
 
         data_files: list[str] = list(args.data_files) if args.data_files else []
 

--- a/src/wiser/__main__.py
+++ b/src/wiser/__main__.py
@@ -238,9 +238,18 @@ def main():
 
     args = parser.parse_args()
 
-    if args.smoke:
-        # Headless launch check: use the offscreen Qt platform unless one is set,
-        # so the frozen bundle can be verified on a runner with no display.
+    if args.smoke and args.test_mode is not None:
+        parser.error("--smoke and --test_mode cannot be combined.")
+
+    if (
+        args.smoke
+        and sys.platform.startswith("linux")
+        and not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    ):
+        # Headless Linux has no window server, so fall back to the offscreen Qt
+        # platform. Windows/macOS (including the CI runners) have a display and use
+        # their native platform, so the smoke check does not hard-depend on the
+        # bundled offscreen plugin.
         os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
     # Load the WISER configuration file.  If the user specifies a config file,


### PR DESCRIPTION
## What does this change do?
Makes the release build actually smoke-test Windows and macOS, and hardens the build
against the transient failures that currently force manual re-runs.

## What type of PR is this? (check all applicable)
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [x] Build
- [x] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
The job is named "Build and Smoke Test WISER," but the Windows and macOS smoke steps were
commented out — only Linux actually ran a check. The disabled `--test_mode` path runs the
*entire* pytest suite inside the frozen app (needs a display, slow, fragile), which is why
it was turned off. Separately, the builds fail transiently (base-image pulls, shared Docker
cache eviction across the six Linux legs, tight timeouts) and have to be re-triggered by hand.

## How did you implement the change?
Smoke test — a genuine, fast launch ce whole suite:
- New `--smoke` flag in `src/wiser/__main__.py`: forces the offscreen Qt platform, starts
  `QApplication`, shows the splash, ases the frozen bundle's
  launch + all of `__main__`'s module-level imports + Qt platform init + resource loading.
- Re-enabled the Windows/macOS steps
  (`dist/WISER/WISER.exe --smoke`, `dist/WISER/WISER_Bin --smoke`), 5-min timeout each.
  Linux keeps its in-container `run_s

Reliability:
- `build_linux_multistage.sh`: scope the GHA cache per distro/arch (`scope=<distro>_<arch>`)
  so legs stop evicting each other, a up to 3× (30s backoff).
- Raise timeouts: micromamba setup 10→20 min, macOS build 25→40 min.

## Added tests?
- [x] no, because they aren’t needed

The change *is* the smoke test. Validy` via **workflow_dispatch**
and confirming the Windows/macOS "Smoke test" steps pass on the frozen build.

## Added to documentation?
- [ ] yes
- [x] no documentation needed

## Checklist
- [ ] There is an issue associated wi
- [ ] Code compiles/builds without errors <!-- app change ruff-clean; frozen-build smoke pending a
dispatch run -->
- [x] No new lint/style issues introduced <!-- ruff check + format pass; DCO signed -->
- [x] Branch is up-to-date with main/ain @ 37da2be9 -->
- [ ] All CI checks passed <!-- not yet run on this branch -->

## Desktop Screenshots/Recordings
N/A — no user-facing UI changes.

## [optional] Are there any post-merg
- **Dry-run first:** trigger `prod-deploy` via workflow_dispatch to confirm the smoke steps
  pass (validates the offscreen Qt plx). If offscreen is
  missing there, the fix is to drop the `QT_QPA_PLATFORM=offscreen` default (Win/macOS
  runners have a display) or mirror tlatforms` bundling.
- **Merge order:** this and `feat/release-assets-naming` both edit `prod-deploy.yml`
  (different regions), so whichever mbase.
- If a specific step is still flaky after this, grab a failing run log so the retry can be
  aimed precisely (e.g. micromamba en