### PR TITLE
feat(project): dataset persister with ENVI sidecars (#618)

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/save-to-project.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/save-to-project.md
@@ -118,7 +118,7 @@ types, and bad enum values degrade gracefully.
 
 | Persister | Persists | Notes |
 |-----------|----------|-------|
-| `datasets` | Loaded datasets | File-backed by reference; RAM-backed to ENVI sidecars under `datasets/`. Original ids preserved on load so references stay valid. |
+| `datasets` | Loaded datasets | File-backed by reference, RAM-backed to ENVI sidecars under `datasets/`; a NetCDF subdataset also records which subdataset was selected, and a JSON snapshot of the runtime-editable metadata (data-ignore, bad bands, wavelengths + units, band names, display bands, georeferenced CRS) rides in the manifest and is reapplied on load. Original ids preserved so references stay valid. |
 | `rois` | Regions of interest | Standalone; multi-selection geometry round-trips through the pyrep convention. |
 | `spectra` | Collected + active spectra | Three kinds: self-contained NumPy, raster-backed (dataset + point + area), ROI-average (dataset + roi). Dataset-backed spectra go faithful when the dataset is saved, freeze to NumPy when cut. |
 | `stretches` | Per-`(dataset, band)` contrast stretches | Dataset-cascade leaf: dropped when its dataset is unsaved. Polymorphic across the stretch types. |
@@ -126,6 +126,33 @@ types, and bad enum values degrade gracefully.
 | `runs` | PCA / MNF / unmixing / K-Means histories | Every record self-contained; datasets referenced softly by id; run ids re-minted on load. |
 | `crs` | User-created coordinate systems | WKT + creator-dialog state; rebuilt via GDAL/`osr`, bad WKT drops the entry, a bad enum degrades one field. |
 | `bandmath` | Saved band-math expressions | A plain list of expression strings on `ApplicationState`. |
+
+### Dataset metadata and subdatasets
+
+A file-backed dataset is re-opened from its path on load, which re-derives its
+metadata from the source file — so metadata the user edited at runtime (a renamed
+band, an adjusted data-ignore value, a hand-marked bad-band list) would be lost on
+reopen. Each dataset entry therefore also carries a JSON snapshot of the
+runtime-editable metadata: the data-ignore value, the bad-band list, per-band
+wavelengths and their unit, band descriptions, the default display bands, and any
+georeferencer-assigned CRS (WKT) with its geo-transform. On load the snapshot is
+reapplied through the safe per-field setters in a fixed order — data-ignore first,
+since it keys the band-statistics cache, and band descriptions after wavelengths,
+since rebuilding band info overwrites them. Reapply is best-effort and
+field-guarded: a value that no longer fits the reopened dataset (a band-count
+mismatch, an unparseable unit) is skipped so the dataset still restores.
+
+A NetCDF **subdataset** needs one extra field. Its `get_filepaths()` returns a GDAL
+descriptor (`NETCDF:"/path/file.nc":var`) rather than a plain path, so the entry
+records the base `.nc` file together with the `subdataset_name` descriptor and
+reopens via `load_from_file(base, subdataset_name=…, interactive=False)` — restoring
+the *same* subdataset the user had open instead of re-running the auto-pick heuristic
+or dropping the dataset because the descriptor is not a file on disk. Subdataset
+selection is NetCDF-only.
+
+Both the metadata snapshot and `subdataset_name` are **additive, optional** manifest
+fields, so they require no `format_version` bump: an older manifest simply lacks them
+and loads exactly as before.
 
 ---
 

--- a/src/tests/test_project_datasets.py
+++ b/src/tests/test_project_datasets.py
@@ -10,16 +10,21 @@ a malformed id.
 import os
 
 import numpy as np
+from astropy import units as u
 
 import tests.context  # noqa: F401
+
+from osgeo import osr
 
 from wiser.project import ProjectBundle, unzip_bundle, zip_bundle
 from wiser.project.persisters.datasets import (
     STORAGE_REFERENCE,
     STORAGE_SIDECAR,
+    dataset_to_pyrep,
     load_datasets,
     save_datasets,
 )
+from wiser.raster.dataset import SpatialMetadata
 from wiser.raster.loader import RasterDataLoader
 
 
@@ -192,6 +197,140 @@ def test_unknown_storage_kind_is_dropped(tmp_path):
     dst = _FakeAppState()
     assert load_datasets(manifest, dst, bundle) == [7]
     assert dst.get_datasets() == []
+
+
+def _file_backed_dataset(app_state, tmp_path, name):
+    """Materialize an ENVI file on disk and open it as a file-backed dataset."""
+    loader = app_state.get_loader()
+    mem = loader.dataset_from_numpy_array(_sample_array(), None)
+    ext_path = tmp_path / f"{name}.img"
+    loader.save_dataset_as(mem, str(ext_path), format="ENVI", config=None)
+    ds = loader.load_from_file(str(ext_path), data_cache=None, interactive=False)[0]
+    app_state.add_dataset(ds)
+    return ds
+
+
+def test_file_backed_metadata_round_trips(tmp_path):
+    # Runtime edits a file reopen would otherwise revert must round-trip.
+    src = _FakeAppState()
+    ds = _file_backed_dataset(src, tmp_path, "edited")  # 4 bands
+    ds.set_data_ignore_value(-9999.0)
+    ds.set_bad_bands([1, 0, 1, 1])
+    ds.update_band_info([w * u.nm for w in (400.0, 500.0, 600.0, 700.0)])
+    ds.set_band_descriptions(["b0", "b1", "b2", "b3"])
+    ds.set_default_display_bands((2, 1, 0))
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    ds.copy_spatial_metadata(SpatialMetadata((0.0, 1.0, 0.0, 0.0, 0.0, -1.0), srs.ExportToWkt()))
+
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {}
+    save_datasets(src, manifest, bundle)
+
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == []
+    (restored,) = dst.get_datasets()
+    assert restored.get_data_ignore_value() == -9999.0
+    assert restored.get_bad_bands() == [1, 0, 1, 1]
+    assert [w.value for w in restored.get_wavelengths()] == [400.0, 500.0, 600.0, 700.0]
+    assert str(restored.get_band_unit()) == "nm"
+    assert [b.get("description") for b in restored.band_list()] == ["b0", "b1", "b2", "b3"]
+    assert restored.default_display_bands() == (2, 1, 0)
+    restored_srs = osr.SpatialReference()
+    restored_srs.ImportFromWkt(restored.get_wkt_spatial_reference())
+    assert restored_srs.IsSame(srs) == 1
+
+
+def test_metadata_snapshot_field_length_mismatch_skipped(tmp_path):
+    # A snapshot field that no longer fits the reopened band count is skipped, but
+    # the dataset still restores and valid fields still apply.
+    src = _FakeAppState()
+    _file_backed_dataset(src, tmp_path, "mm")  # 4 bands
+
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {}
+    save_datasets(src, manifest, bundle)
+    manifest["datasets"][0]["metadata"]["bad_bands"] = [1, 0]  # wrong length
+    manifest["datasets"][0]["metadata"]["data_ignore_value"] = 42.0  # still valid
+
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == []
+    (restored,) = dst.get_datasets()
+    assert restored.get_bad_bands() != [1, 0]  # mismatched field skipped
+    assert restored.get_data_ignore_value() == 42.0  # valid field applied
+
+
+def test_dataset_entry_without_metadata_restores(tmp_path):
+    # An older manifest entry with no "metadata" key restores as before.
+    src = _FakeAppState()
+    _memory_dataset(src, "in-mem")
+
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {}
+    save_datasets(src, manifest, bundle)
+    del manifest["datasets"][0]["metadata"]
+
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == []
+    (restored,) = dst.get_datasets()
+    assert restored.get_name() == "in-mem"
+
+
+def test_subdataset_base_path_parses_descriptor():
+    from wiser.project.persisters.datasets import _subdataset_base_path
+
+    assert _subdataset_base_path('NETCDF:"/data/scene.nc":reflectance') == "/data/scene.nc"
+    assert _subdataset_base_path("/plain/path.tif") == "/plain/path.tif"
+
+
+def test_subdataset_recorded_as_base_path_and_descriptor():
+    # A subdataset is stored as base path + subdataset_name so the same subdataset
+    # re-opens.  (The full NetCDF reopen needs a live NetCDF file + GDAL driver;
+    # here we lock the manifest shape.)
+    descriptor = 'NETCDF:"/data/scene.nc":reflectance'
+
+    class _StubDataset:
+        def get_id(self):
+            return 7
+
+        def get_name(self):
+            return "sub"
+
+        def get_description(self):
+            return ""
+
+        def get_subdataset_name(self):
+            return descriptor
+
+        def get_filepaths(self):
+            return [descriptor]
+
+        def get_data_ignore_value(self):
+            return None
+
+        def get_bad_bands(self):
+            return None
+
+        def get_wavelengths(self):
+            return None
+
+        def band_list(self):
+            return []
+
+        def default_display_bands(self):
+            return None
+
+        def get_wkt_spatial_reference(self):
+            return None
+
+        def get_geo_transform(self):
+            return None
+
+    entry = dataset_to_pyrep(_StubDataset(), None, None)
+    assert entry["storage"] == STORAGE_REFERENCE
+    assert entry["path"] == "/data/scene.nc"
+    assert entry["subdataset_name"] == descriptor
+    assert entry["metadata"] == {}
 
 
 def test_malformed_id_is_skipped(tmp_path):

--- a/src/tests/test_project_datasets.py
+++ b/src/tests/test_project_datasets.py
@@ -9,6 +9,7 @@ a malformed id.
 
 import os
 
+import netCDF4 as nc
 import numpy as np
 from astropy import units as u
 
@@ -331,6 +332,69 @@ def test_subdataset_recorded_as_base_path_and_descriptor():
     assert entry["path"] == "/data/scene.nc"
     assert entry["subdataset_name"] == descriptor
     assert entry["metadata"] == {}
+
+
+def _netcdf_with_subdatasets(tmp_path, name="scene.nc"):
+    """Write a NetCDF whose two variables surface as GDAL subdatasets.
+
+    ``reflectance`` is what the loader's non-interactive auto-pick heuristic
+    selects; ``temperature`` scores zero, so opening it exercises an explicit,
+    non-default subdataset choice a reopen must preserve rather than re-derive.
+    """
+    path = tmp_path / name
+    ds = nc.Dataset(str(path), "w")
+    try:
+        ds.createDimension("band", 4)
+        ds.createDimension("y", 5)
+        ds.createDimension("x", 6)
+        refl = ds.createVariable("reflectance", "f4", ("band", "y", "x"))
+        refl[:] = np.arange(4 * 5 * 6, dtype=np.float32).reshape(4, 5, 6)
+        temp = ds.createVariable("temperature", "f4", ("y", "x"))
+        temp[:] = np.arange(5 * 6, dtype=np.float32).reshape(5, 6) + 1000.0
+    finally:
+        ds.close()
+    return str(path)
+
+
+def test_netcdf_subdataset_round_trips(tmp_path):
+    # A file-backed NetCDF subdataset must reopen to the SAME subdataset, not the
+    # one the non-interactive auto-pick heuristic would choose.  The manifest
+    # records the base .nc path plus the full GDAL descriptor.
+    nc_path = _netcdf_with_subdatasets(tmp_path)
+    src = _FakeAppState()
+    loader = src.get_loader()
+
+    # The heuristic's default pick is reflectance; temperature is the deliberate
+    # non-default choice the round-trip must hold onto.
+    auto = loader.load_from_file(nc_path, data_cache=None, interactive=False)[0]
+    assert auto.get_subdataset_name().endswith(":reflectance")
+
+    descriptor = f'NETCDF:"{nc_path}":temperature'
+    file_ds = loader.load_from_file(nc_path, data_cache=None, interactive=False, subdataset_name=descriptor)[
+        0
+    ]
+    assert file_ds.get_subdataset_name() == descriptor
+    src.add_dataset(file_ds)
+
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {}
+    save_datasets(src, manifest, bundle)
+
+    (entry,) = manifest["datasets"]
+    assert entry["storage"] == STORAGE_REFERENCE
+    assert entry["path"] == nc_path  # base file, not the GDAL descriptor
+    assert entry["subdataset_name"] == descriptor
+    # A subdataset is referenced, not copied into the bundle.
+    assert not (bundle.root / ProjectBundle.DATASETS_DIR).exists()
+
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == []
+    (restored,) = dst.get_datasets()
+    assert restored.get_id() == file_ds.get_id()
+    # Reopened to temperature, not the auto-pick's reflectance.
+    assert restored.get_subdataset_name() == descriptor
+    assert restored.get_subdataset_name() != auto.get_subdataset_name()
+    np.testing.assert_array_equal(_data(restored), _data(file_ds))
 
 
 def test_malformed_id_is_skipped(tmp_path):

--- a/src/tests/test_project_datasets.py
+++ b/src/tests/test_project_datasets.py
@@ -1,0 +1,149 @@
+"""Unit tests for the dataset persister (issue #618).
+
+Covers the two storage paths -- in-memory datasets snapshotted to an ENVI
+sidecar, file-backed datasets saved by reference -- plus id preservation, the
+zip round-trip, and graceful handling of a reference whose file has vanished.
+"""
+
+import os
+
+import numpy as np
+
+import tests.context  # noqa: F401
+
+from wiser.project import ProjectBundle, unzip_bundle, zip_bundle
+from wiser.project.persisters.datasets import (
+    STORAGE_REFERENCE,
+    STORAGE_SIDECAR,
+    load_datasets,
+    save_datasets,
+)
+from wiser.raster.loader import RasterDataLoader
+
+
+class _FakeAppState:
+    """Minimal stand-in exposing only the accessors the persister uses."""
+
+    def __init__(self):
+        self._loader = RasterDataLoader()
+        self._datasets = {}
+        self._next_id = 1
+
+    def get_loader(self):
+        return self._loader
+
+    def get_cache(self):
+        return None
+
+    def get_datasets(self):
+        return list(self._datasets.values())
+
+    def add_dataset(self, dataset, view_dataset=True, ds_id=None):
+        if ds_id is None:
+            ds_id = self._next_id
+        self._next_id = max(self._next_id, ds_id + 1)
+        dataset.set_id(ds_id)
+        self._datasets[ds_id] = dataset
+
+
+def _sample_array(bands=4, rows=5, cols=6):
+    return np.arange(bands * rows * cols, dtype=np.float32).reshape((bands, rows, cols))
+
+
+def _data(dataset):
+    """Raw pixel cube, unfiltered, as a plain ndarray for comparison."""
+    return np.asarray(dataset.get_image_data(filter_data_ignore_value=False))
+
+
+def _memory_dataset(app_state, name):
+    ds = app_state.get_loader().dataset_from_numpy_array(_sample_array(), None)
+    ds.set_name(name)
+    app_state.add_dataset(ds)
+    return ds
+
+
+def test_in_memory_dataset_saved_as_sidecar(tmp_path):
+    src = _FakeAppState()
+    ds = _memory_dataset(src, "in-mem")
+
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {}
+    save_datasets(src, manifest, bundle)
+
+    (entry,) = manifest["datasets"]
+    assert entry["storage"] == STORAGE_SIDECAR
+    assert entry["id"] == ds.get_id()
+    assert (bundle.root / entry["path"]).is_file()
+
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == []
+
+    (restored,) = dst.get_datasets()
+    assert restored.get_id() == ds.get_id()
+    assert restored.get_name() == "in-mem"
+    np.testing.assert_array_equal(_data(restored), _data(ds))
+
+
+def test_file_backed_dataset_saved_by_reference(tmp_path):
+    src = _FakeAppState()
+    loader = src.get_loader()
+
+    # Materialize an ENVI file on disk, then open it as a file-backed dataset.
+    mem = loader.dataset_from_numpy_array(_sample_array(), None)
+    ext_path = tmp_path / "external.img"
+    loader.save_dataset_as(mem, str(ext_path), format="ENVI", config=None)
+    file_ds = loader.load_from_file(str(ext_path), data_cache=None, interactive=False)[0]
+    file_ds.set_name("on-disk")
+    src.add_dataset(file_ds)
+
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {}
+    save_datasets(src, manifest, bundle)
+
+    (entry,) = manifest["datasets"]
+    assert entry["storage"] == STORAGE_REFERENCE
+    assert os.path.isfile(entry["path"])
+    # A file-backed dataset is not copied into the bundle.
+    assert not (bundle.root / ProjectBundle.DATASETS_DIR).exists()
+
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == []
+    (restored,) = dst.get_datasets()
+    assert restored.get_id() == file_ds.get_id()
+    np.testing.assert_array_equal(_data(restored), _data(file_ds))
+
+
+def test_missing_reference_is_dropped_not_fatal(tmp_path):
+    manifest = {
+        "datasets": [
+            {
+                "type": "RasterDataSet",
+                "id": 3,
+                "name": "gone",
+                "storage": STORAGE_REFERENCE,
+                "path": str(tmp_path / "nope.img"),
+            }
+        ]
+    }
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == [3]
+    assert dst.get_datasets() == []
+
+
+def test_sidecar_survives_zip_round_trip(tmp_path):
+    src = _FakeAppState()
+    ds = _memory_dataset(src, "zipme")
+
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {}
+    save_datasets(src, manifest, bundle)
+    bundle.write_manifest(manifest)
+
+    zip_path = zip_bundle(bundle, tmp_path / "proj.wiserproj")
+    reopened = unzip_bundle(zip_path, tmp_path / "unpacked")
+
+    dst = _FakeAppState()
+    assert load_datasets(reopened.read_manifest(), dst, reopened) == []
+    (restored,) = dst.get_datasets()
+    np.testing.assert_array_equal(_data(restored), _data(ds))

--- a/src/tests/test_project_datasets.py
+++ b/src/tests/test_project_datasets.py
@@ -1,8 +1,10 @@
 """Unit tests for the dataset persister (issue #618).
 
 Covers the two storage paths -- in-memory datasets snapshotted to an ENVI
-sidecar, file-backed datasets saved by reference -- plus id preservation, the
-zip round-trip, and graceful handling of a reference whose file has vanished.
+sidecar, file-backed datasets saved by reference -- plus id preservation,
+name/description round-trip, the zip round-trip, and graceful handling of a
+vanished reference, an out-of-bundle sidecar path, an unknown storage kind, and
+a malformed id.
 """
 
 import os
@@ -94,6 +96,7 @@ def test_file_backed_dataset_saved_by_reference(tmp_path):
     loader.save_dataset_as(mem, str(ext_path), format="ENVI", config=None)
     file_ds = loader.load_from_file(str(ext_path), data_cache=None, interactive=False)[0]
     file_ds.set_name("on-disk")
+    file_ds.set_description("user-edited")
     src.add_dataset(file_ds)
 
     bundle = ProjectBundle.create(tmp_path / "proj")
@@ -110,6 +113,10 @@ def test_file_backed_dataset_saved_by_reference(tmp_path):
     assert load_datasets(manifest, dst, bundle) == []
     (restored,) = dst.get_datasets()
     assert restored.get_id() == file_ds.get_id()
+    # Runtime edits to name/description round-trip even though the source file's
+    # own header does not carry them.
+    assert restored.get_name() == "on-disk"
+    assert restored.get_description() == "user-edited"
     np.testing.assert_array_equal(_data(restored), _data(file_ds))
 
 
@@ -147,3 +154,55 @@ def test_sidecar_survives_zip_round_trip(tmp_path):
     assert load_datasets(reopened.read_manifest(), dst, reopened) == []
     (restored,) = dst.get_datasets()
     np.testing.assert_array_equal(_data(restored), _data(ds))
+
+
+def test_sidecar_path_traversal_is_dropped(tmp_path):
+    # A file outside the bundle that a crafted sidecar path might try to read.
+    np.save(tmp_path / "secret.npy", np.arange(3))
+    manifest = {
+        "datasets": [
+            {
+                "type": "RasterDataSet",
+                "id": 5,
+                "name": "evil",
+                "storage": STORAGE_SIDECAR,
+                "path": "../secret.npy",
+            }
+        ]
+    }
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == [5]
+    assert dst.get_datasets() == []
+
+
+def test_unknown_storage_kind_is_dropped(tmp_path):
+    manifest = {
+        "datasets": [
+            {
+                "type": "RasterDataSet",
+                "id": 7,
+                "name": "huh",
+                "storage": "future-kind",
+                "path": "whatever",
+            }
+        ]
+    }
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == [7]
+    assert dst.get_datasets() == []
+
+
+def test_malformed_id_is_skipped(tmp_path):
+    manifest = {
+        "datasets": [
+            {"type": "RasterDataSet", "name": "no-id", "storage": STORAGE_REFERENCE, "path": "x"},
+            {"type": "RasterDataSet", "id": "3", "name": "str-id", "storage": STORAGE_REFERENCE, "path": "x"},
+        ]
+    }
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    dst = _FakeAppState()
+    # No integer id to preserve or report: skipped entirely, not in dropped.
+    assert load_datasets(manifest, dst, bundle) == []
+    assert dst.get_datasets() == []

--- a/src/tests/test_project_datasets.py
+++ b/src/tests/test_project_datasets.py
@@ -345,3 +345,14 @@ def test_malformed_id_is_skipped(tmp_path):
     # No integer id to preserve or report: skipped entirely, not in dropped.
     assert load_datasets(manifest, dst, bundle) == []
     assert dst.get_datasets() == []
+
+
+def test_non_dict_and_non_list_dataset_entries_are_skipped(tmp_path):
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    dst = _FakeAppState()
+    # A non-dict entry (string/null/number) is skipped without crashing the load.
+    assert load_datasets({"datasets": ["not-a-dict", None, 5]}, dst, bundle) == []
+    assert dst.get_datasets() == []
+    # A non-list section (hand-edited/corrupt) is ignored, not iterated as keys.
+    assert load_datasets({"datasets": {"0": {"id": 1}}}, dst, bundle) == []
+    assert dst.get_datasets() == []

--- a/src/wiser/project/persisters/datasets.py
+++ b/src/wiser/project/persisters/datasets.py
@@ -27,6 +27,7 @@ from ..bundle import ProjectBundle
 
 if TYPE_CHECKING:
     from wiser.gui.app_state import ApplicationState
+    from wiser.raster.data_cache import DataCache
     from wiser.raster.dataset import RasterDataSet
     from wiser.raster.loader import RasterDataLoader
 
@@ -107,7 +108,7 @@ def load_datasets(
 
 
 def _load_dataset(
-    entry: Dict[str, Any], bundle: ProjectBundle, loader: "RasterDataLoader", cache
+    entry: Dict[str, Any], bundle: ProjectBundle, loader: "RasterDataLoader", cache: Optional["DataCache"]
 ) -> Optional["RasterDataSet"]:
     storage = entry.get("storage")
     if storage == STORAGE_SIDECAR:
@@ -122,7 +123,12 @@ def _load_dataset(
     if not path or not os.path.isfile(path):
         return None
 
-    datasets = loader.load_from_file(path, data_cache=cache, interactive=False)
+    try:
+        datasets = loader.load_from_file(path, data_cache=cache, interactive=False)
+    except Exception:
+        # A referenced file that exists but is unreadable/unsupported (e.g. an
+        # ENVI .img missing its .hdr) is dropped and reported, not fatal.
+        return None
     if not datasets:
         return None
 

--- a/src/wiser/project/persisters/datasets.py
+++ b/src/wiser/project/persisters/datasets.py
@@ -1,0 +1,120 @@
+"""Dataset persistence (issue #618).
+
+Datasets are the roots of the project's dependency DAG -- the backbone every
+other persister references by id -- so restoring them with their original ids
+intact is what keeps downstream references (spectra, stretches, run records)
+valid across a save/load.
+
+Each dataset is captured one of two ways:
+
+* **By reference** -- a file-backed dataset records only its on-disk path and is
+  re-opened from that path on load.  Bulk raster bytes never enter the bundle.
+* **As a sidecar** -- an in-memory dataset (a NumPy-backed ``RasterDataSet``
+  with no file, e.g. a band-math result) is snapshotted to a native ENVI raster
+  under the bundle's ``datasets/`` directory.
+
+Unlike the ROI persister, datasets carry bulk raster bytes and cannot be rebuilt
+from the manifest dict alone, so they bypass the generic
+:func:`~wiser.project.pyrep.from_pyrep` registry: :func:`save_datasets` /
+:func:`load_datasets` drive the sidecar I/O through the bundle and the
+application's raster loader directly.
+"""
+
+import os
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from ..bundle import ProjectBundle
+
+if TYPE_CHECKING:
+    from wiser.gui.app_state import ApplicationState
+    from wiser.raster.dataset import RasterDataSet
+    from wiser.raster.loader import RasterDataLoader
+
+DATASET_PYREP_TYPE = "RasterDataSet"
+
+# Storage kinds recorded in a dataset's manifest entry.
+STORAGE_REFERENCE = "reference"  # file-backed: re-opened from its original path
+STORAGE_SIDECAR = "sidecar"  # in-memory: snapshotted to datasets/ as ENVI
+
+
+def dataset_to_pyrep(
+    dataset: "RasterDataSet", bundle: ProjectBundle, loader: "RasterDataLoader"
+) -> Dict[str, Any]:
+    """Serialize one dataset, writing an ENVI sidecar if it is in-memory.
+
+    A file-backed dataset records only its path; an in-memory dataset is written
+    to ``datasets/ds_<id>.img`` (plus its ``.hdr``) inside ``bundle``.
+    """
+    ds_id = dataset.get_id()
+    entry: Dict[str, Any] = {
+        "type": DATASET_PYREP_TYPE,
+        "id": ds_id,
+        "name": dataset.get_name(),
+    }
+
+    filepaths = dataset.get_filepaths()
+    if filepaths:
+        entry["storage"] = STORAGE_REFERENCE
+        entry["path"] = filepaths[0]
+    else:
+        sidecar = bundle.raster_sidecar_path(f"ds_{ds_id}.img")
+        loader.save_dataset_as(dataset, str(sidecar), format="ENVI", config=None)
+        entry["storage"] = STORAGE_SIDECAR
+        entry["path"] = f"{ProjectBundle.DATASETS_DIR}/{sidecar.name}"
+
+    return entry
+
+
+def save_datasets(app_state: "ApplicationState", manifest: Dict[str, Any], bundle: ProjectBundle) -> None:
+    """Write every dataset in ``app_state`` into ``manifest['datasets']``."""
+    loader = app_state.get_loader()
+    manifest["datasets"] = [dataset_to_pyrep(ds, bundle, loader) for ds in app_state.get_datasets()]
+
+
+def load_datasets(
+    manifest: Dict[str, Any], app_state: "ApplicationState", bundle: ProjectBundle
+) -> List[int]:
+    """Reconstruct datasets from ``manifest['datasets']`` into ``app_state``.
+
+    Each restored dataset keeps its original id via
+    :meth:`ApplicationState.add_dataset`'s ``ds_id``.  Returns the ids that could
+    not be restored -- a referenced file that has since moved, or a sidecar
+    missing from the bundle -- so the caller can warn without aborting the load
+    rather than leaving a dangling reference.
+    """
+    loader = app_state.get_loader()
+    cache = app_state.get_cache()
+    dropped: List[int] = []
+
+    for entry in manifest.get("datasets", []):
+        dataset = _load_dataset(entry, bundle, loader, cache)
+        if dataset is None:
+            dropped.append(entry.get("id"))
+            continue
+        app_state.add_dataset(dataset, ds_id=entry.get("id"))
+
+    return dropped
+
+
+def _load_dataset(
+    entry: Dict[str, Any], bundle: ProjectBundle, loader: "RasterDataLoader", cache
+) -> Optional["RasterDataSet"]:
+    if entry.get("storage") == STORAGE_SIDECAR:
+        path = str(bundle.root / entry["path"])
+    else:
+        path = entry.get("path")
+
+    if not path or not os.path.isfile(path):
+        return None
+
+    datasets = loader.load_from_file(path, data_cache=cache, interactive=False)
+    if not datasets:
+        return None
+
+    # A file may yield several sub-datasets; the persister round-trips the
+    # primary one, matching how a plain single-raster file is opened.
+    dataset = datasets[0]
+    name = entry.get("name")
+    if name is not None:
+        dataset.set_name(name)
+    return dataset

--- a/src/wiser/project/persisters/datasets.py
+++ b/src/wiser/project/persisters/datasets.py
@@ -7,11 +7,17 @@ valid across a save/load.
 
 Each dataset is captured one of two ways:
 
-* **By reference** -- a file-backed dataset records only its on-disk path and is
-  re-opened from that path on load.  Bulk raster bytes never enter the bundle.
+* **By reference** -- a file-backed dataset records its on-disk path and is
+  re-opened from it on load.  Bulk raster bytes never enter the bundle.  A NetCDF
+  subdataset also records its ``subdataset_name`` so the *same* subdataset re-opens.
 * **As a sidecar** -- an in-memory dataset (a NumPy-backed ``RasterDataSet``
   with no file, e.g. a band-math result) is snapshotted to a native ENVI raster
   under the bundle's ``datasets/`` directory.
+
+Either way the manifest also carries a JSON snapshot of the runtime-editable
+metadata (data-ignore, bad bands, wavelengths, band names, display bands,
+georeferenced CRS), reapplied on load via the safe per-field setters so edits a
+file reopen would otherwise revert are preserved.
 
 Unlike the ROI persister, datasets carry bulk raster bytes and cannot be rebuilt
 from the manifest dict alone, so they bypass the generic
@@ -47,18 +53,29 @@ def dataset_to_pyrep(
     to ``datasets/ds_<id>.img`` (plus its ``.hdr``) inside ``bundle``.
     """
     ds_id = dataset.get_id()
-    # The manifest carries the user-editable SOURCE identity (name, description).
-    # Richer spectral/spatial metadata rides in the raster itself -- the ENVI
-    # sidecar header for in-memory datasets, the source file for file-backed ones.
+    # The manifest carries the user-editable SOURCE identity (name, description)
+    # plus a snapshot of the runtime-editable spectral/spatial metadata, so edits
+    # a file-backed dataset would otherwise lose on reopen (data-ignore, bad bands,
+    # wavelengths, band names, display bands, georeferenced CRS) round-trip.
     entry: Dict[str, Any] = {
         "type": DATASET_PYREP_TYPE,
         "id": ds_id,
         "name": dataset.get_name(),
         "description": dataset.get_description(),
+        "metadata": _metadata_to_pyrep(dataset),
     }
 
+    subdataset_name = dataset.get_subdataset_name()
     filepaths = dataset.get_filepaths()
-    if filepaths:
+    if subdataset_name:
+        # A NetCDF subdataset's get_filepaths() returns the GDAL descriptor, not a
+        # plain path; store the base file and the descriptor so load re-opens the
+        # SAME subdataset instead of re-running the auto-pick heuristic (or dropping
+        # the dataset because os.path.isfile rejects the descriptor).
+        entry["storage"] = STORAGE_REFERENCE
+        entry["path"] = _subdataset_base_path(subdataset_name)
+        entry["subdataset_name"] = subdataset_name
+    elif filepaths:
         entry["storage"] = STORAGE_REFERENCE
         entry["path"] = filepaths[0]
     else:
@@ -123,8 +140,11 @@ def _load_dataset(
     if not path or not os.path.isfile(path):
         return None
 
+    subdataset_name = entry.get("subdataset_name") or ""
     try:
-        datasets = loader.load_from_file(path, data_cache=cache, interactive=False)
+        datasets = loader.load_from_file(
+            path, data_cache=cache, interactive=False, subdataset_name=subdataset_name
+        )
     except Exception:
         # A referenced file that exists but is unreadable/unsupported (e.g. an
         # ENVI .img missing its .hdr) is dropped and reported, not fatal.
@@ -136,6 +156,7 @@ def _load_dataset(
     # primary one, matching how a plain single-raster file is opened.
     dataset = datasets[0]
     _apply_source_metadata(dataset, entry)
+    _apply_metadata_snapshot(dataset, entry.get("metadata") or {})
     return dataset
 
 
@@ -169,3 +190,118 @@ def _apply_source_metadata(dataset: "RasterDataSet", entry: Dict[str, Any]) -> N
         dataset.set_name(name)
     if "description" in entry:
         dataset.set_description(entry.get("description"))
+
+
+def _subdataset_base_path(descriptor: str) -> str:
+    """Extract the base file path from a GDAL subdataset descriptor.
+
+    ``NETCDF:"/abs/file.nc":var`` -> ``/abs/file.nc``.  Returns the descriptor
+    unchanged if it is not in the expected quoted form.
+    """
+    if '"' in descriptor:
+        return descriptor.split('"')[1]
+    return descriptor
+
+
+def _metadata_to_pyrep(dataset: "RasterDataSet") -> Dict[str, Any]:
+    """JSON-safe snapshot of the runtime-editable metadata a file reopen loses.
+
+    Only present fields are recorded (presence-checked, so a ``data_ignore_value``
+    of ``0`` is kept).  Reapplied on load by :func:`_apply_metadata_snapshot`.
+    """
+    meta: Dict[str, Any] = {}
+
+    ignore = dataset.get_data_ignore_value()
+    if ignore is not None:
+        meta["data_ignore_value"] = float(ignore)
+
+    bad_bands = dataset.get_bad_bands()
+    if bad_bands is not None:
+        meta["bad_bands"] = [int(b) for b in bad_bands]
+
+    wavelengths = dataset.get_wavelengths()
+    if wavelengths:
+        meta["wavelengths"] = [float(w.value) for w in wavelengths]
+        unit = dataset.get_band_unit()
+        if unit is not None:
+            meta["wavelength_units"] = str(unit)
+
+    descriptions = [b.get("description") for b in dataset.band_list()]
+    if any(d is not None for d in descriptions):
+        meta["band_descriptions"] = descriptions
+
+    display = dataset.default_display_bands()
+    if display is not None:
+        meta["default_display_bands"] = list(display)
+
+    wkt = dataset.get_wkt_spatial_reference()
+    geo = dataset.get_geo_transform()
+    if wkt and geo is not None:
+        meta["wkt_spatial_ref"] = wkt
+        meta["geo_transform"] = list(geo)
+
+    return meta
+
+
+def _apply_metadata_snapshot(dataset: "RasterDataSet", meta: Dict[str, Any]) -> None:
+    """Reapply a saved metadata snapshot via the safe per-field setters.
+
+    Best-effort and field-guarded: a value that no longer fits the reopened
+    dataset (a band-count mismatch, an unparseable unit) is skipped so the dataset
+    still restores, never aborting the load.  Order matters -- data-ignore first
+    (it feeds the band-stat cache key), and band descriptions after wavelengths
+    (``update_band_info`` rebuilds band info).  Never uses the destructive
+    ``set_band_list`` / ``set_band_unit``.
+    """
+    if not isinstance(meta, dict):
+        return
+
+    import astropy.units as u
+
+    from wiser.raster.dataset import SpatialMetadata
+
+    num_bands = dataset.num_bands()
+
+    if "data_ignore_value" in meta:
+        try:
+            dataset.set_data_ignore_value(meta["data_ignore_value"])
+        except Exception:
+            pass
+
+    wavelengths = meta.get("wavelengths")
+    units = meta.get("wavelength_units")
+    if isinstance(wavelengths, list) and len(wavelengths) == num_bands and units:
+        try:
+            unit = u.Unit(units)
+            dataset.update_band_info([float(w) * unit for w in wavelengths])
+        except Exception:
+            pass
+
+    descriptions = meta.get("band_descriptions")
+    if isinstance(descriptions, list) and len(descriptions) == num_bands:
+        try:
+            dataset.set_band_descriptions(descriptions)
+        except Exception:
+            pass
+
+    bad_bands = meta.get("bad_bands")
+    if isinstance(bad_bands, list) and len(bad_bands) == num_bands:
+        try:
+            dataset.set_bad_bands([int(b) for b in bad_bands])
+        except Exception:
+            pass
+
+    display = meta.get("default_display_bands")
+    if isinstance(display, list):
+        try:
+            dataset.set_default_display_bands(tuple(display))
+        except Exception:
+            pass
+
+    wkt = meta.get("wkt_spatial_ref")
+    geo = meta.get("geo_transform")
+    if wkt and isinstance(geo, list) and len(geo) == 6:
+        try:
+            dataset.copy_spatial_metadata(SpatialMetadata(tuple(geo), wkt))
+        except Exception:
+            pass

--- a/src/wiser/project/persisters/datasets.py
+++ b/src/wiser/project/persisters/datasets.py
@@ -109,7 +109,15 @@ def load_datasets(
     cache = app_state.get_cache()
     dropped: List[int] = []
 
-    for entry in manifest.get("datasets", []):
+    entries = manifest.get("datasets", [])
+    if not isinstance(entries, list):
+        # A non-list datasets section (hand-edited/corrupt manifest) has nothing
+        # to restore; ignore it rather than iterating a dict's keys.
+        return dropped
+    for entry in entries:
+        if not isinstance(entry, dict):
+            # A non-dict entry has no id to preserve or report; skip it.
+            continue
         ds_id = entry.get("id")
         if not isinstance(ds_id, int):
             # A non-int id passed to add_dataset would silently mint a new one

--- a/src/wiser/project/persisters/datasets.py
+++ b/src/wiser/project/persisters/datasets.py
@@ -46,10 +46,14 @@ def dataset_to_pyrep(
     to ``datasets/ds_<id>.img`` (plus its ``.hdr``) inside ``bundle``.
     """
     ds_id = dataset.get_id()
+    # The manifest carries the user-editable SOURCE identity (name, description).
+    # Richer spectral/spatial metadata rides in the raster itself -- the ENVI
+    # sidecar header for in-memory datasets, the source file for file-backed ones.
     entry: Dict[str, Any] = {
         "type": DATASET_PYREP_TYPE,
         "id": ds_id,
         "name": dataset.get_name(),
+        "description": dataset.get_description(),
     }
 
     filepaths = dataset.get_filepaths()
@@ -80,18 +84,24 @@ def load_datasets(
     :meth:`ApplicationState.add_dataset`'s ``ds_id``.  Returns the ids that could
     not be restored -- a referenced file that has since moved, or a sidecar
     missing from the bundle -- so the caller can warn without aborting the load
-    rather than leaving a dangling reference.
+    rather than leaving a dangling reference.  Entries with no integer id (a
+    malformed manifest) are skipped, since there is no id to preserve or report.
     """
     loader = app_state.get_loader()
     cache = app_state.get_cache()
     dropped: List[int] = []
 
     for entry in manifest.get("datasets", []):
+        ds_id = entry.get("id")
+        if not isinstance(ds_id, int):
+            # A non-int id passed to add_dataset would silently mint a new one
+            # and cross-wire every downstream reference, so drop the entry.
+            continue
         dataset = _load_dataset(entry, bundle, loader, cache)
         if dataset is None:
-            dropped.append(entry.get("id"))
+            dropped.append(ds_id)
             continue
-        app_state.add_dataset(dataset, ds_id=entry.get("id"))
+        app_state.add_dataset(dataset, ds_id=ds_id)
 
     return dropped
 
@@ -99,10 +109,15 @@ def load_datasets(
 def _load_dataset(
     entry: Dict[str, Any], bundle: ProjectBundle, loader: "RasterDataLoader", cache
 ) -> Optional["RasterDataSet"]:
-    if entry.get("storage") == STORAGE_SIDECAR:
-        path = str(bundle.root / entry["path"])
-    else:
+    storage = entry.get("storage")
+    if storage == STORAGE_SIDECAR:
+        path = _sidecar_path(bundle, entry.get("path", ""))
+    elif storage == STORAGE_REFERENCE:
         path = entry.get("path")
+    else:
+        # Unknown storage kind (newer or hand-edited manifest): drop rather than
+        # treat an arbitrary string as a filesystem path.
+        return None
 
     if not path or not os.path.isfile(path):
         return None
@@ -114,7 +129,37 @@ def _load_dataset(
     # A file may yield several sub-datasets; the persister round-trips the
     # primary one, matching how a plain single-raster file is opened.
     dataset = datasets[0]
+    _apply_source_metadata(dataset, entry)
+    return dataset
+
+
+def _sidecar_path(bundle: ProjectBundle, rel: str) -> Optional[str]:
+    """Resolve a sidecar key confined to the bundle's ``datasets/`` directory.
+
+    Returns the absolute path, or ``None`` if ``rel`` is empty or escapes
+    ``datasets/`` (an absolute path or ``../`` segments in an untrusted
+    manifest), so a crafted manifest cannot read files outside the bundle.
+    """
+    if not rel:
+        return None
+    datasets_root = (bundle.root / ProjectBundle.DATASETS_DIR).resolve()
+    target = (bundle.root / rel).resolve()
+    try:
+        target.relative_to(datasets_root)
+    except ValueError:
+        return None
+    return str(target)
+
+
+def _apply_source_metadata(dataset: "RasterDataSet", entry: Dict[str, Any]) -> None:
+    """Reapply the user-editable SOURCE identity captured in the manifest.
+
+    ``load_from_file`` derives name and metadata from the file itself; reapplying
+    the saved values restores runtime edits (a renamed or re-described dataset)
+    that a file-backed dataset would otherwise lose on reload.
+    """
     name = entry.get("name")
     if name is not None:
         dataset.set_name(name)
-    return dataset
+    if "description" in entry:
+        dataset.set_description(entry.get("description"))


### PR DESCRIPTION
## What does this change do?
Adds the dataset persister for the Save/Open Project feature: saves and restores `RasterDataSet`s in a project bundle, with datasets as the id-preserving backbone every other item references.

## What type of PR is this? (check all applicable)
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] Chore
- [ ] Revert

## Why is this change needed?
Datasets are the roots of the project's dependency DAG — restoring them with their original ids intact is what keeps downstream references (spectra,
stretches, run records) valid across a save/load. Closes #618.

**Stacked on #616/#619** (`feat/proj-file`). This PR is based oows only the #618 changes — please review/merge #616/#619 first, after which this rebases onto `main`.

## How did you implement the change?
New `src/wiser/project/persisters/datasets.py`:
- File-backed datasets (`get_filepaths()` non-empty) are saved **by reference** — only the path is recorded; bulk bytes never enter the bundle.
- In-memory datasets (NumPy-backed, e.g. a band-math result) arNVI sidecars (`datasets/ds_<id>.img` + `.hdr`) via the existing`RasterDataLoader.save_dataset_as`.
- Restore re-opens each dataset and re-registers it with its orte.add_dataset(ds_id=...)`.
- A referenced file that has since moved (or a missing sidecar) is reported as **dropped**, not fatal — the load warns and continues rather than leaving a
dangling reference.

## Added tests?
- [x] yes

`src/tests/test_project_datasets.py` — the sidecar and by-reference round-trips, id preservation, the zip round-trip, and the missing-reference drop. **4
passed.**

## Added to documentation?
- [x] no documentation needed

## Checklist
- [x] There is an issue associated with this pull request (#618
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced (ruff + ruff-format c
- [ ] Branch is up-to-date with main/master — stacked on `feat/proj-file`; rebase onto `main` after that merges
- [ ] All CI checks passed — pending CI

## [optional] Are there any post-merge tasks we need to perform
- After #616/#619 merges, rebase this branch onto `main` (GitHub retargets the base automatically), then this PR closes #618.
