### PR TITLE
feat: Rendering mosaic polygons and building camera and raster model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,7 @@ Secret.sh
 
 .vscode/
 
+.claude/
+
 src/wiser/bandmath/temp_output/
 src/wiser/profiling/output/*

--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -6,9 +6,10 @@ intended for developers reading, debugging, or extending the tool.
 
 ```{note}
 This is an in-progress feature (EPIC #629). As of this writing, scene ingestion,
-materialization, and common-grid/CRS resolution are implemented and wired into the
-GUI. **Pixel compositing (the preview) and the vector footprint overlay are not yet
-implemented** — see [What Isn't Built Yet](#what-isnt-built-yet).
+materialization, common-grid/CRS resolution, and the **vector overlay** (footprints,
+bounding box, overlap highlight) are implemented and wired into the GUI. **Pixel
+compositing (the preview) is not yet implemented** — see [What Isn't Built
+Yet](#what-isnt-built-yet).
 ```
 
 For the design rationale and full child-issue breakdown, see `EPIC_seamless_mosaic.md`
@@ -31,8 +32,10 @@ The feature is built from three cooperating layers:
 
 - **The rendering layer** — `MosaicView` is a `QWidget` sibling of `RasterView`
   (not a subclass — a mosaic is N scenes on one shared world grid, not one dataset
-  zoomed). It currently paints only an empty background; compositing and the
-  footprint overlay are stubbed seams for later issues.
+  zoomed). It draws the **vector overlay** (footprints, bounding box, overlap
+  highlight) on a QGIS-style unbounded canvas via a world→screen camera
+  (`MosaicViewTransform`); the pixel-compositing layer beneath it is still a stubbed
+  seam (#637). See [The Geometry Overlay](#the-geometry-overlay-vector-layer).
 
 Every scene, regardless of its original backing (GDAL file, NumPy array, PDR, etc.),
 is first turned into a warpable, disk-backed tiled GeoTIFF by a `SceneMaterializer` —
@@ -93,6 +96,10 @@ classDiagram
         mosaic_view.py
         -_controller : MosaicController
         -_composite_pixmap : QPixmap
+        -_transform : MosaicViewTransform
+        -_footprint_paths : List~QPainterPath~
+        -_hidden_paths : List~QPainterPath~
+        +invalidate_overlay()
         +composite(layers, order) QImage
         +paintEvent(event)
     }
@@ -412,6 +419,89 @@ convention used throughout WISER (see the georeferencer's identical convention i
 
 ---
 
+## The Geometry Overlay (Vector Layer)
+
+**Files:** `src/wiser/gui/mosaic_view.py` (rendering) and the Qt-free geometry helpers
+in `src/wiser/raster/mosaic_controller.py`.
+
+`MosaicView` draws the vector overlay (issue #636): each visible scene's footprint
+outline (green), the union bounding box (dashed), and the **overlap highlight**
+(magenta/purple) marking where a scene is hidden by anything above it in z-order. It
+matches the ENVI reference and is used **purely for on-screen rendering** — it never
+decides which pixel wins (that is z-order in the compositor/export, #637/#639).
+
+### The camera: `MosaicViewTransform`
+
+The view is a **QGIS-style unbounded canvas**, not `RasterView`'s
+`QScrollArea`-around-a-fixed-`QPixmap` (which is bounded by the pixmap's pixel size).
+There is no backing store sized to the data; the only state that persists between
+paints is a **camera** — three floats:
+
+- `center_x`, `center_y` — a point in **world (target-CRS) coordinates** that always
+  maps to the center of the widget. Panning moves it; nothing clamps it, so panning
+  far from every footprint simply shows blank canvas (what makes it "unbounded").
+- `world_units_per_pixel` — a single scale; zooming changes it.
+
+There is no invented `(0, 0)` origin: world coordinates come from the common CRS and
+screen coordinates are Qt's usual top-left widget space. The visible world rectangle
+is *derived* from `center + scale + widget size` each paint (never stored — storing it
+would distort the aspect ratio on resize). `world_to_screen(viewport_size)` returns a
+`QTransform` (with a y-flip, since world y increases north but screen y increases
+downward); `screen_to_world` is its inverse. The viewport size is passed in rather than
+cached, since `QWidget` already tracks it. The same camera is shared with the pixel
+layer (#637), which is why #636 builds it.
+
+Interaction: **middle-button drag** pans, the **mouse wheel** zooms (anchored at the
+cursor). The mosaic extent is framed once — the first time a common grid is available
+*and* the widget has a real size (done in `paintEvent`, not on grid-build, to avoid a
+0×0 not-yet-shown viewport) — and never auto-refit afterward, so a user's pan/zoom is
+never yanked out from under them.
+
+### Footprint reprojection and the overlap computation (Qt-free)
+
+The raw `footprint_wkt` on each `MosaicScene` is in the scene's **own** CRS. Two
+Qt-free helpers in `mosaic_controller.py` turn those into common-CRS geometry (so the
+overlay stays unit-testable without Qt, mirroring the controller's no-Qt rule):
+
+- `reprojected_footprint_geometry(scene, src_srs, target_srs)` — the footprint polygon
+  transformed *whole* into the target CRS (`_footprint_envelope` now delegates to this,
+  so the reprojection is defined once).
+- `MosaicController.visible_scene_footprints_in_common_crs()` — `(scene, geometry)` for
+  each visible scene, bottom-to-top, in the resolved target CRS; returns `[]` when no
+  target CRS is resolved yet (the view then draws nothing).
+- `compute_union_overlaps(footprints)` — each scene's **hidden region** = its footprint
+  ∩ the union of everything above it. Walking top-to-bottom with a running union, this
+  is one `Intersection` + one `Union` per scene (`O(n)`), not all-pairs `O(n²)`. The
+  topmost scene is never hidden.
+
+### Rendering and the geometry cache
+
+`MosaicView` caches the overlay as world-space `QPainterPath`s (`_footprint_paths` and
+the parallel `_hidden_paths`, plus `_bbox_extent`) converted from those `ogr.Geometry`
+objects by `_geometry_to_qpainterpath` (handles polygons-with-holes via the odd-even
+fill rule, and skips degenerate non-polygon `Intersection` results).
+
+This split is deliberate: **geometry** is recomputed only when scenes, z-order, or the
+target CRS change; **the transform** is applied fresh every paint. So pan/zoom is a
+cheap repaint (`paintEvent` just installs a new `QTransform` and redraws cached paths)
+with no GDAL/OSR work, satisfying the "redraws on pan/zoom without recomputing pixels"
+requirement.
+
+`MosaicPane` calls `MosaicView.invalidate_overlay()` (which sets a dirty flag and
+schedules a repaint) after every controller mutation that changes the overlay — scene
+add/remove, visibility toggle, and target-CRS change. The actual rebuild runs lazily
+in `paintEvent` when the flag is set (coalescing repeated invalidations into one
+rebuild) and is fully guarded: any OGR/OSR failure clears the cache and logs rather
+than letting an exception escape a paint. Pens are **cosmetic**, so outline width stays
+constant in screen pixels regardless of zoom.
+
+`paintEvent` draws, in order: the pixel layer (still stubbed, #637), then the bounding
+box, then per scene a clip to its hidden region filled + outlined in the highlight
+color, then all footprint outlines on top in green (so every boundary stays visible
+even where it crosses an overlap region).
+
+---
+
 ## `ReprojectPromptDialog`
 
 **File:** `src/wiser/gui/mosaic_crs_dialog.py`
@@ -443,18 +533,16 @@ selected.
 
 ## What Isn't Built Yet
 
-`MosaicView.paintEvent` currently only fills the background; both layers are stubbed
-seams with `TODO` markers pointing at the issues that will fill them in:
+`MosaicView.paintEvent` now draws the vector overlay (#636, see [The Geometry
+Overlay](#the-geometry-overlay-vector-layer)); the pixel layer beneath it is still a
+stubbed seam with a `TODO` marker, alongside the control-panel and export gaps:
 
 - **Pixel layer (compositing, issue #637)** — `MosaicView.composite(layers, order)` is
   a stub that returns `None`. The design calls for per-scene ARGB `QImage` caches at
   screen resolution (alpha = validity, from the GDAL mask band), stacked bottom-to-top
-  by `QPainter`; z-order reorders would only re-stack cached layers (no GDAL reads),
-  while pan/zoom would re-read from overviews (debounced).
-- **Vector overlay (issue #636)** — footprints, the mosaic bounding box, and the
-  "overlap highlight" (where a lower scene's footprint is covered by a higher one)
-  drawn on top of the pixel layer via a world→screen affine derived from the
-  controller's `CommonGrid`.
+  by `QPainter` and drawn beneath the vector overlay via the same
+  `MosaicViewTransform` camera; z-order reorders would only re-stack cached layers (no
+  GDAL reads), while pan/zoom would re-read from overviews (debounced).
 - **Control panel additions (issue #638)** — drag-to-reorder z-order, resampling
   method selector, and a band-metadata chooser are not yet in `MosaicPane`; today's
   panel only has Add Scene, the scene list (visibility toggle + remove), and the
@@ -484,7 +572,15 @@ consume the same `MosaicController` state once implemented.
 ## Testing
 
 - `src/tests/test_mosaic_controller.py` — grid math per `ResolutionMode`, CRS
-  resolution/validation, cache invalidation (pure `MosaicController`, no Qt).
+  resolution/validation, cache invalidation, and the Qt-free geometry helpers
+  (`reprojected_footprint_geometry`, `compute_union_overlaps`,
+  `visible_scene_footprints_in_common_crs`) — all pure `MosaicController`, no Qt.
+- `src/tests/test_mosaic_view_transform.py` — `MosaicViewTransform` camera math:
+  world↔screen round-trip, y-flip orientation, zoom-anchor invariance, aspect-ratio
+  preservation (pure `QTransform` math, no widget shown).
+- `src/tests/test_mosaic_view_gui.py` — the overlay wiring end to end: geometry cache
+  populates for overlapping scenes and re-invalidates on scene removal / target-CRS
+  change, driven through the real `MosaicPane` ingestion path.
 - `src/tests/test_mosaic_ingestion.py` — `validate_scene`, `build_overviews`,
   `compute_footprint_wkt`, and progress-reporting behavior.
 - `src/tests/test_mosaic_crs_dialog.py` — `ReprojectPromptDialog` in isolation

--- a/src/tests/test_mosaic_controller.py
+++ b/src/tests/test_mosaic_controller.py
@@ -12,6 +12,10 @@ from wiser.raster.mosaic_controller import (
     ResolutionMode,
     TargetCrsRequired,
     UnmappableCrsError,
+    compute_union_overlaps,
+    reprojected_footprint_geometry,
+    _footprint_envelope,
+    _srs_from_wkt,
     _warped_resolution,
 )
 
@@ -304,6 +308,100 @@ def test_scene_crs_summary(tmp_path):
     assert "EPSG:32611" in summary[0][1]
     assert "EPSG:4326" in summary[1][1]
     assert summary[2][1] == "(no CRS)"
+
+
+# -- geometry overlay helpers (#636) -----------------------------------------
+
+
+def _square(x0, y0, x1, y1) -> ogr.Geometry:
+    """A rectangular polygon geometry (no CRS attached) for overlap tests."""
+    return ogr.CreateGeometryFromWkt(f"POLYGON(({x0} {y0},{x1} {y0},{x1} {y1},{x0} {y1},{x0} {y0}))")
+
+
+def test_reprojected_footprint_matches_envelope(tmp_path):
+    # Reprojecting the whole polygon then taking its envelope must agree with the
+    # grid builder's _footprint_envelope (which does the same reprojection).
+    scene = _make_scene(tmp_path, "s", epsg=32611, origin=(400000.0, 3800000.0), pixel=30.0)
+    src = scene.dataset.get_spatial_ref()
+    target = _srs_from_wkt(_wkt_for_epsg(4326))
+
+    geom = reprojected_footprint_geometry(scene, src, target)
+    env = geom.GetEnvelope()  # (min_x, max_x, min_y, max_y)
+    fe = _footprint_envelope(scene, src, target)  # (min_x, min_y, max_x, max_y)
+    assert env[0] == pytest.approx(fe[0])
+    assert env[1] == pytest.approx(fe[2])
+    assert env[2] == pytest.approx(fe[1])
+    assert env[3] == pytest.approx(fe[3])
+
+
+def test_reprojected_footprint_same_crs_is_identity(tmp_path):
+    scene = _make_scene(tmp_path, "s", epsg=32611)
+    src = scene.dataset.get_spatial_ref()
+    geom = reprojected_footprint_geometry(scene, src, src)
+    orig = ogr.CreateGeometryFromWkt(scene.footprint_wkt)
+    assert geom.GetEnvelope() == pytest.approx(orig.GetEnvelope())
+
+
+def test_compute_union_overlaps_partial():
+    # Bottom-to-top: A, B, C. B partly under C; A partly under B∪C. C is on top.
+    a = _square(0, 0, 10, 10)
+    b = _square(5, 0, 15, 10)
+    c = _square(12, 0, 20, 10)
+    hidden = compute_union_overlaps([(None, a), (None, b), (None, c)])
+
+    # Top scene (index 2) is never hidden.
+    assert set(hidden.keys()) == {0, 1}
+    # B ∩ C = x in [12,15] => area 30.
+    assert hidden[1].GetArea() == pytest.approx(30.0)
+    # A ∩ (B ∪ C) = x in [5,10] => area 50.
+    assert hidden[0].GetArea() == pytest.approx(50.0)
+
+
+def test_compute_union_overlaps_full_cover():
+    lower = _square(0, 0, 10, 10)
+    cover = _square(-1, -1, 11, 11)
+    hidden = compute_union_overlaps([(None, lower), (None, cover)])
+    assert set(hidden.keys()) == {0}
+    assert hidden[0].GetArea() == pytest.approx(100.0)  # the whole lower scene is hidden
+
+
+def test_compute_union_overlaps_disjoint():
+    a = _square(0, 0, 10, 10)
+    b = _square(100, 100, 110, 110)
+    assert compute_union_overlaps([(None, a), (None, b)]) == {}
+
+
+def test_visible_footprints_in_common_crs(tmp_path):
+    a = _make_scene(tmp_path, "a", epsg=32611, origin=(400000.0, 3800000.0))
+    b = _make_scene(tmp_path, "b", epsg=32611, origin=(400500.0, 3800500.0))
+    c = MosaicController()
+    c.add_scene(a)
+    c.add_scene(b)
+
+    # No target CRS resolved yet -> nothing to draw.
+    assert c.visible_scene_footprints_in_common_crs() == []
+
+    c.build_common_grid()  # locks the target to the shared scene CRS
+    fps = c.visible_scene_footprints_in_common_crs()
+    # Bottom-to-top order, and same-CRS reprojection is an identity on the envelope.
+    assert [s.dataset.get_name() for s, _ in fps] == ["a", "b"]
+    for scene, geom in fps:
+        own = ogr.CreateGeometryFromWkt(scene.footprint_wkt).GetEnvelope()
+        assert geom.GetEnvelope() == pytest.approx(own)
+
+
+def test_visible_footprints_excludes_hidden_scenes(tmp_path):
+    a = _make_scene(tmp_path, "a", epsg=32611, origin=(400000.0, 3800000.0))
+    b = _make_scene(tmp_path, "b", epsg=32611, origin=(400500.0, 3800500.0))
+    c = MosaicController()
+    c.add_scene(a)
+    c.add_scene(b)
+    c.build_common_grid()
+
+    c.set_visibility(1, False)  # hide "b"
+    c.build_common_grid()
+    fps = c.visible_scene_footprints_in_common_crs()
+    assert [s.dataset.get_name() for s, _ in fps] == ["a"]
 
 
 # -- validate_target_crs -----------------------------------------------------

--- a/src/tests/test_mosaic_view_gui.py
+++ b/src/tests/test_mosaic_view_gui.py
@@ -1,0 +1,217 @@
+"""GUI smoke tests for the mosaic vector overlay (EPIC #629, issue #636).
+
+Drive real scene ingestion through a :class:`MosaicPane` (as the #635 CRS tests do),
+then assert the :class:`MosaicView` overlay geometry cache populates and invalidates
+correctly. The overlap-geometry math itself is unit-tested in
+``test_mosaic_controller.py``; here we check the GUI wiring end to end.
+"""
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from osgeo import gdal, osr
+from PySide6.QtCore import QPointF
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QDialog
+
+import numpy as np
+
+import tests.context  # noqa: F401  (adds src/ to sys.path)
+from test_utils.test_model import WiserTestModel
+
+import pytest
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.integration,
+]
+
+
+def _write_overlapping_tiff(path, origin, epsg=32611, pixel=30.0, size=20, collar=2, bands=3):
+    """Write a small georeferenced GeoTIFF at ``origin`` with a nodata collar."""
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(epsg)
+    ds = gdal.GetDriverByName("GTiff").Create(
+        path,
+        size,
+        size,
+        bands,
+        gdal.GDT_Float32,
+        options=["TILED=YES", "BLOCKXSIZE=16", "BLOCKYSIZE=16"],
+    )
+    ox, oy = origin
+    ds.SetGeoTransform([ox, pixel, 0.0, oy, 0.0, -pixel])
+    ds.SetProjection(srs.ExportToWkt())
+    for b in range(1, bands + 1):
+        arr = np.full((size, size), 7, dtype=np.float32)
+        arr[:collar, :] = -9999
+        arr[-collar:, :] = -9999
+        arr[:, :collar] = -9999
+        arr[:, -collar:] = -9999
+        band = ds.GetRasterBand(b)
+        band.WriteArray(arr)
+        band.SetNoDataValue(-9999.0)
+    ds.FlushCache()
+    ds = None
+
+
+class TestMosaicViewGui(unittest.TestCase):
+    def setUp(self):
+        self.test_model = WiserTestModel()
+        self._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(self._tmp.cleanup)
+
+    def tearDown(self):
+        self.test_model.close_app()
+        del self.test_model
+
+    def _wait_for(self, predicate, timeout_ms=15000, step_ms=50):
+        waited = 0
+        while waited < timeout_ms:
+            if predicate():
+                return True
+            QTest.qWait(step_ms)
+            waited += step_ms
+        return predicate()
+
+    def _load(self, name, origin):
+        path = os.path.join(self._tmp.name, name)
+        _write_overlapping_tiff(path, origin)
+        return self.test_model.load_dataset(path)
+
+    def _ingest(self, pane, controller, dataset, expected_count):
+        index = pane._dataset_combo.findData(dataset.get_id())
+        self.assertGreaterEqual(index, 0)
+        pane._dataset_combo.setCurrentIndex(index)
+        pane._add_scene_button.click()
+        self.assertTrue(
+            self._wait_for(lambda: controller.scene_count() == expected_count),
+            "scene was not ingested within the timeout",
+        )
+
+    def test_overlay_geometry_populates_for_overlapping_scenes(self):
+        # Two same-CRS scenes whose valid footprints overlap in one corner.
+        ds_a = self._load("a.tif", origin=(400000.0, 3800000.0))
+        ds_b = self._load("b.tif", origin=(400300.0, 3799700.0))
+
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        view = pane.get_mosaic_view()
+
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_a, 1)
+            self._ingest(pane, controller, ds_b, 2)
+
+        # Ingestion invalidates the overlay; the rebuild is what paintEvent runs.
+        self.assertTrue(view._geometry_dirty)
+        view._rebuild_overlay_geometry()
+
+        self.assertEqual(len(view._footprint_paths), 2)
+        self.assertEqual(len(view._hidden_paths), 2)
+        self.assertIsNotNone(view._bbox_extent)
+        # The scenes overlap, so at least one scene has a hidden region.
+        self.assertTrue(any(p is not None for p in view._hidden_paths))
+        # Every footprint path has real geometry.
+        self.assertTrue(all(not p.isEmpty() for p in view._footprint_paths))
+
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_overlay_invalidates_on_scene_removal(self):
+        ds_a = self._load("a.tif", origin=(400000.0, 3800000.0))
+        ds_b = self._load("b.tif", origin=(400300.0, 3799700.0))
+
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        view = pane.get_mosaic_view()
+
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_a, 1)
+            self._ingest(pane, controller, ds_b, 2)
+
+        # Simulate a completed paint clearing the dirty flag.
+        view._rebuild_overlay_geometry()
+        view._geometry_dirty = False
+
+        # Removing a scene must re-dirty the overlay so it is rebuilt next paint.
+        pane._scene_list.setCurrentRow(0)
+        pane._on_remove_scene_clicked()
+        self.assertTrue(view._geometry_dirty)
+
+    def test_overlay_invalidates_on_target_crs_change(self):
+        ds_a = self._load("a.tif", origin=(400000.0, 3800000.0))
+        ds_b = self._load("b.tif", origin=(400300.0, 3799700.0))
+
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        view = pane.get_mosaic_view()
+
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_a, 1)
+            self._ingest(pane, controller, ds_b, 2)
+
+        view._rebuild_overlay_geometry()
+        view._geometry_dirty = False
+
+        target_geo = osr.SpatialReference()
+        target_geo.ImportFromEPSG(4326)
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog") as Dlg:
+            inst = Dlg.return_value
+            inst.exec.return_value = QDialog.Accepted
+            inst.selected_target_wkt.return_value = target_geo.ExportToWkt()
+            pane._on_choose_target_crs()
+
+        self.assertTrue(view._geometry_dirty)
+
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_camera_reframes_after_emptying_and_readding(self):
+        # Regression: add a scene, remove it (mosaic empties), then add a *different*
+        # scene far away. The camera must re-frame onto the new scene rather than stay
+        # parked on the removed scene's extent (which left the new footprint off-screen).
+        ds_a = self._load("a.tif", origin=(400000.0, 3800000.0))
+        ds_b = self._load("b.tif", origin=(700000.0, 3500000.0))  # far from A
+
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        view = pane.get_mosaic_view()
+        view.resize(800, 600)
+
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_a, 1)
+        view.grab()  # force a paint -> fit camera to A
+        self.assertTrue(view._has_fitted)
+
+        # Remove A: the mosaic is now empty, which re-arms the fit.
+        pane._scene_list.setCurrentRow(0)
+        pane._on_remove_scene_clicked()
+        view.grab()
+        self.assertFalse(view._has_fitted)
+
+        # Add B far away: the camera re-frames onto it.
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_b, 1)
+        view.grab()
+
+        self.assertTrue(view._has_fitted)
+        min_x, min_y, max_x, max_y = controller.get_common_grid().extent
+        cx, cy = (min_x + max_x) / 2.0, (min_y + max_y) / 2.0
+        # Camera centered on B's extent...
+        self.assertAlmostEqual(view._transform.center_x, cx, places=3)
+        self.assertAlmostEqual(view._transform.center_y, cy, places=3)
+        # ...and B's footprint maps on-screen (the user-visible symptom).
+        screen = view._transform.world_to_screen(view.size()).map(QPointF(cx, cy))
+        self.assertGreaterEqual(screen.x(), 0.0)
+        self.assertLessEqual(screen.x(), 800.0)
+        self.assertGreaterEqual(screen.y(), 0.0)
+        self.assertLessEqual(screen.y(), 600.0)
+
+        self.test_model.close_seamless_mosaic_dialog()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_mosaic_view_transform.py
+++ b/src/tests/test_mosaic_view_transform.py
@@ -1,0 +1,126 @@
+"""Unit tests for :class:`MosaicViewTransform` (EPIC #629, issue #636).
+
+Pure ``QTransform`` math — no widget is shown and no ``QApplication`` is required
+(``QTransform`` / ``QPointF`` / ``QSize`` are value types). These cover the DoD's
+"world->screen affine round-trips a few control points", plus the two things a naive
+round-trip would *not* catch on its own: the y-flip orientation and the zoom anchor.
+"""
+import unittest
+
+from PySide6.QtCore import QPointF, QSize
+
+import tests.context  # noqa: F401  (adds src/ to sys.path)
+from wiser.gui.mosaic_view import MosaicViewTransform
+
+import pytest
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.unit,
+]
+
+
+class TestMosaicViewTransform(unittest.TestCase):
+    def _camera(self) -> MosaicViewTransform:
+        # A UTM-ish extent: large offset origin, so we exercise real-world magnitudes
+        # rather than a cosy origin near (0, 0).
+        cam = MosaicViewTransform()
+        cam.fit_to_extent((500_000.0, 4_600_000.0, 510_000.0, 4_620_000.0), QSize(800, 600))
+        return cam
+
+    def test_round_trip_control_points(self) -> None:
+        """screen_to_world(world_to_screen(p)) recovers p across several camera states."""
+        vp = QSize(800, 600)
+        control_points = [
+            QPointF(0.0, 0.0),
+            QPointF(800.0, 600.0),
+            QPointF(400.0, 300.0),
+            QPointF(123.4, 567.8),
+        ]
+        cam = self._camera()
+        # Exercise a few distinct states: fitted, panned, zoomed in, zoomed out.
+        cam.pan(-50.0, 37.0)
+        for state in ("panned", "zoom_in", "zoom_out"):
+            if state == "zoom_in":
+                cam.zoom(2.5, QPointF(400.0, 300.0), vp)
+            elif state == "zoom_out":
+                cam.zoom(0.3, QPointF(650.0, 120.0), vp)
+            affine = cam.world_to_screen(vp)
+            for pt in control_points:
+                world = cam.screen_to_world(pt, vp)
+                back = affine.map(world)
+                self.assertAlmostEqual(back.x(), pt.x(), places=3, msg=f"{state} x")
+                self.assertAlmostEqual(back.y(), pt.y(), places=3, msg=f"{state} y")
+
+    def test_center_maps_to_viewport_center(self) -> None:
+        vp = QSize(800, 600)
+        cam = self._camera()
+        screen = cam.world_to_screen(vp).map(QPointF(cam.center_x, cam.center_y))
+        self.assertAlmostEqual(screen.x(), 400.0, places=3)
+        self.assertAlmostEqual(screen.y(), 300.0, places=3)
+
+    def test_y_axis_is_flipped(self) -> None:
+        """Increasing world-y (north) must map to *decreasing* screen-y (up the widget).
+
+        A plain round-trip passes even with the sign wrong, so this is asserted directly.
+        """
+        vp = QSize(800, 600)
+        cam = self._camera()
+        affine = cam.world_to_screen(vp)
+        low = affine.map(QPointF(cam.center_x, cam.center_y))
+        high = affine.map(QPointF(cam.center_x, cam.center_y + 1000.0))
+        self.assertLess(high.y(), low.y())
+
+    def test_zoom_keeps_anchor_world_point_fixed(self) -> None:
+        vp = QSize(800, 600)
+        cam = self._camera()
+        anchor = QPointF(650.0, 120.0)
+        world_before = cam.screen_to_world(anchor, vp)
+        cam.zoom(3.0, anchor, vp)
+        world_after = cam.screen_to_world(anchor, vp)
+        self.assertAlmostEqual(world_before.x(), world_after.x(), places=3)
+        self.assertAlmostEqual(world_before.y(), world_after.y(), places=3)
+
+    def test_zoom_changes_scale_by_factor(self) -> None:
+        vp = QSize(800, 600)
+        cam = self._camera()
+        before = cam.world_units_per_pixel
+        cam.zoom(2.0, QPointF(400.0, 300.0), vp)
+        # Zooming in by 2x means each pixel now covers half as much world.
+        self.assertAlmostEqual(cam.world_units_per_pixel, before / 2.0, places=9)
+
+    def test_pan_shifts_center_in_world_units(self) -> None:
+        cam = self._camera()
+        wupp = cam.world_units_per_pixel
+        cx, cy = cam.center_x, cam.center_y
+        cam.pan(10.0, 0.0)
+        # Dragging the content right by 10px moves the camera left by 10px of world.
+        self.assertAlmostEqual(cam.center_x, cx - 10.0 * wupp, places=6)
+        self.assertAlmostEqual(cam.center_y, cy, places=6)
+
+    def test_fit_preserves_aspect_ratio(self) -> None:
+        """A square world extent in a non-square viewport stays square (uniform scale)."""
+        cam = MosaicViewTransform()
+        cam.fit_to_extent((0.0, 0.0, 100.0, 100.0), QSize(800, 400))
+        affine = cam.world_to_screen(QSize(800, 400))
+        # A unit world square must map to a screen square (|m11| == |m22|).
+        self.assertAlmostEqual(abs(affine.m11()), abs(affine.m22()), places=9)
+
+    def test_fit_frames_whole_extent(self) -> None:
+        """Every corner of the fitted extent lands within the viewport bounds."""
+        vp = QSize(800, 600)
+        extent = (500_000.0, 4_600_000.0, 510_000.0, 4_620_000.0)
+        cam = MosaicViewTransform()
+        cam.fit_to_extent(extent, vp)
+        affine = cam.world_to_screen(vp)
+        min_x, min_y, max_x, max_y = extent
+        for wx, wy in ((min_x, min_y), (max_x, max_y), (min_x, max_y), (max_x, min_y)):
+            p = affine.map(QPointF(wx, wy))
+            self.assertGreaterEqual(p.x(), -0.5)
+            self.assertLessEqual(p.x(), vp.width() + 0.5)
+            self.assertGreaterEqual(p.y(), -0.5)
+            self.assertLessEqual(p.y(), vp.height() + 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/wiser/gui/mosaic_crs_dialog.py
+++ b/src/wiser/gui/mosaic_crs_dialog.py
@@ -180,7 +180,16 @@ class ReprojectPromptDialog(QDialog):
             return
 
         srs = osr.SpatialReference()
-        err = srs.SetFromUserInput(f"{authority}:{code}")
+        try:
+            err = srs.SetFromUserInput(f"{authority}:{code}")
+        except RuntimeError:
+            QMessageBox.warning(
+                self,
+                self.tr("CRS Lookup Failed"),
+                self.tr(f"Could not find spatial reference for {authority}:{code}"),
+            )
+            return
+
         if err != 0:
             QMessageBox.warning(
                 self,

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -264,7 +264,7 @@ class MosaicPane(QWidget):
             self._controller.remove_scene(self._controller.scene_count() - 1)
             return
         self._refresh_scene_list()
-        self._mosaic_view.update()
+        self._mosaic_view.invalidate_overlay()
 
     def _on_scene_failed(self, message: str) -> None:
         QMessageBox.critical(self, self.tr("Add scene failed"), message)
@@ -308,7 +308,7 @@ class MosaicPane(QWidget):
             return
         self._controller.set_visibility(index, item.checkState() == Qt.Checked)
         self._rebuild_grid_quietly()
-        self._mosaic_view.update()
+        self._mosaic_view.invalidate_overlay()
 
     def _on_remove_scene_clicked(self) -> None:
         index = self._selected_scene_index()
@@ -319,7 +319,7 @@ class MosaicPane(QWidget):
         # A removal can only relax the CRS constraint, so rebuild silently rather than
         # popping the reproject dialog.
         self._rebuild_grid_quietly()
-        self._mosaic_view.update()
+        self._mosaic_view.invalidate_overlay()
 
     # -- common grid / target CRS ---------------------------------------------
 
@@ -363,7 +363,7 @@ class MosaicPane(QWidget):
         except UnmappableCrsError as exc:
             QMessageBox.warning(self, self.tr("Cannot reproject"), str(exc))
         self._refresh_target_crs_label()
-        self._mosaic_view.update()
+        self._mosaic_view.invalidate_overlay()
 
     def _prompt_for_target_crs(self) -> bool:
         """

--- a/src/wiser/gui/mosaic_view.py
+++ b/src/wiser/gui/mosaic_view.py
@@ -16,8 +16,11 @@ Later issues fill in the two layers, both drawn through the seams stubbed here:
     drawn in world->screen coordinates on top of the pixel layer.
 """
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional, Tuple
+
+from osgeo import ogr
 
 from PySide6.QtCore import *
 from PySide6.QtGui import *
@@ -26,10 +29,62 @@ from PySide6.QtWidgets import *
 from .app_state import ApplicationState
 from .util import get_painter
 
-from wiser.raster.mosaic_controller import MosaicController, MosaicScene
+from wiser.raster.mosaic_controller import (
+    MosaicController,
+    MosaicScene,
+    compute_union_overlaps,
+)
 
 if TYPE_CHECKING:
     from .mosaic_pane import MosaicPane
+
+logger = logging.getLogger(__name__)
+
+# Vector-overlay styling (#636), matching the ENVI reference: green footprint
+# outlines, a dashed bounding box, and a magenta/purple overlap highlight. Pens are
+# cosmetic so their width stays constant in screen pixels under the world->screen
+# zoom (which would otherwise scale line width along with the geometry).
+_FOOTPRINT_PEN = QPen(QColor(0, 200, 0), 2)
+_FOOTPRINT_PEN.setCosmetic(True)
+_BBOX_PEN = QPen(QColor(230, 230, 230), 1, Qt.DashLine)
+_BBOX_PEN.setCosmetic(True)
+_OVERLAP_PEN = QPen(QColor(200, 0, 200), 2)
+_OVERLAP_PEN.setCosmetic(True)
+_OVERLAP_BRUSH = QBrush(QColor(200, 0, 200, 80))  # translucent purple fill
+
+# Multiplicative zoom per wheel notch (120 eighths-of-a-degree = one notch).
+_WHEEL_ZOOM_STEP = 1.25
+
+
+def _geometry_to_qpainterpath(geom: ogr.Geometry) -> QPainterPath:
+    """
+    Convert an OGR polygonal geometry to a ``QPainterPath`` in **world** coordinates
+    (no view transform applied — that happens per-paint).
+
+    Handles ``POLYGON`` (with interior rings as holes via the odd-even fill rule) and
+    ``MULTIPOLYGON`` / ``GEOMETRYCOLLECTION``; non-polygonal members (a point/line
+    from an edge-touching :meth:`Intersection`) are skipped so nothing degenerate is
+    drawn.
+    """
+    path = QPainterPath()
+    path.setFillRule(Qt.OddEvenFill)  # interior rings subtract as holes
+
+    def add_polygon(poly: ogr.Geometry) -> None:
+        for r in range(poly.GetGeometryCount()):
+            ring = poly.GetGeometryRef(r)
+            pts = [QPointF(x, y) for x, y, *_ in ring.GetPoints()]
+            if pts:
+                path.addPolygon(QPolygonF(pts))
+
+    gtype = geom.GetGeometryType()
+    if gtype in (ogr.wkbPolygon, ogr.wkbPolygon25D):
+        add_polygon(geom)
+    else:  # MultiPolygon / GeometryCollection: take only the polygonal members
+        for g in range(geom.GetGeometryCount()):
+            sub = geom.GetGeometryRef(g)
+            if sub.GetGeometryType() in (ogr.wkbPolygon, ogr.wkbPolygon25D):
+                add_polygon(sub)
+    return path
 
 
 @dataclass
@@ -124,15 +179,105 @@ class MosaicView(QWidget):
 
         # Pixel layer (#637): the composited, screen-resolution mosaic image.
         self._composite_pixmap: Optional[QPixmap] = None
-        # Zoom factor for the world->screen affine (#636). 1.0 == no scaling yet.
-        self._scale_factor: float = 1.0
+
+        # Camera for the QGIS-style unbounded canvas (#636). The view frames the
+        # mosaic extent once, the first time a grid is available (see paintEvent);
+        # after that the user drives it via pan/zoom and it is never auto-refit.
+        self._transform = MosaicViewTransform()
+        self._has_fitted = False
+
+        # Vector-overlay geometry cache (#636), all in world coordinates. Rebuilt
+        # only when scenes / z-order / target CRS change (invalidate_overlay), never
+        # on pan/zoom. _footprint_paths and _hidden_paths are parallel, bottom-to-top.
+        self._geometry_dirty = True
+        self._bbox_extent: Optional[Tuple[float, float, float, float]] = None
+        self._footprint_paths: List[QPainterPath] = []
+        self._hidden_paths: List[Optional[QPainterPath]] = []
+
+        # Middle-button drag-to-pan state (anchor pixel of the last move, or None).
+        self._pan_anchor: Optional[QPointF] = None
 
     def get_controller(self) -> MosaicController:
         return self._controller
 
     def set_controller(self, controller: MosaicController) -> None:
         self._controller = controller
+        self.invalidate_overlay()
+
+    # -- overlay geometry cache (#636) ----------------------------------------
+
+    def invalidate_overlay(self) -> None:
+        """
+        Mark the vector-overlay geometry stale and schedule a repaint.
+
+        Called by :class:`~wiser.gui.mosaic_pane.MosaicPane` after any controller
+        mutation that changes what the overlay draws — a scene added/removed, a
+        visibility toggle, a z-order move, or a target-CRS change. Pan/zoom does
+        **not** call this: the cached world-space paths are unchanged, only the
+        world->screen transform differs, so a plain repaint suffices there.
+        """
+        self._geometry_dirty = True
         self.update()
+
+    def _rebuild_overlay_geometry(self) -> None:
+        """
+        Rebuild the world-space overlay paths from the controller.
+
+        Runs on the GUI thread from :meth:`paintEvent` when the cache is dirty (so
+        repeated invalidations before the next paint coalesce into one rebuild). The
+        body is fully guarded: any OGR/OSR failure clears the cache and logs, rather
+        than letting an exception escape a paint. Only fires on discrete edits, not
+        on pan/zoom, so the synchronous GDAL/OSR work here is not on the hot path.
+        """
+        self._bbox_extent = None
+        self._footprint_paths = []
+        self._hidden_paths = []
+        try:
+            grid = self._controller.get_common_grid()
+            self._bbox_extent = grid.extent  # may be None until the grid is built
+
+            footprints = self._controller.visible_scene_footprints_in_common_crs()
+            if not footprints:
+                return
+            hidden = compute_union_overlaps(footprints)
+            for i, (_scene, geom) in enumerate(footprints):
+                self._footprint_paths.append(_geometry_to_qpainterpath(geom))
+                overlap = hidden.get(i)
+                self._hidden_paths.append(_geometry_to_qpainterpath(overlap) if overlap is not None else None)
+        except Exception:  # noqa: BLE001 — never let a repaint raise
+            logger.exception("Failed to rebuild mosaic overlay geometry")
+            self._bbox_extent = None
+            self._footprint_paths = []
+            self._hidden_paths = []
+
+    # -- pan / zoom -----------------------------------------------------------
+
+    def wheelEvent(self, event: QWheelEvent) -> None:  # noqa: N802 (Qt override)
+        notches = event.angleDelta().y() / 120.0
+        if notches == 0.0:
+            return
+        factor = _WHEEL_ZOOM_STEP**notches
+        self._transform.zoom(factor, event.position(), self.size())
+        self.update()
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:  # noqa: N802 (Qt override)
+        if event.button() == Qt.MiddleButton:
+            self._pan_anchor = event.position()
+            event.accept()
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:  # noqa: N802 (Qt override)
+        if self._pan_anchor is not None:
+            pos = event.position()
+            delta = pos - self._pan_anchor
+            self._transform.pan(delta.x(), delta.y())
+            self._pan_anchor = pos
+            self.update()
+            event.accept()
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:  # noqa: N802 (Qt override)
+        if event.button() == Qt.MiddleButton and self._pan_anchor is not None:
+            self._pan_anchor = None
+            event.accept()
 
     def composite(self, layers: List[MosaicScene], order: List[int]) -> Optional[QImage]:
         """
@@ -146,8 +291,27 @@ class MosaicView(QWidget):
         return None
 
     def paintEvent(self, event: QPaintEvent) -> None:  # noqa: N802 (Qt override)
+        # Initial fit: frame the mosaic extent the first time a grid is available
+        # *and* the widget has a real size (done here rather than on grid-build so we
+        # never divide by a 0x0 not-yet-shown viewport). Later grid rebuilds do not
+        # refit, so a user's pan/zoom is never yanked out from under them.
+        #
+        # When the mosaic goes empty (all scenes removed) the fit is armed again, so
+        # the next scene re-frames the camera instead of leaving it parked on the
+        # extent of the now-removed scene (which would render the new scene's
+        # footprints off-screen).
+        grid = self._controller.get_common_grid()
+        if grid.extent is None:
+            self._has_fitted = False
+        elif not self._has_fitted and self.width() > 1 and self.height() > 1:
+            self._transform.fit_to_extent(grid.extent, self.size())
+            self._has_fitted = True
+
+        if self._geometry_dirty:
+            self._rebuild_overlay_geometry()
+            self._geometry_dirty = False
+
         with get_painter(self) as painter:
-            # Empty background for now; a real theme background lands with the layers.
             painter.fillRect(self.rect(), self.palette().window())
 
             # --- Layer 1: pixel layer (#637) -------------------------------------
@@ -155,5 +319,33 @@ class MosaicView(QWidget):
             # scaled by the world->screen affine.
 
             # --- Layer 2: vector overlay (#636) ----------------------------------
-            # TODO(#636): draw footprints, bounding box, and overlap highlight on top,
-            # using the world->screen affine derived from the controller's common grid.
+            painter.setRenderHint(QPainter.Antialiasing, True)
+            painter.setWorldTransform(self._transform.world_to_screen(self.size()))
+
+            # Bounding box: the union extent of all footprints in the common CRS.
+            if self._bbox_extent is not None:
+                min_x, min_y, max_x, max_y = self._bbox_extent
+                painter.setPen(_BBOX_PEN)
+                painter.setBrush(Qt.NoBrush)
+                painter.drawRect(QRectF(min_x, min_y, max_x - min_x, max_y - min_y))
+
+            # Overlap highlight: for each scene, clip to its hidden region (the part
+            # covered by anything above it in z-order) and fill + outline it in the
+            # highlight color. Union approach => one clip/draw per scene, not per pair.
+            for footprint_path, hidden_path in zip(self._footprint_paths, self._hidden_paths):
+                if hidden_path is None:
+                    continue
+                painter.save()
+                painter.setClipPath(hidden_path)
+                painter.fillPath(hidden_path, _OVERLAP_BRUSH)
+                painter.setPen(_OVERLAP_PEN)
+                painter.setBrush(Qt.NoBrush)
+                painter.drawPath(footprint_path)
+                painter.restore()
+
+            # All footprint outlines on top, normal color, so every boundary stays
+            # visible even where it passes through an overlap region.
+            painter.setPen(_FOOTPRINT_PEN)
+            painter.setBrush(Qt.NoBrush)
+            for footprint_path in self._footprint_paths:
+                painter.drawPath(footprint_path)

--- a/src/wiser/gui/mosaic_view.py
+++ b/src/wiser/gui/mosaic_view.py
@@ -16,7 +16,8 @@ Later issues fill in the two layers, both drawn through the seams stubbed here:
     drawn in world->screen coordinates on top of the pixel layer.
 """
 
-from typing import TYPE_CHECKING, List, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from PySide6.QtCore import *
 from PySide6.QtGui import *
@@ -29,6 +30,75 @@ from wiser.raster.mosaic_controller import MosaicController, MosaicScene
 
 if TYPE_CHECKING:
     from .mosaic_pane import MosaicPane
+
+
+@dataclass
+class MosaicViewTransform:
+    """
+    Camera for the QGIS-style unbounded mosaic canvas (#636).
+
+    The affine *itself* is just ``QTransform`` (6 floats), rebuilt fresh every paint.
+    The only state that must persist between paints is this camera: a world-space
+    center point plus a scale. There is no invented ``(0, 0)`` canvas origin — world
+    coordinates come from the common/target CRS (e.g. UTM metres, degrees) and screen
+    coordinates are Qt's usual widget space. The visible world rectangle is *derived*
+    from ``center + scale + viewport size`` at paint time and never stored (storing it
+    would distort the aspect ratio on resize).
+
+    Nothing clamps ``center_x`` / ``center_y``: pan the camera arbitrarily far from
+    every footprint and the canvas simply shows blank space, which is what makes it
+    "unbounded" (as opposed to :class:`~wiser.gui.rasterview.RasterView`'s
+    scroll-area-over-a-fixed-``QPixmap``, which is bounded by the pixmap's size).
+
+    ``world_to_screen`` / ``screen_to_world`` take the viewport size as an argument
+    rather than caching it, since ``QWidget`` already tracks its own size — this keeps
+    a single source of truth and dodges a stale second copy. Shared with the pixel
+    layer (#637), which is why #636 builds it.
+    """
+
+    center_x: float = 0.0  # world coordinates
+    center_y: float = 0.0
+    world_units_per_pixel: float = 1.0
+
+    def fit_to_extent(self, extent: Tuple[float, float, float, float], viewport_size: QSize) -> None:
+        """Center on and frame a world ``(min_x, min_y, max_x, max_y)`` extent."""
+        min_x, min_y, max_x, max_y = extent
+        self.center_x = (min_x + max_x) / 2.0
+        self.center_y = (min_y + max_y) / 2.0
+        self.world_units_per_pixel = max(
+            (max_x - min_x) / max(viewport_size.width(), 1),
+            (max_y - min_y) / max(viewport_size.height(), 1),
+            1e-12,  # never zero, even for a degenerate single-point extent
+        )
+
+    def pan(self, dx_pixels: float, dy_pixels: float) -> None:
+        """Shift the camera by a screen-pixel delta (screen y-down, world y-up)."""
+        self.center_x -= dx_pixels * self.world_units_per_pixel
+        self.center_y += dy_pixels * self.world_units_per_pixel
+
+    def zoom(self, factor: float, anchor_pixel: QPointF, viewport_size: QSize) -> None:
+        """Zoom by ``factor`` while keeping the world point under ``anchor_pixel`` fixed."""
+        before = self.screen_to_world(anchor_pixel, viewport_size)
+        self.world_units_per_pixel /= factor
+        after = self.screen_to_world(anchor_pixel, viewport_size)
+        self.center_x += before.x() - after.x()
+        self.center_y += before.y() - after.y()
+
+    def world_to_screen(self, viewport_size: QSize) -> QTransform:
+        """Build the world->screen affine for the current camera and viewport."""
+        s = 1.0 / self.world_units_per_pixel  # screen pixels per world unit
+        vw, vh = viewport_size.width(), viewport_size.height()
+        ox = self.center_x - (vw / 2.0) / s  # world x at the widget's left edge
+        oy = self.center_y + (vh / 2.0) / s  # world y at the widget's top edge
+        # m11=s, m22=-s => uniform scale with a y-flip (world y up, screen y down).
+        return QTransform(s, 0.0, 0.0, -s, -s * ox, s * oy)
+
+    def screen_to_world(self, pt: QPointF, viewport_size: QSize) -> QPointF:
+        """Map a screen point back to world coordinates (inverse of the affine)."""
+        inverted, ok = self.world_to_screen(viewport_size).inverted()
+        if not ok:
+            return QPointF(self.center_x, self.center_y)
+        return inverted.map(pt)
 
 
 class MosaicView(QWidget):

--- a/src/wiser/raster/mosaic_controller.py
+++ b/src/wiser/raster/mosaic_controller.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import enum
 import math
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from osgeo import gdal, ogr, osr
 
@@ -322,6 +322,34 @@ class MosaicController:
                 f"({_crs_display_name(target_srs)})."
             )
 
+    # -- geometry overlay (#636) ---------------------------------------------
+
+    def visible_scene_footprints_in_common_crs(
+        self,
+    ) -> List[Tuple[MosaicScene, ogr.Geometry]]:
+        """
+        Return ``(scene, footprint)`` for each visible scene, **bottom-to-top**, with
+        the footprint reprojected into the already-resolved target CRS.
+
+        This is the geometry the vector overlay (#636) draws: outlines, the union
+        bounding box, and — via :func:`compute_union_overlaps` — the overlap
+        highlight. Returns ``[]`` when no target CRS is resolved yet (mirrors
+        :meth:`build_common_grid`'s precondition), so the view treats a not-yet-built
+        mosaic the same as an empty one and draws nothing. Stays Qt-free; the view
+        converts these ``ogr.Geometry`` objects to ``QPainterPath`` itself.
+        """
+        target_wkt = self._target_crs_wkt
+        if target_wkt is None:
+            return []
+        target_srs = _srs_from_wkt(target_wkt)
+        result: List[Tuple[MosaicScene, ogr.Geometry]] = []
+        for scene in self._visible_scenes():
+            src_srs = scene.dataset.get_spatial_ref()
+            if src_srs is None or scene.footprint_wkt is None:
+                continue
+            result.append((scene, reprojected_footprint_geometry(scene, src_srs, target_srs)))
+        return result
+
     # -- common grid ----------------------------------------------------------
 
     def build_common_grid(self) -> CommonGrid:
@@ -438,6 +466,30 @@ def _crs_display_name(srs: Optional[osr.SpatialReference]) -> str:
     return srs.ExportToWkt()
 
 
+def reprojected_footprint_geometry(
+    scene: "MosaicScene",
+    src_srs: osr.SpatialReference,
+    target_srs: osr.SpatialReference,
+) -> ogr.Geometry:
+    """
+    Return the scene's footprint polygon transformed **whole** into ``target_srs``.
+
+    The footprint is the valid-pixel outline (WKT in the scene's own CRS, from
+    #634). This parses a fresh geometry each call and reprojects it in place — the
+    caller owns the returned object. The transform is skipped when the source and
+    target CRS are the same. Both the geometry overlay (#636) and the grid builder's
+    :func:`_footprint_envelope` share this so the reprojection is defined once.
+    """
+    geom = ogr.CreateGeometryFromWkt(scene.footprint_wkt)
+    if geom is None:
+        raise ValueError(f"scene footprint WKT could not be parsed: {scene.footprint_wkt!r}")
+    if not src_srs.IsSame(target_srs):
+        src = src_srs.Clone()
+        src.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        geom.Transform(osr.CoordinateTransformation(src, target_srs))
+    return geom
+
+
 def _footprint_envelope(
     scene: "MosaicScene",
     src_srs: osr.SpatialReference,
@@ -448,15 +500,39 @@ def _footprint_envelope(
     the target CRS. The footprint polygon (valid-pixel outline in the scene's own
     CRS) is reprojected as a whole so the envelope faithfully bounds it.
     """
-    geom = ogr.CreateGeometryFromWkt(scene.footprint_wkt)
-    if geom is None:
-        raise ValueError(f"scene footprint WKT could not be parsed: {scene.footprint_wkt!r}")
-    if not src_srs.IsSame(target_srs):
-        src = src_srs.Clone()
-        src.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
-        geom.Transform(osr.CoordinateTransformation(src, target_srs))
+    geom = reprojected_footprint_geometry(scene, src_srs, target_srs)
     min_x, max_x, min_y, max_y = geom.GetEnvelope()
     return min_x, min_y, max_x, max_y
+
+
+def compute_union_overlaps(
+    footprints: List[Tuple["MosaicScene", ogr.Geometry]],
+) -> Dict[int, ogr.Geometry]:
+    """
+    Compute each scene's **hidden region** — the part of its footprint covered by
+    any scene above it in z-order.
+
+    ``footprints`` is ``(scene, reprojected footprint)`` in **bottom-to-top** order
+    (the controller's convention). Walking top-to-bottom, a running union of every
+    footprint already visited *is* "everything above" the current scene, so each
+    scene needs exactly one :meth:`ogr.Geometry.Intersection` (gated by a cheap
+    :meth:`Intersects`) plus one :meth:`Union` — ``O(n)`` geometry ops overall, not
+    the ``O(n^2)`` of all-pairs. The topmost scene is never hidden.
+
+    Returns a dict keyed by **index into ``footprints``** (bottom-to-top), present
+    only for scenes with a non-empty hidden region, so the caller can pair each
+    result with parallel per-scene path lists.
+    """
+    hidden: Dict[int, ogr.Geometry] = {}
+    union_above: Optional[ogr.Geometry] = None
+    for i in reversed(range(len(footprints))):  # topmost first
+        footprint = footprints[i][1]
+        if union_above is not None and footprint.Intersects(union_above):
+            overlap = footprint.Intersection(union_above)
+            if overlap is not None and not overlap.IsEmpty():
+                hidden[i] = overlap
+        union_above = footprint.Clone() if union_above is None else union_above.Union(footprint)
+    return hidden
 
 
 def _warped_resolution(scene: "MosaicScene", target_wkt: str) -> Tuple[float, float]:


### PR DESCRIPTION
## What does this change do?
Adds the first part of the rendering pipeline to the mosaic view. Currently it just renders foot prints and has a camera model for 

Closes #636

## What type of PR is this? (check all applicable) 
- [X] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [X] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
We need a rendering pipeline for the mosaic view.

## Added tests?
- [X] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [X] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed
