### PR TITLE
feat(project): save-to-project bundle foundation + ROI persister (#616, #619)

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/code-documentation.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/code-documentation.md
@@ -22,4 +22,5 @@ georeferencer-internals.md
 crs-creator-internals.md
 plugin-system.md
 mosaic-internals.md
+save-to-project.md
 ```

--- a/doc/sphinx-general-wiser-docs/source/developer-content/save-to-project.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/save-to-project.md
@@ -1,0 +1,223 @@
+# Save to Project File
+
+WISER can persist an entire working session — the loaded datasets, regions of
+interest, collected spectra, contrast stretches, spectral libraries, analysis run
+histories, user-created coordinate systems, and saved band-math expressions — to a
+single portable **project file** and later reopen it into a fresh session. This
+page documents the on-disk format, the serialization convention, the dependency
+model that decides what is saved faithfully versus snapshotted, and the save/load
+orchestration.
+
+The feature lives in `src/wiser/project/`. It is deliberately layered so that each
+piece of session state is serialized by an isolated *persister*, and a single
+orchestrator drives them in dependency order.
+
+---
+
+## Overview
+
+A project file is a **bundle**: a `manifest.json` describing the session, plus two
+sidecar directories for the binary data that does not belong inline in JSON.
+
+| Path | Contents |
+|------|----------|
+| `manifest.json` | The whole session as type-tagged JSON — one section per state kind. |
+| `arrays/` | NumPy `.npy` sidecars for arrays too large for the manifest (e.g. in-memory dataset pixels, endmember snapshots). |
+| `datasets/` | ENVI-format raster sidecars for in-memory (RAM-backed) datasets that have no source file on disk. |
+
+A bundle is written either as a **directory** or, when the destination ends in
+`.wiserproj`, as a single **zip** of that directory. File-backed datasets are
+stored *by reference* (their path), so a project that loads only on-disk rasters is
+tiny; only RAM-backed datasets and their derived arrays add bulk.
+
+```{mermaid}
+flowchart TB
+    subgraph UI["GUI layer"]
+        Menu["File menu<br/>Open / Save / Save As"]
+        Dialog["SaveProjectDialog<br/>choose RAM datasets, preview cascade"]
+    end
+    subgraph Orch["Orchestration — orchestrate.py"]
+        Save["save_project()"]
+        Load["load_project()"]
+    end
+    subgraph Pers["Persisters — persisters/*.py"]
+        P["datasets · rois · spectra · stretches<br/>libraries · runs · crs · bandmath"]
+    end
+    subgraph Core["Foundation"]
+        Bundle["ProjectBundle<br/>manifest + sidecars, dir/zip"]
+        Resolver["DependencyResolver<br/>FAITHFUL / SNAPSHOT / DROP"]
+        Migrate["migrate.py<br/>format_version, migrate-up"]
+    end
+    Menu --> Save & Load
+    Dialog --> Resolver
+    Save --> P
+    Load --> P
+    P --> Bundle
+    Save --> Resolver
+    Load --> Migrate
+    Bundle --> Migrate
+```
+
+---
+
+## The pyrep convention
+
+Every serializable object is converted to a **pyrep** ("Python representation"): a
+JSON-safe `dict` carrying a `"type"` tag that names how to rebuild it. A central
+registry maps each tag to a reconstruction function.
+
+- `register_pyrep(tag, from_fn)` registers a reconstructor; `from_pyrep(data)`
+  dispatches on `data["type"]`.
+- Large arrays are not inlined. A persister calls the bundle to stash the array and
+  writes an **array reference** in its place — `array_ref(key)` produces a small
+  tagged dict, `is_array_ref(data)` / `array_ref_key(data)` recover it, and the
+  bundle resolves it back to a NumPy array on load.
+
+This keeps the manifest human-readable and diff-friendly while binary payloads live
+in `arrays/`. All manifest paths are confined to the bundle root on read
+(`ProjectBundle` validates sidecar keys and rejects `..`/absolute paths and zip-slip
+entries), because a `.wiserproj` may be shared and is therefore untrusted input.
+
+---
+
+## The dependency resolver
+
+Most session state does not stand alone — a contrast stretch belongs to a
+`(dataset, band)`, a raster-backed spectrum samples a dataset at a point, an
+ROI-average spectrum references an ROI. When the user chooses *not* to save a
+RAM-backed dataset, everything downstream of it must be handled coherently. That
+decision is the resolver's job.
+
+`DependencyResolver` classifies each dependent item against the set of saved
+dataset roots into one of three outcomes:
+
+| Outcome | Meaning |
+|---------|---------|
+| **FAITHFUL** | The dependency is saved, so the item is stored as a live reference and restores exactly. |
+| **SNAPSHOT** | The dependency is cut, but the item can be frozen to self-contained data (e.g. a dataset-backed spectrum saved as raw values). |
+| **DROP** | The dependency is cut and the item cannot be snapshotted (e.g. a stretch, which is meaningless without its band) — it is not saved. |
+
+A `Dependency(kind, id)` with an unresolved (`None`) id is treated as a cut edge for
+every kind, so a dangling reference snapshots or drops rather than being called
+faithful and then failing on load. ROIs are standalone and always saved.
+`resolver_for_all_datasets(app_state)` builds the default "save everything"
+resolver; the Save dialog builds one from the user's exclusions. `cascade_report`
+turns a resolver into the human-readable list of consequences the dialog previews.
+
+---
+
+## Persisters
+
+Each kind of state has a `save_<kind>(app_state, manifest, ...)` /
+`load_<kind>(manifest, app_state, ...)` pair in `persisters/`. They share one
+contract: **a malformed or unrestorable entry is dropped and reported, never
+fatal.** Every `load_*` returns the list of entries it could not restore so the
+orchestrator can surface a single "some items could not be opened" warning instead
+of aborting the whole project open. Parsing is defensive — missing keys, wrong
+types, and bad enum values degrade gracefully.
+
+| Persister | Persists | Notes |
+|-----------|----------|-------|
+| `datasets` | Loaded datasets | File-backed by reference; RAM-backed to ENVI sidecars under `datasets/`. Original ids preserved on load so references stay valid. |
+| `rois` | Regions of interest | Standalone; multi-selection geometry round-trips through the pyrep convention. |
+| `spectra` | Collected + active spectra | Three kinds: self-contained NumPy, raster-backed (dataset + point + area), ROI-average (dataset + roi). Dataset-backed spectra go faithful when the dataset is saved, freeze to NumPy when cut. |
+| `stretches` | Per-`(dataset, band)` contrast stretches | Dataset-cascade leaf: dropped when its dataset is unsaved. Polymorphic across the stretch types. |
+| `libraries` | Spectral libraries | `ENVISpectralLibrary` by reference (reopened from its path); `ListSpectralLibrary` inline (members follow the per-member spectra rule). |
+| `runs` | PCA / MNF / unmixing / K-Means histories | Every record self-contained; datasets referenced softly by id; run ids re-minted on load. |
+| `crs` | User-created coordinate systems | WKT + creator-dialog state; rebuilt via GDAL/`osr`, bad WKT drops the entry, a bad enum degrades one field. |
+| `bandmath` | Saved band-math expressions | A plain list of expression strings on `ApplicationState`. |
+
+---
+
+## Save
+
+`save_project(app_state, dest, resolver=None)` writes the manifest and sidecars in
+**dependency order** — datasets first, since they are the roots the rest of the
+manifest references by id and they own the sidecar I/O. Without an explicit
+resolver, every dataset is treated as saved; the Save dialog supplies a user-driven
+one built from the datasets the user unchecked.
+
+```{mermaid}
+sequenceDiagram
+    participant U as User
+    participant D as SaveProjectDialog
+    participant S as save_project
+    participant B as ProjectBundle
+    U->>D: choose RAM datasets to include
+    D->>D: save_plan() — preview SNAPSHOT/DROP cascade
+    U->>D: confirm
+    D->>S: save_project(dest, resolver)
+    S->>B: create bundle (dir, or temp dir → zip)
+    S->>B: save_datasets → sidecars + manifest
+    S->>B: save_crs, bandmath, rois, stretches, spectra, libraries, runs
+    S->>B: write_manifest
+    B-->>U: .wiserproj written
+```
+
+---
+
+## Load
+
+`load_project(src, app_state, extract_dir=None)` opens a bundle (a directory, or a
+`.wiserproj` extracted into `extract_dir`), migrates the manifest up to the current
+format, **clears the session**, and restores every item in **topological order** so
+each reference resolves — datasets (with their original ids) before the stretches,
+spectra, and run records that reference them; ROIs before ROI-average spectra.
+
+The UI updates for free: each `load_*` restores through the signal-emitting
+`add_*` / `set_*` accessors on `ApplicationState`, so the granular reload signals
+fire inline and derived caches (such as the by-id spectrum index) rebuild
+themselves — there is no separate "emit signals" or "rebuild index" pass.
+
+```{mermaid}
+sequenceDiagram
+    participant U as User
+    participant L as load_project
+    participant B as ProjectBundle
+    participant A as ApplicationState
+    U->>L: open .wiserproj
+    L->>B: read_manifest() — migrate up / refuse too-new
+    L->>A: clear_session()
+    L->>A: load_datasets (preserve ids)
+    L->>A: load_crs, bandmath, rois
+    L->>A: load_stretches, spectra, libraries, runs
+    L-->>U: load report (dropped-per-section warning)
+```
+
+Restoring datasets with their **original ids** is the invariant that keeps every
+downstream reference valid; `clear_session` uses the normal `remove_*` methods so
+the removed-signals fire and the UI empties, and it only deletes scratch temp
+rasters — never a user's source file.
+
+---
+
+## Versioning and migration
+
+The manifest carries a `format_version`. The guarantee is **backward
+compatibility**: any project file written by a released WISER opens in every later
+WISER. Forward compatibility is not promised — a file newer than the running WISER
+is refused cleanly with `ProjectTooNewError` rather than mis-interpreted.
+
+On load, an older manifest is transformed step-by-step up to the current shape by a
+chain of pure `migrate_vN_to_vN+1` functions, so the rest of the load code only ever
+sees the current schema. The rule contributors follow:
+
+- **Additive change** (a new *optional* field) needs **no** version bump and **no**
+  migration — every `from_pyrep` parses leniently and the orchestrator reads sections
+  with `.get`, so unknown keys and sections pass through untouched.
+- **Breaking change** (a renamed, removed, restructured, or semantically-changed
+  field) bumps `CURRENT_FORMAT_VERSION` and registers a migration via
+  `register_migration`.
+
+---
+
+## Extending: adding a new persisted item
+
+1. Write a `save_<kind>` / `load_<kind>` pair in `persisters/`, following the
+   drop-not-fatal contract (return the list of unrestorable entries).
+2. If the item depends on a dataset, classify it through the resolver so it
+   snapshots or drops when its dataset is cut.
+3. Wire it into `orchestrate._write_bundle` and `orchestrate._restore` at the right
+   point in dependency order.
+4. Prefer an additive, optional manifest section so no version bump is needed; bump
+   `format_version` and add a migration only for a breaking change.

--- a/src/tests/test_project_bundle.py
+++ b/src/tests/test_project_bundle.py
@@ -6,6 +6,7 @@ end-to-end.
 """
 
 import json
+import zipfile
 
 import numpy as np
 import pytest
@@ -16,6 +17,7 @@ from PySide6.QtCore import QPoint
 
 from wiser.project import (
     ProjectBundle,
+    ProjectFormatError,
     ProjectTooNewError,
     UnknownPyrepType,
     from_pyrep,
@@ -145,3 +147,31 @@ def test_roi_persister_round_trip():
     load_rois(manifest, dst)
 
     assert [_roi_shape(r) for r in dst.get_rois()] == [_roi_shape(r) for r in src.get_rois()]
+
+
+def test_unzip_rejects_path_traversal(tmp_path):
+    evil_zip = tmp_path / "evil.wiserproj"
+    with zipfile.ZipFile(evil_zip, "w") as zf:
+        zf.writestr("manifest.json", "{}")
+        zf.writestr("../escape.txt", "pwned")
+
+    with pytest.raises(ProjectFormatError):
+        unzip_bundle(evil_zip, tmp_path / "dest")
+
+    # The escaping member must not have been written outside the destination.
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_fetch_array_rejects_path_traversal(tmp_path):
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    np.save(tmp_path / "secret.npy", np.arange(3))
+
+    with pytest.raises(ProjectFormatError):
+        bundle.fetch_array("../secret.npy")
+
+
+def test_roi_from_pyrep_rejects_wrong_type():
+    data = roi_to_pyrep(_sample_roi())
+    data["type"] = "SomethingElse"
+    with pytest.raises(ValueError):
+        roi_from_pyrep(data)

--- a/src/tests/test_project_bundle.py
+++ b/src/tests/test_project_bundle.py
@@ -1,0 +1,147 @@
+"""Unit tests for the project-bundle foundation (issues #616/#619).
+
+Covers the on-disk bundle format, the pyrep convention and dispatch registry,
+format versioning, and the ROI persister round-trip that proves the convention
+end-to-end.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+import tests.context  # noqa: F401
+
+from PySide6.QtCore import QPoint
+
+from wiser.project import (
+    ProjectBundle,
+    ProjectTooNewError,
+    UnknownPyrepType,
+    from_pyrep,
+    migrate_up,
+    unzip_bundle,
+    zip_bundle,
+)
+from wiser.project.migrate import CURRENT_FORMAT_VERSION
+from wiser.project.persisters.rois import load_rois, save_rois
+from wiser.raster.roi import RegionOfInterest, roi_from_pyrep, roi_to_pyrep
+from wiser.raster.selection import (
+    MultiPixelSelection,
+    PolygonSelection,
+    RectangleSelection,
+    SinglePixelSelection,
+)
+
+
+def _sample_roi():
+    """An ROI exercising all four supported selection geometries."""
+    roi = RegionOfInterest(name="test-roi", color="red")
+    roi.set_id(42)
+    roi.set_description("a sample region")
+    roi.get_metadata()["note"] = "hello"
+    roi.add_selection(RectangleSelection(QPoint(0, 0), QPoint(3, 3)))
+    roi.add_selection(PolygonSelection([QPoint(1, 1), QPoint(4, 1), QPoint(2, 5)]))
+    roi.add_selection(SinglePixelSelection(QPoint(6, 6)))
+    roi.add_selection(MultiPixelSelection([QPoint(7, 7), QPoint(8, 8)]))
+    return roi
+
+
+def _roi_shape(roi):
+    """A comparable snapshot of an ROI's identity, geometry, and selection kinds."""
+    return {
+        "id": roi.get_id(),
+        "name": roi.get_name(),
+        "color": roi.get_color(),
+        "description": roi.get_description(),
+        "metadata": dict(roi.get_metadata()),
+        "selection_types": [sel.get_type().name for sel in roi.get_selections()],
+        "pixels": sorted(roi.get_all_pixels()),
+    }
+
+
+def test_roi_pyrep_round_trip():
+    roi = _sample_roi()
+    # Round-trip through JSON to mimic a real save/load (tuples become lists).
+    data = json.loads(json.dumps(roi_to_pyrep(roi)))
+    restored = roi_from_pyrep(data)
+    assert _roi_shape(restored) == _roi_shape(roi)
+
+
+def test_registry_dispatches_roi():
+    roi = _sample_roi()
+    data = json.loads(json.dumps(roi_to_pyrep(roi)))
+    restored = from_pyrep(data)
+    assert isinstance(restored, RegionOfInterest)
+    assert _roi_shape(restored) == _roi_shape(roi)
+
+
+def test_unknown_pyrep_type_raises():
+    with pytest.raises(UnknownPyrepType):
+        from_pyrep({"type": "NoSuchType"})
+
+
+def test_bundle_manifest_round_trip(tmp_path):
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {"rois": [roi_to_pyrep(_sample_roi())]}
+    bundle.write_manifest(manifest)
+
+    reopened = ProjectBundle.open(tmp_path / "proj")
+    loaded = reopened.read_manifest()
+    assert loaded["format_version"] == CURRENT_FORMAT_VERSION
+    assert loaded["rois"] == json.loads(json.dumps(manifest["rois"]))
+
+
+def test_bundle_array_sidecar(tmp_path):
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+    ref = bundle.add_array("centroids", arr)
+    # The manifest carries only a reference, never the bulk data.
+    assert ref == {"$array": "arrays/centroids.npy"}
+    np.testing.assert_array_equal(bundle.fetch_array(ref), arr)
+
+
+def test_bundle_zip_round_trip(tmp_path):
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {"rois": [roi_to_pyrep(_sample_roi())]}
+    bundle.write_manifest(manifest)
+
+    zip_path = zip_bundle(bundle, tmp_path / "proj.wiserproj")
+    reopened = unzip_bundle(zip_path, tmp_path / "unpacked")
+    assert reopened.read_manifest()["rois"] == json.loads(json.dumps(manifest["rois"]))
+
+
+def test_migrate_current_is_noop():
+    manifest = {"format_version": CURRENT_FORMAT_VERSION, "rois": []}
+    assert migrate_up(manifest) == manifest
+
+
+def test_migrate_refuses_too_new():
+    with pytest.raises(ProjectTooNewError):
+        migrate_up({"format_version": CURRENT_FORMAT_VERSION + 5})
+
+
+class _FakeAppState:
+    """Minimal stand-in exposing only the ROI accessors the persister uses."""
+
+    def __init__(self, rois):
+        self._rois = list(rois)
+
+    def get_rois(self):
+        return list(self._rois)
+
+    def add_roi(self, roi, make_name_unique=False):
+        self._rois.append(roi)
+
+
+def test_roi_persister_round_trip():
+    src = _FakeAppState([_sample_roi()])
+    manifest = {}
+    save_rois(src, manifest)
+
+    manifest = json.loads(json.dumps(manifest))
+
+    dst = _FakeAppState([])
+    load_rois(manifest, dst)
+
+    assert [_roi_shape(r) for r in dst.get_rois()] == [_roi_shape(r) for r in src.get_rois()]

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import platform
 import pprint
@@ -319,12 +318,6 @@ class DataVisualizerApp(QMainWindow):
         # act.setStatusTip(self.tr('Open an existing project or file'))
         act.setStatusTip(self.tr("Open a raster dataset or spectral library"))
         act.triggered.connect(self.show_open_file_dialog)
-
-        # TODO(donnie):  Commented out until project-file code is updated for
-        #     current version of WISER.  (Same with line commented-out above.)
-        # act = self._file_menu.addAction(self.tr('Save &project file...'))
-        # act.setStatusTip(self.tr('Save the current project configuration'))
-        # act.triggered.connect(self.show_save_project_dialog)
 
         self._file_menu.addSeparator()
 
@@ -671,8 +664,6 @@ class DataVisualizerApp(QMainWindow):
             self.tr("PDS raster files (*.PDS *.img *.lbl *.xml)"),
             self.tr("ENVI spectral libraries (*.sli *.hdr)"),
             self.tr("Try luck with GDAL (*)"),
-            # self.tr('WISER project files (*.wiser)'),
-            # self.tr('All files (*)'),
         ]
 
         # Let the user select one or more files to open.
@@ -700,159 +691,6 @@ class DataVisualizerApp(QMainWindow):
                 mbox.setDetailedText(traceback.format_exc())
 
                 mbox.exec()
-
-    def show_save_project_dialog(self, evt):
-        """
-        Shows the "Save Project..." dialog in the user interface.  If the user
-        successfully chooses a file, the save_project_file() method is called to
-        perform the actual operation of saving the project details.
-        """
-
-        # These are all file formats that will appear in the file-open dialog
-        supported_formats = [
-            self.tr("WISER project files (*.wiser)"),
-            self.tr("All files (*)"),
-        ]
-
-        selected = QFileDialog.getSaveFileName(
-            self,
-            self.tr("Save WISER Project File"),
-            self._app_state.get_current_dir(),
-            ";;".join(supported_formats),
-        )
-        # print(selected)
-
-        if len(selected[0]) > 0:
-            try:
-                self.save_project_file(selected[0])
-            except:
-                mbox = QMessageBox(
-                    QMessageBox.Critical,
-                    self.tr("Could not save project"),
-                    QMessageBox.Ok,
-                    self,
-                )
-
-                mbox.setText(self.tr("Could not write project file."))
-                mbox.setInformativeText(file_path)
-
-                # TODO(donnie):  Add exception-trace info here, using
-                #     mbox.setDetailedText()
-
-                mbox.exec()
-
-    def save_project_file(self, file_path, force=False):
-        """
-        Saves the entire project state to the specified file path.  This
-        includes the following:
-
-        *   Data sets that are loaded
-        *   Regions of interest
-        *   Qt application state including window geometry and open/close state
-        """
-        # TODO(donnie):  If the project file already exists, and force is False,
-        #     prompt the user about overwriting the file.
-
-        project_info = self.generate_project_info()
-        with open(file_path, "w") as f:
-            # Make the JSON output pretty so that advanced users can understand
-            # it.
-            json.dump(project_info, f, sort_keys=True, indent=4)
-
-        msg = self.tr("Saved project to {}").format(file_path)
-        self.statusBar().showMessage(msg, 5000)
-
-    def generate_project_info(self):
-        """
-        Generates a Python dictionary containing the current project state,
-        which can then be written out as a JSON file.  This includes the
-        following:
-
-        *   Data sets that are loaded
-        *   Regions of interest
-        *   Qt application state including window geometry and open/close state
-        """
-        project_info = {}
-
-        # TODO(donnie):  Project description, owner, email, ...
-
-        # Data sets
-        # TODO(donnie):  This will get more sophisticated when we have multiple
-        #     layers, and the like.
-
-        project_info["datasets"] = []
-        for data_set in self._app_state.get_datasets():
-            ds_info = {
-                "files": data_set.get_filepaths(),
-            }
-
-            # TODO(donnie):  data-set stretch, current display bands
-
-            project_info["datasets"].append(ds_info)
-
-        # Regions of interest
-
-        project_info["regions_of_interest"] = []
-        for name, roi in self._app_state.get_rois().items():
-            assert name == roi.get_name()
-            roi_info = roi_to_pyrep(roi)
-            project_info["regions_of_interest"].append(roi_info)
-
-        # The .toBase64() function returns a QByteArray, which we then convert
-        # to a Python byte-array.  Finally, convert to Python str object to
-        # save.  The base-64 encoding should be fine for UTF-8 conversion.
-        project_info["qt_geometry"] = self.saveGeometry().toBase64().data().decode()
-        project_info["qt_window_state"] = self.saveState().toBase64().data().decode()
-
-        return project_info
-
-    def load_project_file(self, file_path, force=False):
-        """
-        Loads project state from the specified file path.  This includes the
-        following:
-
-        *   Data sets that are loaded
-        *   Regions of interest
-        *   Qt application state including window geometry and open/close state
-        """
-        # TODO(donnie):  If we have in-memory-only project state, and force is
-        #     False, prompt the user about loading the file.
-
-        with open(file_path) as f:
-            # Make the JSON output pretty so that advanced users can understand
-            # it.
-            project_info = json.load(f)
-            self.apply_project_info(project_info)
-
-    def apply_project_info(self, project_info):
-        # TODO(donnie):  Surely we will also have to reset the UI widgets.
-        #     Perhaps it would be better to put a clear_all() or reset()
-        #     operation on the ApplicationState class, which can fire an event
-        #     to views.
-        # self._app_state = ApplicationState()
-        for ds_info in project_info["datasets"]:
-            # The first file in the list is usually the one that we load.
-            filename = ds_info["files"][0]
-            self._app_state.open_file(filename)
-
-            # TODO(donnie):  data-set stretch, current display bands
-
-        # Regions of interest
-
-        for roi_info in project_info["regions_of_interest"]:
-            # Reconstruct the region of interest
-            roi = roi_from_pyrep(roi_info)
-            self._app_state.add_roi(roi)
-
-        # Qt window state/geometry
-
-        s = project_info["qt_geometry"]
-        qba = QByteArray(bytes(s, "utf-8"))
-        self.restoreGeometry(QByteArray.fromBase64(qba))
-
-        s = project_info["qt_window_state"]
-        qba = QByteArray(bytes(s, "utf-8"))
-        self.restoreState(QByteArray.fromBase64(qba))
 
     def save_qt_settings(self):
         """

--- a/src/wiser/gui/app_state.py
+++ b/src/wiser/gui/app_state.py
@@ -344,12 +344,6 @@ class ApplicationState(QObject):
         # Remember the directory of the selected file, for next file-open
         self.update_cwd_from_path(file_path)
 
-        # Is the file a project file?
-
-        if file_path.endswith(".wiser"):
-            self.load_project_file(file_path)
-            return
-
         # Figure out if the user wants to open a raster data set or a
         # spectral library.
 
@@ -377,17 +371,32 @@ class ApplicationState(QObject):
         for raster_data in raster_data_list:
             self.add_dataset(raster_data)
 
-    def add_dataset(self, dataset: RasterDataSet, view_dataset: bool = True):
+    def add_dataset(
+        self,
+        dataset: RasterDataSet,
+        view_dataset: bool = True,
+        ds_id: Optional[int] = None,
+    ):
         """
         Add a dataset to the application state.  A unique numeric ID is assigned
         to the dataset, which is also set on the dataset itself.
+
+        When ``ds_id`` is given (project restore), that id is used verbatim
+        instead of allocating a new one, and the internal id counter is advanced
+        past it so later allocations do not collide.
 
         The method will fire a signal indicating that the dataset was added.
         """
         if not isinstance(dataset, RasterDataSet):
             raise TypeError("dataset must be a RasterDataSet")
 
-        ds_id = self.take_next_id()
+        if ds_id is None:
+            ds_id = self.take_next_id()
+        elif ds_id in self._datasets:
+            raise ValueError(f"dataset id {ds_id} is already in use")
+        else:
+            self._next_id = max(self._next_id, ds_id + 1)
+
         dataset.set_id(ds_id)
         self._datasets[ds_id] = dataset
 

--- a/src/wiser/project/__init__.py
+++ b/src/wiser/project/__init__.py
@@ -1,0 +1,45 @@
+"""WISER project-file subsystem: save/open a session as a portable bundle.
+
+Foundation layer (issues #616/#617): the on-disk :class:`ProjectBundle` format,
+the shared pyrep serialization convention and its dispatch registry, and the
+format-version migrate-up seam.  Per-item persisters live under
+:mod:`wiser.project.persisters`.  The dependency/save-policy resolver (#617) is
+added alongside the dataset/spectra persisters, where it has a real dependency
+graph to model.
+"""
+
+from .bundle import ProjectBundle, unzip_bundle, zip_bundle
+from .migrate import (
+    CURRENT_FORMAT_VERSION,
+    ProjectFormatError,
+    ProjectTooNewError,
+    migrate_up,
+)
+from .pyrep import (
+    UnknownPyrepType,
+    array_ref,
+    array_ref_key,
+    from_pyrep,
+    is_array_ref,
+    register_pyrep,
+)
+
+# Importing the persisters registers each state item's pyrep reconstructor with
+# the dispatch registry above.
+from . import persisters  # noqa: E402,F401
+
+__all__ = [
+    "ProjectBundle",
+    "zip_bundle",
+    "unzip_bundle",
+    "CURRENT_FORMAT_VERSION",
+    "ProjectFormatError",
+    "ProjectTooNewError",
+    "migrate_up",
+    "UnknownPyrepType",
+    "from_pyrep",
+    "register_pyrep",
+    "array_ref",
+    "is_array_ref",
+    "array_ref_key",
+]

--- a/src/wiser/project/bundle.py
+++ b/src/wiser/project/bundle.py
@@ -1,0 +1,126 @@
+"""On-disk project bundle: ``manifest.json`` plus raster and array sidecars.
+
+A bundle is a directory.  The single-file ``.wiserproj`` form is just that
+directory zipped; :func:`zip_bundle` / :func:`unzip_bundle` convert between the
+two.  Bulk data never goes in the manifest: large arrays are written to
+``arrays/`` and referenced by key, and raster pixels to ``datasets/``.
+"""
+
+import json
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, Union
+
+import numpy as np
+
+from .migrate import CURRENT_FORMAT_VERSION, migrate_up
+from .pyrep import array_ref, array_ref_key, is_array_ref
+
+PathLike = Union[str, Path]
+
+
+class ProjectBundle:
+    """A WISER project bundle rooted at a directory."""
+
+    MANIFEST_NAME = "manifest.json"
+    DATASETS_DIR = "datasets"
+    ARRAYS_DIR = "arrays"
+    EXTENSION = ".wiserproj"
+
+    def __init__(self, root: PathLike):
+        self._root = Path(root)
+
+    @classmethod
+    def create(cls, root: PathLike) -> "ProjectBundle":
+        """Create (or reuse) an empty bundle directory at ``root``."""
+        root = Path(root)
+        root.mkdir(parents=True, exist_ok=True)
+        return cls(root)
+
+    @classmethod
+    def open(cls, root: PathLike) -> "ProjectBundle":
+        """Open an existing bundle directory containing a manifest."""
+        root = Path(root)
+        if not root.is_dir():
+            raise NotADirectoryError(f"Not a project bundle directory: {root}")
+        if not (root / cls.MANIFEST_NAME).is_file():
+            raise FileNotFoundError(f"No {cls.MANIFEST_NAME} in bundle: {root}")
+        return cls(root)
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    # -- manifest -----------------------------------------------------------
+
+    def write_manifest(self, manifest: Dict[str, Any]) -> None:
+        """Write ``manifest`` to ``manifest.json``, stamping the current
+        ``format_version`` if the caller did not set one."""
+        manifest = dict(manifest)
+        manifest.setdefault("format_version", CURRENT_FORMAT_VERSION)
+        path = self._root / self.MANIFEST_NAME
+        path.write_text(json.dumps(manifest, indent=2, sort_keys=True))
+
+    def read_manifest(self) -> Dict[str, Any]:
+        """Read ``manifest.json`` and migrate it up to the current schema.
+
+        Raises :class:`~wiser.project.migrate.ProjectTooNewError` if the bundle
+        was written by a newer WISER than this one understands.
+        """
+        path = self._root / self.MANIFEST_NAME
+        manifest = json.loads(path.read_text())
+        return migrate_up(manifest)
+
+    @property
+    def format_version(self) -> int:
+        path = self._root / self.MANIFEST_NAME
+        manifest = json.loads(path.read_text())
+        return int(manifest.get("format_version", 1))
+
+    # -- array sidecars -----------------------------------------------------
+
+    def add_array(self, key: str, array: np.ndarray) -> Dict[str, str]:
+        """Write ``array`` to ``arrays/<key>.npy`` and return a
+        manifest-embeddable reference (``{"$array": "arrays/<key>.npy"}``)."""
+        rel = f"{self.ARRAYS_DIR}/{key}.npy"
+        dest = self._root / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        np.save(dest, array)
+        return array_ref(rel)
+
+    def fetch_array(self, ref: Union[Dict[str, str], str]) -> np.ndarray:
+        """Load an array written with :meth:`add_array`, given either its
+        reference dict or its relative key."""
+        rel = array_ref_key(ref) if is_array_ref(ref) else ref
+        return np.load(self._root / rel)
+
+    # -- raster sidecars ----------------------------------------------------
+
+    def raster_sidecar_path(self, filename: str) -> Path:
+        """Return the on-disk path under ``datasets/`` for a raster sidecar.
+
+        The bundle owns the path; writing the raster bytes is the dataset
+        persister's job (issue #618)."""
+        dest = self._root / self.DATASETS_DIR
+        dest.mkdir(parents=True, exist_ok=True)
+        return dest / filename
+
+
+def zip_bundle(bundle: ProjectBundle, zip_path: PathLike) -> Path:
+    """Package a bundle directory into a single ``.wiserproj`` zip file."""
+    zip_path = Path(zip_path)
+    root = bundle.root
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(root.rglob("*")):
+            if path.is_file():
+                zf.write(path, path.relative_to(root))
+    return zip_path
+
+
+def unzip_bundle(zip_path: PathLike, dest_dir: PathLike) -> ProjectBundle:
+    """Extract a ``.wiserproj`` zip into ``dest_dir`` and open it as a bundle."""
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        zf.extractall(dest_dir)
+    return ProjectBundle.open(dest_dir)

--- a/src/wiser/project/bundle.py
+++ b/src/wiser/project/bundle.py
@@ -13,10 +13,27 @@ from typing import Any, Dict, Union
 
 import numpy as np
 
-from .migrate import CURRENT_FORMAT_VERSION, migrate_up
+from .migrate import CURRENT_FORMAT_VERSION, ProjectFormatError, migrate_up
 from .pyrep import array_ref, array_ref_key, is_array_ref
 
 PathLike = Union[str, Path]
+
+
+def _resolve_within(root: PathLike, rel: str) -> Path:
+    """Resolve ``rel`` under ``root``, refusing paths that escape the bundle.
+
+    Returns the absolute resolved path when ``rel`` stays inside ``root``;
+    raises :class:`~wiser.project.migrate.ProjectFormatError` otherwise. Keeps
+    manifest- or archive-supplied paths from reaching outside the bundle
+    directory (``../`` segments, absolute paths).
+    """
+    root = Path(root).resolve()
+    target = (root / rel).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError:
+        raise ProjectFormatError(f"Path escapes the bundle root: {rel!r}") from None
+    return target
 
 
 class ProjectBundle:
@@ -90,9 +107,13 @@ class ProjectBundle:
 
     def fetch_array(self, ref: Union[Dict[str, str], str]) -> np.ndarray:
         """Load an array written with :meth:`add_array`, given either its
-        reference dict or its relative key."""
+        reference dict or its relative key.
+
+        The key is confined to the bundle directory: a reference that resolves
+        outside the bundle is rejected rather than read, since the manifest may
+        come from an untrusted source."""
         rel = array_ref_key(ref) if is_array_ref(ref) else ref
-        return np.load(self._root / rel)
+        return np.load(_resolve_within(self._root, rel))
 
     # -- raster sidecars ----------------------------------------------------
 
@@ -118,9 +139,15 @@ def zip_bundle(bundle: ProjectBundle, zip_path: PathLike) -> Path:
 
 
 def unzip_bundle(zip_path: PathLike, dest_dir: PathLike) -> ProjectBundle:
-    """Extract a ``.wiserproj`` zip into ``dest_dir`` and open it as a bundle."""
+    """Extract a ``.wiserproj`` zip into ``dest_dir`` and open it as a bundle.
+
+    Guards against zip-slip: a member whose path escapes ``dest_dir`` (via
+    ``../`` or an absolute path) is refused before anything is extracted, since
+    a project file may come from an untrusted source."""
     dest_dir = Path(dest_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(zip_path, "r") as zf:
+        for name in zf.namelist():
+            _resolve_within(dest_dir, name)
         zf.extractall(dest_dir)
     return ProjectBundle.open(dest_dir)

--- a/src/wiser/project/migrate.py
+++ b/src/wiser/project/migrate.py
@@ -1,0 +1,55 @@
+"""Project-file format versioning and the migrate-up seam.
+
+The loader only ever understands the *current* schema.  On load, an older
+manifest is transformed step-by-step up to the current shape by a chain of pure
+functions; a manifest newer than this WISER understands is refused cleanly.
+
+This module provides the version constant and the migrate-up mechanism only.
+The migration *policy* (the per-version transform functions) and the golden-file
+regression suite that enforces "old files still load" are owned by issue #628.
+"""
+
+from typing import Any, Callable, Dict
+
+CURRENT_FORMAT_VERSION = 1
+
+
+class ProjectFormatError(Exception):
+    """Raised when a project file cannot be brought to the current schema."""
+
+
+class ProjectTooNewError(ProjectFormatError):
+    """Raised when a project file is newer than this WISER can open."""
+
+
+# Maps a from-version to the function transforming a manifest dict to the next
+# version.  Empty while v1 is current; issue #628 appends migrations here as the
+# schema evolves (e.g. ``{1: migrate_v1_to_v2}``).
+_MIGRATIONS: Dict[int, Callable[[Dict[str, Any]], Dict[str, Any]]] = {}
+
+
+def migrate_up(manifest: Dict[str, Any]) -> Dict[str, Any]:
+    """Return ``manifest`` transformed up to :data:`CURRENT_FORMAT_VERSION`.
+
+    Raises :class:`ProjectTooNewError` if the manifest's ``format_version`` is
+    greater than this WISER understands, and :class:`ProjectFormatError` if a
+    required migration step is missing.
+    """
+    version = int(manifest.get("format_version", 1))
+
+    if version > CURRENT_FORMAT_VERSION:
+        raise ProjectTooNewError(
+            f"This project was created with a newer version of WISER "
+            f"(project format v{version}; this WISER understands "
+            f"v{CURRENT_FORMAT_VERSION}).  Please upgrade WISER to open it."
+        )
+
+    while version < CURRENT_FORMAT_VERSION:
+        migrate = _MIGRATIONS.get(version)
+        if migrate is None:
+            raise ProjectFormatError(f"No migration registered from project format v{version}.")
+        manifest = migrate(manifest)
+        version += 1
+        manifest["format_version"] = version
+
+    return manifest

--- a/src/wiser/project/persisters/__init__.py
+++ b/src/wiser/project/persisters/__init__.py
@@ -1,0 +1,7 @@
+"""Per-state-item persisters for the project-file subsystem.
+
+Importing this package registers each item's pyrep reconstructor with the
+dispatch registry in :mod:`wiser.project.pyrep`.
+"""
+
+from . import rois  # noqa: F401

--- a/src/wiser/project/persisters/rois.py
+++ b/src/wiser/project/persisters/rois.py
@@ -1,0 +1,28 @@
+"""Region-of-interest persistence (issue #619).
+
+ROIs are standalone ``[SOURCE]`` state with no dataset dependency, so they save
+and load directly via the pyrep convention.  Each ROI is captured as its
+identity plus a list of faithfully-serialized selections.
+"""
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from wiser.raster.roi import ROI_PYREP_TYPE, roi_from_pyrep, roi_to_pyrep
+
+from ..pyrep import register_pyrep
+
+if TYPE_CHECKING:
+    from wiser.gui.app_state import ApplicationState
+
+register_pyrep(ROI_PYREP_TYPE, roi_from_pyrep)
+
+
+def save_rois(app_state: "ApplicationState", manifest: Dict[str, Any]) -> None:
+    """Write every ROI in ``app_state`` into ``manifest['rois']``."""
+    manifest["rois"] = [roi_to_pyrep(roi) for roi in app_state.get_rois()]
+
+
+def load_rois(manifest: Dict[str, Any], app_state: "ApplicationState") -> None:
+    """Reconstruct ROIs from ``manifest['rois']`` into ``app_state``."""
+    for data in manifest.get("rois", []):
+        app_state.add_roi(roi_from_pyrep(data))

--- a/src/wiser/project/pyrep.py
+++ b/src/wiser/project/pyrep.py
@@ -1,0 +1,59 @@
+"""Shared pyrep serialization convention for project files.
+
+A *pyrep* is a plain, JSON-serializable ``dict`` describing one persistable
+object.  Every persistable type exposes ``to_pyrep() -> dict`` and a
+``from_pyrep(data)`` reconstructor; each dict carries a ``"type"`` tag so the
+loader can dispatch to the right reconstructor.  Large numpy arrays are never
+inlined -- they are written to the bundle's ``arrays/`` area and referenced by
+key (see :class:`~wiser.project.bundle.ProjectBundle`).
+
+``from_pyrep`` implementations should parse leniently: ignore unknown keys and
+supply defaults for missing ones, so that adding a new *optional* field is a
+non-breaking change that needs no migration (see :mod:`wiser.project.migrate`).
+"""
+
+from typing import Any, Callable, Dict
+
+PYREP_TYPE_KEY = "type"
+ARRAY_REF_KEY = "$array"
+
+
+class UnknownPyrepType(Exception):
+    """Raised when a pyrep dict carries a ``type`` tag with no reconstructor."""
+
+
+_FROM_PYREP: Dict[str, Callable[[Dict[str, Any]], Any]] = {}
+
+
+def register_pyrep(type_tag: str, from_pyrep_fn: Callable[[Dict[str, Any]], Any]) -> None:
+    """Register the reconstructor for a pyrep ``type`` tag."""
+    _FROM_PYREP[type_tag] = from_pyrep_fn
+
+
+def from_pyrep(data: Dict[str, Any]) -> Any:
+    """Reconstruct the object described by a pyrep dict.
+
+    Dispatches on the dict's ``"type"`` tag.  Raises :class:`UnknownPyrepType`
+    for an unregistered tag so the loader can warn and continue rather than
+    crash.
+    """
+    tag = data.get(PYREP_TYPE_KEY)
+    reconstruct = _FROM_PYREP.get(tag)
+    if reconstruct is None:
+        raise UnknownPyrepType(f"No pyrep reconstructor registered for type {tag!r}")
+    return reconstruct(data)
+
+
+def array_ref(key: str) -> Dict[str, str]:
+    """Build a manifest-embeddable reference to an array sidecar."""
+    return {ARRAY_REF_KEY: key}
+
+
+def is_array_ref(obj: Any) -> bool:
+    """Return whether ``obj`` is an array-sidecar reference."""
+    return isinstance(obj, dict) and ARRAY_REF_KEY in obj
+
+
+def array_ref_key(obj: Dict[str, str]) -> str:
+    """Return the relative sidecar key from an array-sidecar reference."""
+    return obj[ARRAY_REF_KEY]

--- a/src/wiser/raster/roi.py
+++ b/src/wiser/raster/roi.py
@@ -6,7 +6,6 @@ from .selection import (
 )
 
 from PySide6.QtCore import QRect
-from PySide6.QtGui import QColor
 
 
 class RegionOfInterest:
@@ -102,24 +101,46 @@ class RegionOfInterest:
         print("]")
 
 
-def roi_to_pyrep(roi):
-    data = {
-        "name": roi.get_name(),
-        "color": str(roi.get_color().name()),
-        "metadata": roi.get_metadata(),
-    }
-    # TODO(donnie):  Composite/multi-selection ROIs
-    data["selection"] = roi.get_selection().to_pyrep()
+ROI_PYREP_TYPE = "RegionOfInterest"
 
-    return data
+
+def roi_to_pyrep(roi):
+    """Serialize a region of interest to a JSON-friendly pyrep dict.
+
+    Captures the ROI's identity and styling plus every selection's own pyrep,
+    so multi-selection ROIs round-trip faithfully (a polygon comes back a
+    polygon, not a rasterized pixel dump).
+    """
+    return {
+        "type": ROI_PYREP_TYPE,
+        "id": roi.get_id(),
+        "name": roi.get_name(),
+        "color": roi.get_color(),
+        "description": roi.get_description(),
+        "metadata": roi.get_metadata(),
+        "selections": [sel.to_pyrep() for sel in roi.get_selections()],
+    }
 
 
 def roi_from_pyrep(data):
-    name = data["name"]
-    color = QColor(data["color"])
-    metadata = data["metadata"]
-    # TODO(donnie):  Composite/multi-selection ROIs
-    sel = selection_from_pyrep(data["selection"])
+    """Reconstruct a region of interest from a :func:`roi_to_pyrep` dict.
 
-    roi = RegionOfInterest(name, sel, color, **metadata)
+    Parses leniently: unknown keys are ignored and missing optional keys take
+    their defaults.
+    """
+    roi = RegionOfInterest(name=data.get("name"), color=data.get("color", "yellow"))
+
+    roi_id = data.get("id")
+    if roi_id is not None:
+        roi.set_id(roi_id)
+
+    roi.set_description(data.get("description"))
+
+    metadata = data.get("metadata")
+    if metadata:
+        roi.get_metadata().update(metadata)
+
+    for sel_data in data.get("selections", []):
+        roi.add_selection(selection_from_pyrep(sel_data))
+
     return roi

--- a/src/wiser/raster/roi.py
+++ b/src/wiser/raster/roi.py
@@ -126,8 +126,13 @@ def roi_from_pyrep(data):
     """Reconstruct a region of interest from a :func:`roi_to_pyrep` dict.
 
     Parses leniently: unknown keys are ignored and missing optional keys take
-    their defaults.
+    their defaults.  A present ``type`` tag must match, so a pyrep of the wrong
+    kind is rejected rather than silently mangled into an ROI.
     """
+    type_tag = data.get("type")
+    if type_tag is not None and type_tag != ROI_PYREP_TYPE:
+        raise ValueError(f"Expected pyrep type {ROI_PYREP_TYPE!r}, got {type_tag!r}")
+
     roi = RegionOfInterest(name=data.get("name"), color=data.get("color", "yellow"))
 
     roi_id = data.get("id")

--- a/src/wiser/raster/selection.py
+++ b/src/wiser/raster/selection.py
@@ -142,7 +142,7 @@ class SinglePixelSelection(Selection):
 
     def from_pyrep(data):
         assert data["type"] == SelectionType.SINGLE_PIXEL.name
-        return SinglePixelSelection(pixel=data["pixel"])
+        return SinglePixelSelection(pixel=QPoint(data["pixel"][0], data["pixel"][1]))
 
 
 class MultiPixelSelection(Selection):
@@ -345,7 +345,7 @@ class PredicateSelection(Selection):
 
     def from_pyrep(data):
         assert data["type"] == SelectionType.PREDICATE.name
-        return PredicateSelection(points=data["predicate"])
+        return PredicateSelection(predicate=data["predicate"])
 
 
 def selection_from_pyrep(data):


### PR DESCRIPTION
## What does this change do?
Introduces the foundation for saving and restoring a WISER session as a portable `.wiserproj` bundle, plus the first per-item persister (ROIs) that proves the serialization convention end-to-end. Foundation layer of the Save/Open Project epic (#615).

## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [x] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] Chore
- [ ] Revert

## Why is this change needed?
A WISER session is entirely in-RAM today — closing the app loses loaded datasets, ROIs, spectra, stretches, run histories, etc. This PR lands the on-disk bundle format and the shared serialization convention that every other persister in the epic builds on.

Closes #616 (bundle format + pyrep conventions) and #619 (ROI persister). Part of epic #615.

## How did you implement the change?
New `src/wiser/project/` package:
- **`ProjectBundle`** — a bundle is a directory (a `.wiserproj` is that directory zipped): `manifest.json` (a plain-dict "pyrep" → JSON) plus `arrays/`
(`.npy`) and `datasets/` (raster) sidecars. Bulk data never ent
- **`pyrep`** — the shared convention: every persistable type eep()`; each dict carries a `"type"` tag; a dispatch registry
reconstructs by tag; large arrays are referenced by key. `from_ding an optional field needs no migration.
- **`migrate`** — `format_version`, a migrate-up chain, and a c
- **`persisters/rois.py`** (#619) — the canonical persister thep`/`roi_from_pyrep` rewritten to round-trip multi-selection ROIs
faithfully.

Also in this PR:
- Fixes two latent `selection.py` `from_pyrep` bugs surfaced by the round-trip: `SinglePixelSelection` never rebuilt its `QPoint` (restored single-pixel
ROIs would crash), and `PredicateSelection` used the wrong cons
- Removes the disabled + broken legacy `.wiser` save/load path en_file` routing — the `.wiserproj` bundle supersedes it.
- Adds an optional `ds_id` parameter to `ApplicationState.add_dataset` as groundwork for id-preserving dataset restore (consumed by the stacked #618 PR).

## Added tests?
- [x] yes

`src/tests/test_project_bundle.py` — pyrep round-trips, registry dispatch, unknown-type handling, bundle manifest + array sidecar, zip round-trip, migration (no-op + refuse-too-new), and the ROI persister round-trip. Focused suite green: **29 passed** (`test_project_bundle` + `test_roi_storage` +
`test_selection_pickle`).

## Added to documentation?
- [x] no documentation needed

User-facing Save/Open UI and docs land with the orchestration issues #626/#627.

## Checklist
- [x] There is an issue associated with this pull request (#616
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced (ruff + ruff-format clean)
- [ ] Branch is up-to-date with main/master — based on the PySide6 merge (`8d8c53f1`); **needs a rebase onto current `main` before merge**
- [ ] All CI checks passed — pending CI

## [optional] Are there any post-merge tasks we need to perform?
- Rebase the stacked #618 PR (`feat/proj-618-datasets`) onto `main` once this merges.
</details>
