### PR TITLE
ci: add daily download-count snapshot workflow

### DIFF
--- a/.github/workflows/snapshot-download-counts.yml
+++ b/.github/workflows/snapshot-download-counts.yml
@@ -1,0 +1,80 @@
+# Records a daily snapshot of every release asset's cumulative download_count so we can
+# chart downloads over time (per platform and per release). The GitHub API only exposes
+# running totals, so we append a timestamped row to a CSV and keep the history in git.
+#
+# Data lives on the long-lived `stats` branch (created automatically on first run) at
+# stats/downloads.csv, keeping the default branch's history clean. Read it with:
+#   git fetch origin stats && git show origin/stats:stats/downloads.csv
+#
+# Notes: download_count includes bots/CI traffic and excludes the auto-generated source
+# archives (those are not release assets).
+name: snapshot-download-counts
+
+on:
+  schedule:
+    - cron: "0 6 * * *"     # daily 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Append snapshot to the stats branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Move onto the long-lived stats branch (orphan it on the first run).
+          if git ls-remote --exit-code --heads origin stats >/dev/null 2>&1; then
+            git fetch origin stats
+            git checkout -B stats FETCH_HEAD
+          else
+            git checkout --orphan stats
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          mkdir -p stats
+          test -f stats/downloads.csv || \
+            echo "timestamp,release_tag,asset_name,download_count" > stats/downloads.csv
+
+          gh api --paginate "repos/${{ github.repository }}/releases" \
+            --jq '.[] | .tag_name as $t | .assets[]? | [$t, .name, .download_count] | @csv' \
+          | while IFS= read -r row; do echo "$TS,$row" >> stats/downloads.csv; done
+
+          # Human-readable rollup for this run (Actions summaries are retention-capped;
+          # the CSV in git is the durable record).
+          {
+            echo "## WISER download snapshot — $TS"
+            echo ""
+            echo "| platform | total downloads |"
+            echo "|---|---|"
+            awk -F, -v ts="$TS" '
+              $1==ts {
+                name=tolower($3); c=$4
+                if (name ~ /windows/ || name ~ /\.exe/)              win+=c
+                else if (name ~ /mac/ || name ~ /\.dmg/)             mac+=c
+                else if (name ~ /linux/ || name ~ /\.tar\.gz/ || name ~ /\.zip/) lin+=c
+              }
+              END { printf "| windows | %d |\n| macos | %d |\n| linux | %d |\n", win, mac, lin }
+            ' stats/downloads.csv
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          git add stats/downloads.csv
+          if git diff --staged --quiet; then
+            echo "No change in download counts; nothing to commit."
+          else
+            git commit -m "chore(stats): snapshot download counts ($TS) [skip ci]"
+            git push origin stats
+          fi

--- a/.github/workflows/snapshot-download-counts.yml
+++ b/.github/workflows/snapshot-download-counts.yml
@@ -79,7 +79,7 @@ jobs:
 
           git add stats/downloads.csv
           if git diff --staged --quiet; then
-            echo "No new rows appended (no release assets, or counts unchanged); nothing to commit."
+            echo "No rows appended (no release assets); nothing to commit."
           else
             git commit -m "chore(stats): snapshot download counts ($TS) [skip ci]"
             git push origin stats

--- a/.github/workflows/snapshot-download-counts.yml
+++ b/.github/workflows/snapshot-download-counts.yml
@@ -15,9 +15,6 @@ on:
     - cron: "0 6 * * *"     # daily 06:00 UTC
   workflow_dispatch: {}
 
-permissions:
-  contents: write
-
 concurrency:
   # Keep a manual run from overlapping the scheduled one (they'd race on the stats push).
   group: snapshot-download-counts
@@ -26,6 +23,8 @@ concurrency:
 jobs:
   snapshot:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,7 +79,7 @@ jobs:
 
           git add stats/downloads.csv
           if git diff --staged --quiet; then
-            echo "No change in download counts; nothing to commit."
+            echo "No new rows appended (no release assets, or counts unchanged); nothing to commit."
           else
             git commit -m "chore(stats): snapshot download counts ($TS) [skip ci]"
             git push origin stats

--- a/.github/workflows/snapshot-download-counts.yml
+++ b/.github/workflows/snapshot-download-counts.yml
@@ -70,8 +70,8 @@ jobs:
             awk -F, -v ts="$TS" '
               $1==ts {
                 line=tolower($0); c=$NF
-                if (line ~ /windows/ || line ~ /\.exe/)              win+=c
-                else if (line ~ /mac/ || line ~ /\.dmg/)             mac+=c
+                if (line ~ /windows/ || line ~ /\.exe/ || line ~ /\.msi/)       win+=c
+                else if (line ~ /mac/ || line ~ /\.dmg/ || line ~ /\.app/ || line ~ /\.pkg/) mac+=c
                 else if (line ~ /linux/ || line ~ /\.tar\.gz/ || line ~ /\.zip/) lin+=c
               }
               END { printf "| windows | %d |\n| macos | %d |\n| linux | %d |\n", win, mac, lin }

--- a/.github/workflows/snapshot-download-counts.yml
+++ b/.github/workflows/snapshot-download-counts.yml
@@ -18,6 +18,11 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  # Keep a manual run from overlapping the scheduled one (they'd race on the stats push).
+  group: snapshot-download-counts
+  cancel-in-progress: false
+
 jobs:
   snapshot:
     runs-on: ubuntu-latest
@@ -47,11 +52,11 @@ jobs:
           TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           mkdir -p stats
           test -f stats/downloads.csv || \
-            echo "timestamp,release_tag,asset_name,download_count" > stats/downloads.csv
+            printf '%s\n' "timestamp,release_tag,asset_name,download_count" > stats/downloads.csv
 
           gh api --paginate "repos/${{ github.repository }}/releases" \
             --jq '.[] | .tag_name as $t | .assets[]? | [$t, .name, .download_count] | @csv' \
-          | while IFS= read -r row; do echo "$TS,$row" >> stats/downloads.csv; done
+          | while IFS= read -r row; do printf '%s,%s\n' "$TS" "$row" >> stats/downloads.csv; done
 
           # Human-readable rollup for this run (Actions summaries are retention-capped;
           # the CSV in git is the durable record).
@@ -60,12 +65,14 @@ jobs:
             echo ""
             echo "| platform | total downloads |"
             echo "|---|---|"
+            # download_count is always the last field ($NF), so this is robust even if an
+            # asset name contained commas; platform is matched on the whole line.
             awk -F, -v ts="$TS" '
               $1==ts {
-                name=tolower($3); c=$4
-                if (name ~ /windows/ || name ~ /\.exe/)              win+=c
-                else if (name ~ /mac/ || name ~ /\.dmg/)             mac+=c
-                else if (name ~ /linux/ || name ~ /\.tar\.gz/ || name ~ /\.zip/) lin+=c
+                line=tolower($0); c=$NF
+                if (line ~ /windows/ || line ~ /\.exe/)              win+=c
+                else if (line ~ /mac/ || line ~ /\.dmg/)             mac+=c
+                else if (line ~ /linux/ || line ~ /\.tar\.gz/ || line ~ /\.zip/) lin+=c
               }
               END { printf "| windows | %d |\n| macos | %d |\n| linux | %d |\n", win, mac, lin }
             ' stats/downloads.csv


### PR DESCRIPTION
## What does this change do?
Adds a scheduled workflow that snapshots each release asset's cumulative `download_count`
daily, so we get a longitudinal time series (per platform, per release) that the GitHub
API alone doesn't provide.

## What type of PR is this? (check all applicable)
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [x] CI
- [ ] [Chore](https://stackoverflow.c-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
We want reliable download telemetry to chart adoption per platform and per release. The
GitHub API only returns **cumulative*no history — so without
periodic snapshots we can't compute daily deltas or trends. This records those snapshots
in git so the series is durable.

## How did you implement the change?
New workflow `.github/workflows/snapshot-download-counts.yml`:
- Runs daily at 06:00 UTC (`schedule`spatch`).
- Pulls every release's assets via `gh api --paginate … --jq '… .assets[]? …'` and appends
  `timestamp,release_tag,asset_name,d/downloads.csv`
  (`--paginate` + `.assets[]?` keep it safe across all releases, including ones with no
  assets).
- Commits the CSV to a **long-lived `stats` branch** (orphaned automatically on first run)
  so the default branch's history stacarries `[skip ci]` so
  the daily commit doesn't trigger the test suite.
- Writes a per-platform rollup (windon's job summary, so each
  run is human-readable without touching the CSV.

Read the data with: `git fetch origin stats && git show origin/stats:stats/downloads.csv`.

## Added tests?
- [x] no, because they aren’t needed

No automated tests. Validate by runniw_dispatch** and
confirming it bootstraps the `stats` branch and appends a row. (The platform-rollup awk was
verified locally against sample rows,)

## Added to documentation?
- [ ] yes
- [x] no documentation needed

The workflow carries a header commentives and how to read it.

## Checklist
- [ ] There is an issue associated with this pull request
- [ ] Code compiles/builds without er YAML validates, rollup logic testedlocally, but a real run is pending -->
- [x] No new lint/style issues introd
- [x] Branch is up-to-date with main/master <!-- based on origin/main @ 37da2be9 -->
- [ ] All CI checks passed <!-- workfh -->

## Desktop Screenshots/Recordings
N/A — no UI changes.

## [optional] Are there any post-merge tasks we need to perform?
- **Repo/org setting:** the job now declares `permissions: contents: write` itself, so a
  read-only default `GITHUB_TOKEN` is fine (per-workflow write overrides the default). No
  repo-wide setting change needed unless org policy forbids workflow write entirely. If you
  protect all branches, allow `github-actions[bot]` to push to the `stats` branch.
- **Bootstrap run:** trigger the workflow once via `workflow_dispatch` to create the `stats`
  branch and confirm the first snapshot commits.
- **Storage decision (for reviewers):** data lands on a dedicated `stats` branch. Alternatives
  were `main` under `stats/` or a separate `wiser-download-stats` repo (that one needs a new
  repo + a fine-grained PAT secret, since the default `GITHUB_TOKEN` can't push cross-repo).
- Note: `download_count` includes bots/CI traffic and excludes the auto-generated source
  archives — both expected.