### PR TITLE
feat(mosaic): Adding scene compositor and cache

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -52,6 +52,7 @@ SRS/geotransform/nodata/band metadata from the dataset object, not from its `_im
 | `src/wiser/gui/mosaic_crs_dialog.py` | `ReprojectPromptDialog` — modal target-CRS chooser |
 | `src/wiser/raster/mosaic_controller.py` | `MosaicController`, `MosaicScene`, `CommonGrid`, `ResolutionMode` — the non-GUI model |
 | `src/wiser/raster/mosaic_ingestion.py` | `validate_scene`, `build_overviews`, `compute_footprint_wkt` — Qt-free ingestion gates |
+| `src/wiser/raster/mosaic_compositor.py` | `render_scene_argb` — Qt-free per-scene warp→RGBA renderer (alpha = validity) for the pixel layer |
 | `src/wiser/raster/mosaic_materialize.py` | `SceneMaterializer`, `materialize_to_tiled_geotiff` — the object-model adapter |
 | `src/wiser/utils/progress.py` | `ProgressReporter` — Qt-free progress plumbing shared with any scheduler task |
 | `src/wiser/gui/progress_task.py` | `run_with_progress` — reusable modal + Activity Monitor bridge for scheduler tasks |
@@ -561,12 +562,14 @@ selected.
 Overlay](#the-geometry-overlay-vector-layer)); the pixel layer beneath it is still a
 stubbed seam with a `TODO` marker, alongside the control-panel and export gaps:
 
-- **Pixel layer (compositing, issue #637)** — `MosaicView.composite(layers, order)` is
-  a stub that returns `None`. The design calls for per-scene ARGB `QImage` caches at
-  screen resolution (alpha = validity, from the GDAL mask band), stacked bottom-to-top
-  by `QPainter` and drawn beneath the vector overlay via the same
-  `MosaicViewTransform` camera; z-order reorders would only re-stack cached layers (no
-  GDAL reads), while pan/zoom would re-read from overviews (debounced).
+- **Pixel layer (compositing, issue #637)** — *in progress.* The Qt-free per-scene
+  renderer exists (`mosaic_compositor.render_scene_argb`: warps a scene onto the visible
+  world window at screen resolution via `gdal.Warp(dstAlpha=True)`, reading from the
+  internal overviews, and returns an RGBA array whose alpha is the validity mask). Still
+  to come: wiring it into `MosaicView` — the per-scene `QImage` cache, the `composite()`
+  stack, drawing beneath the vector overlay via the `MosaicViewTransform` camera, and the
+  off-thread/debounced re-read on pan/zoom. `MosaicView.composite(...)` is still a stub
+  that returns `None`.
 - **Control panel additions (issue #638)** — drag-to-reorder z-order, resampling
   method selector, and a band-metadata chooser are not yet in `MosaicPane`; today's
   panel only has Add Scene, the scene list (visibility toggle + remove), and the

--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -6,10 +6,11 @@ intended for developers reading, debugging, or extending the tool.
 
 ```{note}
 This is an in-progress feature (EPIC #629). As of this writing, scene ingestion,
-materialization, common-grid/CRS resolution, and the **vector overlay** (footprints,
-bounding box, overlap highlight) are implemented and wired into the GUI. **Pixel
-compositing (the preview) is not yet implemented** — see [What Isn't Built
-Yet](#what-isnt-built-yet).
+materialization, common-grid/CRS resolution, the **vector overlay** (footprints,
+bounding box, overlap highlight), and the **static-scene pixel compositor** (the
+composited preview, with an off-thread debounced per-scene cache) are implemented and
+wired into the GUI. The remaining gaps are the richer control panel and export — see
+[What Isn't Built Yet](#what-isnt-built-yet).
 ```
 
 For the design rationale and full child-issue breakdown, see `EPIC_seamless_mosaic.md`
@@ -32,10 +33,11 @@ The feature is built from three cooperating layers:
 
 - **The rendering layer** — `MosaicView` is a `QWidget` sibling of `RasterView`
   (not a subclass — a mosaic is N scenes on one shared world grid, not one dataset
-  zoomed). It draws the **vector overlay** (footprints, bounding box, overlap
-  highlight) on a QGIS-style unbounded canvas via a world→screen camera
-  (`MosaicViewTransform`); the pixel-compositing layer beneath it is still a stubbed
-  seam (#637). See [The Geometry Overlay](#the-geometry-overlay-vector-layer).
+  zoomed). It draws two layers on a QGIS-style unbounded canvas via a world→screen
+  camera (`MosaicViewTransform`): the **pixel layer** (the composited scenes, from a
+  per-scene ARGB cache — see [The Pixel Layer](#the-pixel-layer-static-scene-compositor))
+  and, on top, the **vector overlay** (footprints, bounding box, overlap highlight — see
+  [The Geometry Overlay](#the-geometry-overlay-vector-layer)).
 
 Every scene, regardless of its original backing (GDAL file, NumPy array, PDR, etc.),
 is first turned into a warpable, disk-backed tiled GeoTIFF by a `SceneMaterializer` —
@@ -97,11 +99,15 @@ classDiagram
         mosaic_view.py
         -_controller : MosaicController
         -_composite_pixmap : QPixmap
+        -_scene_layers : Dict~int, QImage~
+        -_render_signature : tuple
         -_transform : MosaicViewTransform
         -_footprint_paths : List~QPainterPath~
         -_hidden_paths : List~QPainterPath~
         +invalidate_overlay()
-        +composite(layers, order) QImage
+        +invalidate_pixels()
+        +recomposite_only()
+        +composite(layers) QImage
         +paintEvent(event)
     }
 
@@ -420,6 +426,81 @@ convention used throughout WISER (see the georeferencer's identical convention i
 
 ---
 
+## The Pixel Layer (Static-Scene Compositor)
+
+**Files:** `src/wiser/raster/mosaic_compositor.py` (Qt-free per-scene renderer) and
+`src/wiser/gui/mosaic_view.py` (cache, compositing, drawing, threading).
+
+Beneath the vector overlay, `MosaicView` draws the actual composited scenes (issue
+#637): each visible scene is read at **screen resolution** into an **ARGB `QImage`**
+whose alpha is its validity mask, and the scenes are stacked bottom-to-top honoring
+z-order so lower scenes show through upper scenes' nodata holes.
+
+### The per-scene renderer (`render_scene_argb`, Qt-free)
+
+`mosaic_compositor.render_scene_argb(scene, target_wkt, world_extent, w, h)` warps one
+scene onto the current viewport rectangle at output size `w×h` via
+`gdal.Warp(..., dstSRS=target_wkt, outputBounds=world_extent, dstAlpha=True)` and returns
+an `(h, w, 4)` uint8 RGBA array. A single `gdal.Warp` does four jobs at once:
+
+- **reprojection** onto the target CRS,
+- **downsampling** — because the output is far coarser than the source, GDAL reads from
+  the internal **overviews** built in #634 (the whole point of building them),
+- **alignment** to the visible world rectangle, and
+- **the validity mask** — `dstAlpha=True` yields an alpha band that is `0` on nodata /
+  outside-coverage pixels, so the alpha channel *is* the validity mask (no manual
+  mask-band read). This mirrors the warp seam already used by `_warped_resolution`.
+
+RGB comes from the dataset's `get_default_display_bands()` (1 band → grayscale, 3 →
+RGB), contrast-stretched per band over the valid pixels (2–98 percentile). Invalid
+pixels are forced fully clear `(0,0,0,0)` so nothing bleeds under a transparent alpha.
+It is Qt-free (produces a NumPy array) so it is unit-testable without a running app and
+can run on a background thread; the view wraps the array into a `QImage` on the GUI
+thread.
+
+### The per-scene cache and `composite()`
+
+`MosaicView` holds one ARGB `QImage` per visible scene in `_scene_layers` (keyed by
+`id(scene)`), built for the **current viewport** — the *render signature*
+`(center_x, center_y, world_units_per_pixel, width, height)`. `composite(layers)` stacks
+those layers bottom-to-top with `QPainter` `SourceOver` into a single image; `layers` is
+already in render order (index 0 = bottom), so z-order is encoded in the list and hidden
+scenes are simply `None`. `composite()` is the **single indirection point** where
+deferred seamline/feathering work will later re-implement the stacking (by territory
+mask) without touching callers.
+
+This split gives the caching tiers the design calls for:
+
+- **Z-order reorder / visibility toggle** (`recomposite_only()`) — a pure restack of the
+  cached layers, **no GDAL reads**. Hiding a scene just drops it from the composite (its
+  `visible` flag), and unhiding at the same viewport reuses its still-cached layer.
+  `recomposite_only()` falls back to a read only when *revealing* a scene that was hidden
+  at the last read (so it was never cached at this viewport).
+- **Pan / zoom** — changes the render signature, so every layer is re-read. This is the
+  cache's deliberate trade-off: it does **not** survive pan/zoom (the composite is
+  re-read), but it makes reorder/visibility at a fixed viewport free.
+- **Add / remove scene, target-CRS change** (`invalidate_pixels()`) — marks the cache
+  stale so the next paint re-reads.
+
+### Off-thread, debounced reads
+
+Reads run **off the UI thread** and pan/zoom re-reads are **debounced** so the view stays
+responsive. A `paintEvent` whose render signature changed (re)starts a single-shot
+`QTimer` (`_PIXEL_READ_DEBOUNCE_MS`, ~120 ms); a gesture's burst of paints collapses into
+one read once the camera settles. On fire, `_start_pixel_read` snapshots the viewport on
+the GUI thread (resolving footprints and the in-view intersect test — cheap OSR work),
+then hands only the heavy per-scene warps to `app_services.scheduler.submit_thread`. The
+worker returns NumPy arrays (no Qt off-thread); the future's done-callback emits the
+`_read_ready` signal, whose queued connection wraps them into `QImage`s and restacks on
+the GUI thread. `_reading_signature` tracks the in-flight read so a superseded (or
+out-of-order) result is discarded and never clobbers newer pixels. In the interim the
+prior composite keeps drawing, scaled by the camera (it is drawn mapped from its own
+`_composite_world_extent` through the world→screen affine), so pan/zoom shows a scaled
+preview until the sharp re-read lands. With no scheduler (e.g. a bare view in a unit
+test) the read falls back to synchronous.
+
+---
+
 ## The Geometry Overlay (Vector Layer)
 
 **Files:** `src/wiser/gui/mosaic_view.py` (rendering) and the Qt-free geometry helpers
@@ -442,9 +523,12 @@ flowchart TD
     E --> F
     F -->|yes| G["_rebuild_overlay_geometry()<br/>geometry_dirty = False"]
     F -->|no, cache is fresh| H
-    G --> H["painter.setWorldTransform(world_to_screen)"]
-    H --> I["draw pixel layer (stub, #637)"]
-    I --> J["draw bounding box (_bbox_extent)"]
+    G --> P{"render signature<br/>changed / pixels dirty?"}
+    P -->|yes| Q["_schedule_pixel_read()<br/>(debounced, off-thread)"]
+    P -->|no| H
+    Q --> H["draw pixel layer:<br/>_composite_pixmap mapped by world_to_screen"]
+    H --> H2["painter.setWorldTransform(world_to_screen)"]
+    H2 --> J["draw bounding box (_bbox_extent)"]
     J --> K["per scene: clip to hidden_path (if any),<br/>fill + outline in the highlight color"]
     K --> L["draw all footprint outlines on top"]
 ```
@@ -558,18 +642,11 @@ selected.
 
 ## What Isn't Built Yet
 
-`MosaicView.paintEvent` now draws the vector overlay (#636, see [The Geometry
-Overlay](#the-geometry-overlay-vector-layer)); the pixel layer beneath it is still a
-stubbed seam with a `TODO` marker, alongside the control-panel and export gaps:
+`MosaicView.paintEvent` now draws both layers — the pixel compositor (#637, see [The
+Pixel Layer](#the-pixel-layer-static-scene-compositor)) beneath the vector overlay (#636,
+see [The Geometry Overlay](#the-geometry-overlay-vector-layer)). The remaining gaps are
+the richer control panel and export:
 
-- **Pixel layer (compositing, issue #637)** — *in progress.* The Qt-free per-scene
-  renderer exists (`mosaic_compositor.render_scene_argb`: warps a scene onto the visible
-  world window at screen resolution via `gdal.Warp(dstAlpha=True)`, reading from the
-  internal overviews, and returns an RGBA array whose alpha is the validity mask). Still
-  to come: wiring it into `MosaicView` — the per-scene `QImage` cache, the `composite()`
-  stack, drawing beneath the vector overlay via the `MosaicViewTransform` camera, and the
-  off-thread/debounced re-read on pan/zoom. `MosaicView.composite(...)` is still a stub
-  that returns `None`.
 - **Control panel additions (issue #638)** — drag-to-reorder z-order, resampling
   method selector, and a band-metadata chooser are not yet in `MosaicPane`; today's
   panel only has Add Scene, the scene list (visibility toggle + remove), and the
@@ -605,9 +682,15 @@ consume the same `MosaicController` state once implemented.
 - `src/tests/test_mosaic_view_transform.py` — `MosaicViewTransform` camera math:
   world↔screen round-trip, y-flip orientation, zoom-anchor invariance, aspect-ratio
   preservation (pure `QTransform` math, no widget shown).
-- `src/tests/test_mosaic_view_gui.py` — the overlay wiring end to end: geometry cache
-  populates for overlapping scenes and re-invalidates on scene removal / target-CRS
-  change, driven through the real `MosaicPane` ingestion path.
+- `src/tests/test_mosaic_compositor.py` — the Qt-free `render_scene_argb`: alpha is 0
+  exactly on the nodata collar and 255 on the valid interior, RGBA shape/dtype, valid
+  pixels get color, a disjoint viewport comes back fully transparent (no Qt).
+- `src/tests/test_mosaic_view_gui.py` — the overlay **and** pixel-layer wiring end to
+  end, driven through the real `MosaicPane` ingestion path: geometry cache populates /
+  re-invalidates; `composite()` stacks known ARGB layers (top opaque wins, holes reveal
+  below); the per-scene cache populates; z-order reorder / visibility toggle trigger **no
+  GDAL reads** (spy on `render_scene_argb`); and a pan burst **coalesces into a single
+  debounced background read**.
 - `src/tests/test_mosaic_ingestion.py` — `validate_scene`, `build_overviews`,
   `compute_footprint_wkt`, and progress-reporting behavior.
 - `src/tests/test_mosaic_crs_dialog.py` — `ReprojectPromptDialog` in isolation

--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -430,6 +430,30 @@ outline (green), the union bounding box (dashed), and the **overlap highlight**
 matches the ENVI reference and is used **purely for on-screen rendering** — it never
 decides which pixel wins (that is z-order in the compositor/export, #637/#639).
 
+```{mermaid}
+flowchart TD
+    A[paintEvent] --> B{grid.extent is None?}
+    B -->|yes, mosaic empty| C["_has_fitted = False<br/>(re-arm the initial fit)"]
+    B -->|no| D{"not _has_fitted and<br/>viewport has real size?"}
+    D -->|yes| E["transform.fit_to_extent(grid.extent)<br/>_has_fitted = True"]
+    D -->|no, already fitted| F
+    C --> F{geometry_dirty?}
+    E --> F
+    F -->|yes| G["_rebuild_overlay_geometry()<br/>geometry_dirty = False"]
+    F -->|no, cache is fresh| H
+    G --> H["painter.setWorldTransform(world_to_screen)"]
+    H --> I["draw pixel layer (stub, #637)"]
+    I --> J["draw bounding box (_bbox_extent)"]
+    J --> K["per scene: clip to hidden_path (if any),<br/>fill + outline in the highlight color"]
+    K --> L["draw all footprint outlines on top"]
+```
+
+The `_has_fitted` re-arm on an empty grid matters in practice: without it, removing
+every scene and then adding a *different* one left the camera parked on the removed
+scene's extent, so the new scene's footprints rendered off-screen (fixed as a
+regression once observed — see the camera-reframe test in
+`test_mosaic_view_gui.py`).
+
 ### The camera: `MosaicViewTransform`
 
 The view is a **QGIS-style unbounded canvas**, not `RasterView`'s

--- a/src/tests/test_mosaic_compositor.py
+++ b/src/tests/test_mosaic_compositor.py
@@ -1,0 +1,146 @@
+"""
+Unit tests for the Qt-free per-scene renderer (:mod:`wiser.raster.mosaic_compositor`,
+issue #637).
+
+These are pure GDAL/NumPy tests -- no Qt, no ``QApplication`` -- exercising
+:func:`render_scene_argb` against small on-disk GeoTIFF fixtures with a nodata collar.
+The load-bearing assertion is that the returned alpha channel is the scene's validity
+mask: ``0`` exactly on nodata / outside-coverage pixels, ``255`` where the scene has
+real data.
+"""
+
+import os
+
+import numpy as np
+import pytest
+from osgeo import gdal, osr
+
+import tests.context  # noqa: F401  (adds src/ to sys.path)
+from wiser.raster.mosaic_compositor import render_scene_argb
+from wiser.raster.mosaic_controller import MosaicScene
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.unit,
+]
+
+_EPSG = 32611  # UTM 11N, metric CRS -> easy-to-reason extents
+_ORIGIN = (300000.0, 4000000.0)
+_PIXEL = 10.0
+_SIZE = 8
+_COLLAR = 2  # nodata border, in pixels
+_NODATA = -9999.0
+_FILL = 7.0
+
+
+class _DatasetStub:
+    """Minimal RasterDataSet stand-in exposing just what the renderer reads."""
+
+    def __init__(self, wkt, display_bands):
+        self._wkt = wkt
+        self._display_bands = display_bands
+
+    def get_spatial_ref(self):
+        srs = osr.SpatialReference()
+        srs.ImportFromWkt(self._wkt)
+        return srs
+
+    def get_default_display_bands(self):
+        return self._display_bands
+
+
+def _write_collar_tiff(path, num_bands=1):
+    """
+    Write a small GeoTIFF whose outer ``_COLLAR`` ring is nodata and whose interior
+    is a flat valid value. Returns the projection WKT.
+    """
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(_EPSG)
+    ds = gdal.GetDriverByName("GTiff").Create(
+        path,
+        _SIZE,
+        _SIZE,
+        num_bands,
+        gdal.GDT_Float32,
+        options=["TILED=YES", "BLOCKXSIZE=16", "BLOCKYSIZE=16"],
+    )
+    ox, oy = _ORIGIN
+    ds.SetGeoTransform([ox, _PIXEL, 0.0, oy, 0.0, -_PIXEL])
+    ds.SetProjection(srs.ExportToWkt())
+    arr = np.full((_SIZE, _SIZE), _FILL, dtype=np.float32)
+    arr[:_COLLAR, :] = _NODATA
+    arr[-_COLLAR:, :] = _NODATA
+    arr[:, :_COLLAR] = _NODATA
+    arr[:, -_COLLAR:] = _NODATA
+    for b in range(num_bands):
+        band = ds.GetRasterBand(b + 1)
+        band.WriteArray(arr)
+        band.SetNoDataValue(_NODATA)
+    ds.FlushCache()
+    ds = None
+    return srs.ExportToWkt()
+
+
+def _source_extent():
+    """(min_x, min_y, max_x, max_y) of the whole fixture raster in its own CRS."""
+    ox, oy = _ORIGIN
+    return (ox, oy - _PIXEL * _SIZE, ox + _PIXEL * _SIZE, oy)
+
+
+def _make_scene(tmp_path, display_bands=(0,), num_bands=1):
+    path = os.path.join(str(tmp_path), "scene.tif")
+    wkt = _write_collar_tiff(path, num_bands=num_bands)
+    scene = MosaicScene(dataset=_DatasetStub(wkt, display_bands), gdal_path=path)
+    return scene, wkt
+
+
+def _expected_valid_mask():
+    """True where the fixture has valid data (the interior, collar excluded)."""
+    mask = np.zeros((_SIZE, _SIZE), dtype=bool)
+    mask[_COLLAR:-_COLLAR, _COLLAR:-_COLLAR] = True
+    return mask
+
+
+def test_shape_and_dtype(tmp_path):
+    scene, wkt = _make_scene(tmp_path)
+    rgba = render_scene_argb(scene, wkt, _source_extent(), _SIZE, _SIZE)
+    assert rgba.shape == (_SIZE, _SIZE, 4)
+    assert rgba.dtype == np.uint8
+
+
+def test_alpha_is_validity_mask(tmp_path):
+    """Alpha is 0 exactly on the nodata collar and 255 on the valid interior."""
+    scene, wkt = _make_scene(tmp_path)
+    rgba = render_scene_argb(scene, wkt, _source_extent(), _SIZE, _SIZE)
+    alpha = rgba[:, :, 3]
+    valid = _expected_valid_mask()
+    assert np.all(alpha[valid] == 255)
+    assert np.all(alpha[~valid] == 0)
+
+
+def test_valid_pixels_have_color(tmp_path):
+    """Valid pixels render with non-transparent RGB; nodata pixels stay fully clear."""
+    scene, wkt = _make_scene(tmp_path)
+    rgba = render_scene_argb(scene, wkt, _source_extent(), _SIZE, _SIZE)
+    valid = _expected_valid_mask()
+    # Flat interior -> stretched to full white; nodata collar RGB stays 0.
+    assert np.all(rgba[valid, 0] == 255)
+    assert np.all(rgba[~valid, :3] == 0)
+
+
+def test_disjoint_window_is_fully_transparent(tmp_path):
+    """A viewport that does not overlap the scene comes back fully transparent."""
+    scene, wkt = _make_scene(tmp_path)
+    far = (900000.0, 3000000.0, 900100.0, 3000100.0)  # nowhere near the source
+    rgba = render_scene_argb(scene, wkt, far, _SIZE, _SIZE)
+    assert np.all(rgba[:, :, 3] == 0)
+
+
+def test_rgb_scene_uses_three_display_bands(tmp_path):
+    """A 3-band scene with RGB display bands fills all three channels on valid pixels."""
+    scene, wkt = _make_scene(tmp_path, display_bands=(0, 1, 2), num_bands=3)
+    rgba = render_scene_argb(scene, wkt, _source_extent(), _SIZE, _SIZE)
+    valid = _expected_valid_mask()
+    assert np.all(rgba[valid, 0] == 255)
+    assert np.all(rgba[valid, 1] == 255)
+    assert np.all(rgba[valid, 2] == 255)

--- a/src/tests/test_mosaic_view_gui.py
+++ b/src/tests/test_mosaic_view_gui.py
@@ -20,7 +20,7 @@ import numpy as np
 
 import tests.context  # noqa: F401  (adds src/ to sys.path)
 import wiser.gui.mosaic_view as mosaic_view
-from wiser.gui.mosaic_view import MosaicView
+from wiser.gui.mosaic_view import MosaicView, _PIXEL_READ_DEBOUNCE_MS
 from test_utils.test_model import WiserTestModel
 
 import pytest
@@ -254,9 +254,13 @@ class TestMosaicViewGui(unittest.TestCase):
             self._ingest(pane, controller, ds_a, 1)
             self._ingest(pane, controller, ds_b, 2)
 
-        view.grab()  # force a paint -> fit camera + read per-scene layers
-
-        self.assertEqual(len(view._scene_layers), 2)
+        # The read is off the UI thread and debounced, so force a paint to schedule it
+        # then pump the loop until the layers arrive.
+        view.grab()
+        self.assertTrue(
+            self._wait_for(lambda: len(view._scene_layers) == 2),
+            "per-scene layers were not read within the timeout",
+        )
         self.assertIsNotNone(view._composite_pixmap)
         self.assertIsNotNone(view._composite_world_extent)
 
@@ -278,29 +282,59 @@ class TestMosaicViewGui(unittest.TestCase):
 
         real_render = mosaic_view.render_scene_argb
         with mock.patch.object(mosaic_view, "render_scene_argb", side_effect=real_render) as spy:
-            view.grab()  # initial read populates the cache
+            # Initial debounced read populates the cache.
+            view.grab()
+            self.assertTrue(self._wait_for(lambda: len(view._scene_layers) == 2))
             self.assertGreater(spy.call_count, 0)
 
-            # Z-order reorder: pure restack, no GDAL reads.
-            spy.reset_mock()
-            controller.move_scene(0, 1)
-            view.recomposite_only()
-            view.grab()
-            self.assertEqual(spy.call_count, 0)
+            def _assert_no_read(mutate):
+                spy.reset_mock()
+                mutate()
+                view.recomposite_only()
+                view.grab()
+                QTest.qWait(2 * _PIXEL_READ_DEBOUNCE_MS)  # past the debounce window — nothing should read
+                self.assertEqual(spy.call_count, 0)
 
-            # Hiding a scene removes it from the composite without re-reading others.
-            spy.reset_mock()
-            controller.set_visibility(0, False)
-            view.recomposite_only()
-            view.grab()
-            self.assertEqual(spy.call_count, 0)
+            # Z-order reorder, hide, and unhide-still-cached are all pure restacks.
+            _assert_no_read(lambda: controller.move_scene(0, 1))
+            _assert_no_read(lambda: controller.set_visibility(0, False))
+            _assert_no_read(lambda: controller.set_visibility(0, True))
 
-            # Unhiding a still-cached scene is also read-free at the same viewport.
-            spy.reset_mock()
-            controller.set_visibility(0, True)
-            view.recomposite_only()
-            view.grab()
-            self.assertEqual(spy.call_count, 0)
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_pan_debounces_into_a_single_read(self):
+        ds_a = self._load("a.tif", origin=(400000.0, 3800000.0))
+        ds_b = self._load("b.tif", origin=(400300.0, 3799700.0))
+
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        view = pane.get_mosaic_view()
+        view.resize(800, 600)
+
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_a, 1)
+            self._ingest(pane, controller, ds_b, 2)
+
+        view.grab()
+        self.assertTrue(self._wait_for(lambda: len(view._scene_layers) == 2))
+
+        # A burst of pans must collapse into one background read, not one per event.
+        real_worker = mosaic_view._render_scene_layers
+        with mock.patch.object(mosaic_view, "_render_scene_layers", side_effect=real_worker) as worker_spy:
+            initial_extent = view._composite_world_extent
+            for _ in range(5):
+                view._transform.pan(40, 0)
+                view.grab()  # each paint restarts the debounce timer
+                QTest.qWait(_PIXEL_READ_DEBOUNCE_MS / 10)  # well under the debounce window
+            # Still mid-gesture: the debounce timer keeps restarting, so no read yet.
+            self.assertEqual(worker_spy.call_count, 0)
+
+            # Once the gesture settles, the composite updates to the panned viewport...
+            self.assertTrue(self._wait_for(lambda: view._composite_world_extent != initial_extent))
+            # ...via a single coalesced read, not one per pan event.
+            QTest.qWait(2 * _PIXEL_READ_DEBOUNCE_MS)
+            self.assertEqual(worker_spy.call_count, 1)
 
         self.test_model.close_seamless_mosaic_dialog()
 

--- a/src/tests/test_mosaic_view_gui.py
+++ b/src/tests/test_mosaic_view_gui.py
@@ -11,13 +11,16 @@ import unittest
 from unittest import mock
 
 from osgeo import gdal, osr
-from PySide6.QtCore import QPointF
+from PySide6.QtCore import QPointF, QRect, Qt
+from PySide6.QtGui import QColor, QImage, QPainter
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QDialog
 
 import numpy as np
 
 import tests.context  # noqa: F401  (adds src/ to sys.path)
+import wiser.gui.mosaic_view as mosaic_view
+from wiser.gui.mosaic_view import MosaicView
 from test_utils.test_model import WiserTestModel
 
 import pytest
@@ -209,6 +212,95 @@ class TestMosaicViewGui(unittest.TestCase):
         self.assertLessEqual(screen.x(), 800.0)
         self.assertGreaterEqual(screen.y(), 0.0)
         self.assertLessEqual(screen.y(), 600.0)
+
+        self.test_model.close_seamless_mosaic_dialog()
+
+    # -- pixel layer (#637) ---------------------------------------------------
+
+    def test_composite_stacks_bottom_to_top_with_alpha(self):
+        """composite() stacks known ARGB layers: top opaque wins, holes reveal below."""
+        view = MosaicView()  # QApplication exists (WiserTestModel); no controller needed
+        w = h = 4
+        bottom = QImage(w, h, QImage.Format_ARGB32)
+        bottom.fill(QColor(255, 0, 0, 255))  # opaque red
+        top = QImage(w, h, QImage.Format_ARGB32)
+        top.fill(Qt.transparent)
+        painter = QPainter(top)
+        painter.fillRect(QRect(0, 0, 2, h), QColor(0, 0, 255, 255))  # left half opaque blue
+        painter.end()
+
+        result = view.composite([bottom, top])  # bottom-to-top
+        self.assertIsNotNone(result)
+        # Left: top (blue) is opaque, so it wins.
+        self.assertEqual(result.pixelColor(0, 0), QColor(0, 0, 255, 255))
+        # Right: top is a transparent hole, so the bottom (red) shows through.
+        self.assertEqual(result.pixelColor(3, 0), QColor(255, 0, 0, 255))
+
+        # Nothing drawable -> None (hidden scenes contribute None entries).
+        self.assertIsNone(view.composite([None, None]))
+        self.assertIsNone(view.composite([]))
+
+    def test_scene_layers_populate_and_composite(self):
+        ds_a = self._load("a.tif", origin=(400000.0, 3800000.0))
+        ds_b = self._load("b.tif", origin=(400300.0, 3799700.0))
+
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        view = pane.get_mosaic_view()
+        view.resize(800, 600)
+
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_a, 1)
+            self._ingest(pane, controller, ds_b, 2)
+
+        view.grab()  # force a paint -> fit camera + read per-scene layers
+
+        self.assertEqual(len(view._scene_layers), 2)
+        self.assertIsNotNone(view._composite_pixmap)
+        self.assertIsNotNone(view._composite_world_extent)
+
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_reorder_and_visibility_trigger_no_reads(self):
+        ds_a = self._load("a.tif", origin=(400000.0, 3800000.0))
+        ds_b = self._load("b.tif", origin=(400300.0, 3799700.0))
+
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        view = pane.get_mosaic_view()
+        view.resize(800, 600)
+
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_a, 1)
+            self._ingest(pane, controller, ds_b, 2)
+
+        real_render = mosaic_view.render_scene_argb
+        with mock.patch.object(mosaic_view, "render_scene_argb", side_effect=real_render) as spy:
+            view.grab()  # initial read populates the cache
+            self.assertGreater(spy.call_count, 0)
+
+            # Z-order reorder: pure restack, no GDAL reads.
+            spy.reset_mock()
+            controller.move_scene(0, 1)
+            view.recomposite_only()
+            view.grab()
+            self.assertEqual(spy.call_count, 0)
+
+            # Hiding a scene removes it from the composite without re-reading others.
+            spy.reset_mock()
+            controller.set_visibility(0, False)
+            view.recomposite_only()
+            view.grab()
+            self.assertEqual(spy.call_count, 0)
+
+            # Unhiding a still-cached scene is also read-free at the same viewport.
+            spy.reset_mock()
+            controller.set_visibility(0, True)
+            view.recomposite_only()
+            view.grab()
+            self.assertEqual(spy.call_count, 0)
 
         self.test_model.close_seamless_mosaic_dialog()
 

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -116,6 +116,7 @@ class MosaicPane(QWidget):
             app_state=self._app_state,
             controller=self._controller,
             mosaicpane=self,
+            app_services=self._app_services,
         )
         self._splitter.addWidget(self._mosaic_view)
 

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -265,6 +265,7 @@ class MosaicPane(QWidget):
             return
         self._refresh_scene_list()
         self._mosaic_view.invalidate_overlay()
+        self._mosaic_view.invalidate_pixels()
 
     def _on_scene_failed(self, message: str) -> None:
         QMessageBox.critical(self, self.tr("Add scene failed"), message)
@@ -309,6 +310,9 @@ class MosaicPane(QWidget):
         self._controller.set_visibility(index, item.checkState() == Qt.Checked)
         self._rebuild_grid_quietly()
         self._mosaic_view.invalidate_overlay()
+        # Visibility is a restack at the same viewport — no GDAL reads (recompose only
+        # falls back to a read if a revealed scene was never cached at this viewport).
+        self._mosaic_view.recomposite_only()
 
     def _on_remove_scene_clicked(self) -> None:
         index = self._selected_scene_index()
@@ -320,6 +324,7 @@ class MosaicPane(QWidget):
         # popping the reproject dialog.
         self._rebuild_grid_quietly()
         self._mosaic_view.invalidate_overlay()
+        self._mosaic_view.invalidate_pixels()
 
     # -- common grid / target CRS ---------------------------------------------
 
@@ -364,6 +369,7 @@ class MosaicPane(QWidget):
             QMessageBox.warning(self, self.tr("Cannot reproject"), str(exc))
         self._refresh_target_crs_label()
         self._mosaic_view.invalidate_overlay()
+        self._mosaic_view.invalidate_pixels()
 
     def _prompt_for_target_crs(self) -> bool:
         """

--- a/src/wiser/gui/mosaic_view.py
+++ b/src/wiser/gui/mosaic_view.py
@@ -33,13 +33,41 @@ from .util import get_painter
 from wiser.raster.mosaic_compositor import render_scene_argb
 from wiser.raster.mosaic_controller import (
     MosaicController,
+    MosaicScene,
     compute_union_overlaps,
 )
+from wiser.utils.primitives import PriorityClass
 
 if TYPE_CHECKING:
+    from .app_services import AppServices
     from .mosaic_pane import MosaicPane
 
 logger = logging.getLogger(__name__)
+
+# Debounce window for pan/zoom pixel re-reads: coalesce a gesture's burst of paints
+# into one background read once the camera settles for this long.
+_PIXEL_READ_DEBOUNCE_MS = 120
+
+
+def _render_scene_layers(
+    jobs: List[Tuple[int, MosaicScene, str, Tuple[float, float, float, float], int, int]],
+) -> List[Tuple[int, np.ndarray]]:
+    """
+    Warp each job's scene into an RGBA array. Runs on a **scheduler thread** (no Qt).
+
+    ``jobs`` is ``(scene_key, scene, target_wkt, world_extent, width, height)``; the
+    result pairs each key with its ``(H, W, 4)`` RGBA array for the GUI thread to wrap
+    into a ``QImage``. A single scene that fails to render is skipped rather than
+    failing the whole batch (mirrors the per-scene guard in the synchronous path).
+    """
+    out: List[Tuple[int, np.ndarray]] = []
+    for key, scene, target_wkt, world_extent, width, height in jobs:
+        try:
+            out.append((key, render_scene_argb(scene, target_wkt, world_extent, width, height)))
+        except Exception:  # noqa: BLE001 — a bad scene must not break the batch
+            pass
+    return out
+
 
 # Vector-overlay styling (#636), matching the ENVI reference: green footprint
 # outlines, a dashed bounding box, and a magenta/purple overlap highlight. Pens are
@@ -166,17 +194,25 @@ class MosaicView(QWidget):
     common grid) and exposes the paint/compositing seams that #636 and #637 target.
     """
 
+    # Delivers a completed background pixel read from the scheduler thread to the GUI
+    # thread. Emitted from the future's done-callback (worker thread); the queued
+    # connection runs :meth:`_apply_pixel_read` on the GUI thread. Payload is
+    # ``(signature, world_extent, read_scene_ids, [(scene_key, rgba_ndarray), ...])``.
+    _read_ready = Signal(object)
+
     def __init__(
         self,
         parent: Optional[QWidget] = None,
         app_state: Optional[ApplicationState] = None,
         controller: Optional[MosaicController] = None,
         mosaicpane: Optional["MosaicPane"] = None,
+        app_services: Optional["AppServices"] = None,
     ) -> None:
         super().__init__(parent=parent)
         self._app_state = app_state
         self._controller = controller if controller is not None else MosaicController()
         self._mosaicpane = mosaicpane
+        self._app_services = app_services
 
         # Pixel layer (#637): the composited, screen-resolution mosaic image plus the
         # per-scene ARGB caches it is stacked from.
@@ -195,6 +231,19 @@ class MosaicView(QWidget):
         self._read_scene_ids: Set[int] = set()
         self._render_signature: Optional[Tuple[float, float, float, int, int]] = None
         self._pixels_dirty = True
+
+        # Off-thread + debounced pixel reads (#637). Pan/zoom paints coalesce into one
+        # background read once the camera settles for _PIXEL_READ_DEBOUNCE_MS. Reads are
+        # submitted to the scheduler (when available); the prior composite is drawn,
+        # scaled by the camera, in the interim. _reading_signature is the viewport the
+        # in-flight read targets, so a superseded read's late result is discarded.
+        self._reading_signature: Optional[Tuple[float, float, float, int, int]] = None
+        self._pending_future = None
+        self._debounce_timer = QTimer(self)
+        self._debounce_timer.setSingleShot(True)
+        self._debounce_timer.setInterval(_PIXEL_READ_DEBOUNCE_MS)
+        self._debounce_timer.timeout.connect(self._start_pixel_read)
+        self._read_ready.connect(self._apply_pixel_read)
 
         # Camera for the QGIS-style unbounded canvas (#636). The view frames the
         # mosaic extent once, the first time a grid is available (see paintEvent);
@@ -330,42 +379,101 @@ class MosaicView(QWidget):
         argb = np.ascontiguousarray((a << 24) | (r << 16) | (g << 8) | b, dtype=np.uint32)
         return QImage(argb.data, w, h, QImage.Format_ARGB32).copy()
 
-    def _rebuild_scene_layers(self) -> None:
-        """
-        Re-read every visible, in-view scene into the per-scene ARGB cache at the
-        current viewport. This is the **only** path that touches GDAL.
+    def _current_signature(self) -> Tuple[float, float, float, int, int]:
+        """The render signature (viewport identity) the pixel cache is keyed on."""
+        return (
+            self._transform.center_x,
+            self._transform.center_y,
+            self._transform.world_units_per_pixel,
+            self.width(),
+            self.height(),
+        )
 
-        The cache is rebuilt wholesale (stale layers, including hidden scenes' layers
-        from a prior viewport, are dropped) so it always corresponds to the current
-        render signature. Off-thread/debounced execution is layered on in #637 step 3;
-        here it runs synchronously from :meth:`paintEvent`.
+    def _schedule_pixel_read(self) -> None:
         """
-        self._scene_layers = {}
-        self._read_scene_ids = set()
-        self._composite_world_extent = None
+        Ask for a fresh per-scene read of the current viewport.
 
+        With a scheduler, this (re)starts the debounce timer so a pan/zoom gesture's
+        burst of paints collapses into a single background read once the camera
+        settles. Without one (e.g. a bare view in a unit test), it reads synchronously
+        so behavior is still correct, just on the GUI thread.
+        """
+        if self._app_services is None:
+            self._start_pixel_read()
+        else:
+            self._debounce_timer.start()
+
+    def _start_pixel_read(self) -> None:
+        """
+        Snapshot the current viewport on the GUI thread, then read its scenes.
+
+        The cheap, Qt-adjacent work (resolving the target CRS, reprojecting footprints,
+        the in-view intersect test) happens here; only the heavy per-scene warps are
+        handed to the worker. With no scheduler the worker runs inline.
+        """
+        signature = self._current_signature()
         target_wkt = self._controller.get_target_crs()
         w, h = self.width(), self.height()
         if target_wkt is None or w <= 1 or h <= 1:
+            # Nothing to read; clear the cache and mark this viewport as done so we
+            # don't reschedule every paint.
+            self._apply_pixel_read((signature, None, set(), []))
+            self._reading_signature = signature
             return
 
         world_extent = self._visible_world_extent()
-        self._composite_world_extent = world_extent
         try:
             footprints = self._controller.visible_scene_footprints_in_common_crs()
-        except Exception:  # noqa: BLE001 — never let a repaint raise
+        except Exception:  # noqa: BLE001 — never let a paint-driven read raise
             logger.exception("Failed to resolve mosaic scene footprints")
+            footprints = []
+
+        read_scene_ids: Set[int] = set()
+        jobs: List[Tuple[int, MosaicScene, str, Tuple[float, float, float, float], int, int]] = []
+        for scene, geom in footprints:
+            read_scene_ids.add(id(scene))
+            if self._envelope_intersects(geom, world_extent):
+                jobs.append((id(scene), scene, target_wkt, world_extent, w, h))
+
+        self._reading_signature = signature
+        if self._app_services is None:
+            self._apply_pixel_read((signature, world_extent, read_scene_ids, _render_scene_layers(jobs)))
             return
 
-        for scene, geom in footprints:
-            self._read_scene_ids.add(id(scene))
-            if not self._envelope_intersects(geom, world_extent):
-                continue
+        def _done(future, signature=signature, world_extent=world_extent, read_scene_ids=read_scene_ids):
+            # Runs on the scheduler thread; hop back to the GUI thread via the signal.
             try:
-                rgba = render_scene_argb(scene, target_wkt, world_extent, w, h)
-                self._scene_layers[id(scene)] = self._numpy_to_argb_qimage(rgba)
-            except Exception:  # noqa: BLE001 — a bad scene must not break the paint
-                logger.exception("Failed to render mosaic scene layer")
+                results = future.result()
+            except Exception:  # noqa: BLE001 — surface nothing rather than crash a worker
+                logger.exception("Mosaic pixel read failed")
+                results = []
+            self._read_ready.emit((signature, world_extent, read_scene_ids, results))
+
+        self._pending_future = self._app_services.scheduler.submit_thread(
+            PriorityClass.BACKGROUND, _render_scene_layers, jobs
+        )
+        self._pending_future.add_done_callback(_done)
+
+    def _apply_pixel_read(self, payload) -> None:
+        """
+        Install a completed read on the GUI thread, unless it has been superseded.
+
+        Only the most recently *submitted* read (``_reading_signature``) is applied;
+        an out-of-order or stale result for an older viewport is dropped so it can
+        never clobber newer pixels. Wrapping RGBA into ``QImage`` happens here (Qt
+        objects must be built on the GUI thread), then the layers are restacked.
+        """
+        signature, world_extent, read_scene_ids, results = payload
+        if signature != self._reading_signature:
+            return  # superseded by a newer read; discard
+        self._reading_signature = None
+        self._scene_layers = {key: self._numpy_to_argb_qimage(rgba) for key, rgba in results}
+        self._read_scene_ids = read_scene_ids
+        self._composite_world_extent = world_extent
+        self._render_signature = signature
+        self._pixels_dirty = False
+        self._recomposite()
+        self.update()
 
     def _recomposite(self) -> None:
         """
@@ -459,21 +567,15 @@ class MosaicView(QWidget):
             self._rebuild_overlay_geometry()
             self._geometry_dirty = False
 
-        # Pixel layer: re-read per-scene layers when the viewport (render signature)
-        # changed or the cache was explicitly invalidated, then restack. In step 3 the
-        # read becomes off-thread + debounced; here it is synchronous.
-        signature = (
-            self._transform.center_x,
-            self._transform.center_y,
-            self._transform.world_units_per_pixel,
-            self.width(),
-            self.height(),
-        )
-        if self._pixels_dirty or self._render_signature != signature:
-            self._rebuild_scene_layers()
-            self._recomposite()
-            self._render_signature = signature
-            self._pixels_dirty = False
+        # Pixel layer: when the viewport (render signature) changed or the cache was
+        # explicitly invalidated, schedule a debounced background re-read — unless a
+        # read for this exact viewport is already in flight (wait for it instead). The
+        # prior composite keeps drawing, scaled by the camera, in the interim.
+        signature = self._current_signature()
+        if (
+            self._pixels_dirty or self._render_signature != signature
+        ) and signature != self._reading_signature:
+            self._schedule_pixel_read()
 
         with get_painter(self) as painter:
             painter.fillRect(self.rect(), self.palette().window())

--- a/src/wiser/gui/mosaic_view.py
+++ b/src/wiser/gui/mosaic_view.py
@@ -18,8 +18,9 @@ Later issues fill in the two layers, both drawn through the seams stubbed here:
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
+import numpy as np
 from osgeo import ogr
 
 from PySide6.QtCore import *
@@ -29,9 +30,9 @@ from PySide6.QtWidgets import *
 from .app_state import ApplicationState
 from .util import get_painter
 
+from wiser.raster.mosaic_compositor import render_scene_argb
 from wiser.raster.mosaic_controller import (
     MosaicController,
-    MosaicScene,
     compute_union_overlaps,
 )
 
@@ -177,8 +178,23 @@ class MosaicView(QWidget):
         self._controller = controller if controller is not None else MosaicController()
         self._mosaicpane = mosaicpane
 
-        # Pixel layer (#637): the composited, screen-resolution mosaic image.
+        # Pixel layer (#637): the composited, screen-resolution mosaic image plus the
+        # per-scene ARGB caches it is stacked from.
+        #
+        # _scene_layers holds one ARGB QImage per visible scene (keyed by id(scene)) at
+        # the *current viewport* — the render signature below. Any pan/zoom changes the
+        # signature and re-reads every layer; the cache's payoff is that a z-order
+        # reorder or visibility toggle at a fixed viewport is a pure restack with no
+        # GDAL reads. _read_scene_ids records which scenes were visible at the last read
+        # so a restack can tell "legitimately not cached (non-intersecting)" from
+        # "was hidden, needs a read to reveal".
         self._composite_pixmap: Optional[QPixmap] = None
+        self._composite_world_extent: Optional[Tuple[float, float, float, float]] = None
+        # Below, int is the id() of a MosaicScene in the current viewport
+        self._scene_layers: Dict[int, QImage] = {}
+        self._read_scene_ids: Set[int] = set()
+        self._render_signature: Optional[Tuple[float, float, float, int, int]] = None
+        self._pixels_dirty = True
 
         # Camera for the QGIS-style unbounded canvas (#636). The view frames the
         # mosaic extent once, the first time a grid is available (see paintEvent);
@@ -250,6 +266,121 @@ class MosaicView(QWidget):
             self._footprint_paths = []
             self._hidden_paths = []
 
+    # -- pixel layer cache (#637) ---------------------------------------------
+
+    def invalidate_pixels(self) -> None:
+        """
+        Mark the per-scene pixel cache stale (a GDAL re-read is required) and repaint.
+
+        Called after a controller change that alters *which pixels* to read — a scene
+        added/removed or a target-CRS change. The rebuild runs lazily in
+        :meth:`paintEvent`. Distinct from :meth:`recomposite_only`, which restacks the
+        existing cache without any reads.
+        """
+        self._pixels_dirty = True
+        self.update()
+
+    def recomposite_only(self) -> None:
+        """
+        Restack the cached per-scene layers with **no GDAL reads** and repaint.
+
+        This is the fast path for a z-order reorder or a visibility toggle at a fixed
+        viewport: the cached layers are still valid, only their stacking order or
+        which ones are drawn changes. Falls back to :meth:`invalidate_pixels` when a
+        now-visible scene has no cached layer because it was hidden at the last read
+        (revealing it genuinely needs a read); a visible scene that is merely off-view
+        was still *considered* at the last read, so it stays on the no-read path.
+        """
+        visible_ids = {id(s) for s in self._controller.get_scenes() if s.visible}
+        if not visible_ids.issubset(self._read_scene_ids):
+            self.invalidate_pixels()
+            return
+        self._recomposite()
+        self.update()
+
+    def _visible_world_extent(self) -> Tuple[float, float, float, float]:
+        """The camera's visible rectangle as ``(min_x, min_y, max_x, max_y)`` in world."""
+        size = self.size()
+        tl = self._transform.screen_to_world(QPointF(0.0, 0.0), size)
+        br = self._transform.screen_to_world(QPointF(self.width(), self.height()), size)
+        # screen y-down => tl is the top (max world y), br the bottom (min world y).
+        return (tl.x(), br.y(), br.x(), tl.y())
+
+    @staticmethod
+    def _envelope_intersects(geom: ogr.Geometry, extent: Tuple[float, float, float, float]) -> bool:
+        """Cheap AABB test: does a footprint's envelope overlap the visible rect?"""
+        gmin_x, gmax_x, gmin_y, gmax_y = geom.GetEnvelope()
+        emin_x, emin_y, emax_x, emax_y = extent
+        return not (gmax_x < emin_x or gmin_x > emax_x or gmax_y < emin_y or gmin_y > emax_y)
+
+    def _numpy_to_argb_qimage(self, rgba: np.ndarray) -> QImage:
+        """
+        Wrap an ``(H, W, 4)`` uint8 RGBA array as a ``QImage.Format_ARGB32``.
+
+        ``Format_ARGB32`` packs each pixel as a native-endian ``0xAARRGGBB`` uint32,
+        so the channels are shifted into place (the alpha-aware analog of
+        ``rasterview.make_rgb_image``, which forces opaque alpha). ``.copy()`` detaches
+        the result from the transient NumPy buffer so it owns its own pixels.
+        """
+        h, w = rgba.shape[:2]
+        a = rgba[:, :, 3].astype(np.uint32)
+        r = rgba[:, :, 0].astype(np.uint32)
+        g = rgba[:, :, 1].astype(np.uint32)
+        b = rgba[:, :, 2].astype(np.uint32)
+        argb = np.ascontiguousarray((a << 24) | (r << 16) | (g << 8) | b, dtype=np.uint32)
+        return QImage(argb.data, w, h, QImage.Format_ARGB32).copy()
+
+    def _rebuild_scene_layers(self) -> None:
+        """
+        Re-read every visible, in-view scene into the per-scene ARGB cache at the
+        current viewport. This is the **only** path that touches GDAL.
+
+        The cache is rebuilt wholesale (stale layers, including hidden scenes' layers
+        from a prior viewport, are dropped) so it always corresponds to the current
+        render signature. Off-thread/debounced execution is layered on in #637 step 3;
+        here it runs synchronously from :meth:`paintEvent`.
+        """
+        self._scene_layers = {}
+        self._read_scene_ids = set()
+        self._composite_world_extent = None
+
+        target_wkt = self._controller.get_target_crs()
+        w, h = self.width(), self.height()
+        if target_wkt is None or w <= 1 or h <= 1:
+            return
+
+        world_extent = self._visible_world_extent()
+        self._composite_world_extent = world_extent
+        try:
+            footprints = self._controller.visible_scene_footprints_in_common_crs()
+        except Exception:  # noqa: BLE001 — never let a repaint raise
+            logger.exception("Failed to resolve mosaic scene footprints")
+            return
+
+        for scene, geom in footprints:
+            self._read_scene_ids.add(id(scene))
+            if not self._envelope_intersects(geom, world_extent):
+                continue
+            try:
+                rgba = render_scene_argb(scene, target_wkt, world_extent, w, h)
+                self._scene_layers[id(scene)] = self._numpy_to_argb_qimage(rgba)
+            except Exception:  # noqa: BLE001 — a bad scene must not break the paint
+                logger.exception("Failed to render mosaic scene layer")
+
+    def _recomposite(self) -> None:
+        """
+        Stack the cached per-scene layers bottom-to-top into ``_composite_pixmap``.
+
+        Walks the controller's bottom-to-top scene order and takes each visible
+        scene's cached layer (``None`` for hidden scenes or scenes with no cached
+        layer), so z-order and visibility are honored here purely from the cache — no
+        reads. ``_composite_world_extent`` is left as the last read set it.
+        """
+        scenes = self._controller.get_scenes()
+        layers = [self._scene_layers.get(id(s)) if s.visible else None for s in scenes]
+        result = self.composite(layers)
+        self._composite_pixmap = QPixmap.fromImage(result) if result is not None else None
+
     # -- pan / zoom -----------------------------------------------------------
 
     def wheelEvent(self, event: QWheelEvent) -> None:  # noqa: N802 (Qt override)
@@ -279,16 +410,33 @@ class MosaicView(QWidget):
             self._pan_anchor = None
             event.accept()
 
-    def composite(self, layers: List[MosaicScene], order: List[int]) -> Optional[QImage]:
+    def composite(self, layers: List[Optional[QImage]]) -> Optional[QImage]:
         """
-        Composite per-scene layers into a single image, bottom-to-top by ``order``.
+        Stack per-scene ARGB ``layers`` bottom-to-top into one image.
 
-        This is the single indirection point for the pixel layer: today it is a stub;
-        #637 stacks ARGB layers by alpha in z-order, and deferred work (seamlines,
-        feathering) reimplements only this method's internals without touching callers.
+        ``layers`` is already in render order — index 0 is the bottom scene, the last
+        index the top — with ``None`` for scenes that are hidden or have no cached
+        layer, so the z-order is encoded in the list itself. Layers are painted in
+        order with the default ``SourceOver`` compositing, so each layer's alpha lets
+        lower scenes show through its nodata holes. Returns ``None`` when nothing is
+        drawable.
+
+        This is the single indirection point for the pixel layer: deferred work
+        (seamlines, feathering) reimplements only this method's internals — stacking by
+        territory mask instead of raw z-order — without touching callers.
         """
-        # TODO(#637): build/stack per-scene ARGB caches (alpha = validity) in z-order.
-        return None
+        images = [im for im in layers if im is not None]
+        if not images:
+            return None
+        width = max(im.width() for im in images)
+        height = max(im.height() for im in images)
+        result = QImage(width, height, QImage.Format_ARGB32)
+        result.fill(Qt.transparent)
+        painter = QPainter(result)
+        for im in images:  # bottom-to-top; later draws land on top
+            painter.drawImage(0, 0, im)
+        painter.end()
+        return result
 
     def paintEvent(self, event: QPaintEvent) -> None:  # noqa: N802 (Qt override)
         # Initial fit: frame the mosaic extent the first time a grid is available
@@ -311,12 +459,35 @@ class MosaicView(QWidget):
             self._rebuild_overlay_geometry()
             self._geometry_dirty = False
 
+        # Pixel layer: re-read per-scene layers when the viewport (render signature)
+        # changed or the cache was explicitly invalidated, then restack. In step 3 the
+        # read becomes off-thread + debounced; here it is synchronous.
+        signature = (
+            self._transform.center_x,
+            self._transform.center_y,
+            self._transform.world_units_per_pixel,
+            self.width(),
+            self.height(),
+        )
+        if self._pixels_dirty or self._render_signature != signature:
+            self._rebuild_scene_layers()
+            self._recomposite()
+            self._render_signature = signature
+            self._pixels_dirty = False
+
         with get_painter(self) as painter:
             painter.fillRect(self.rect(), self.palette().window())
 
             # --- Layer 1: pixel layer (#637) -------------------------------------
-            # TODO(#637): draw self._composite_pixmap (the composited mosaic) here,
-            # scaled by the world->screen affine.
+            # Draw the composited pixmap mapped by the world->screen affine, so an
+            # interim pan/zoom simply scales the last composite until the next rebuild.
+            if self._composite_pixmap is not None and self._composite_world_extent is not None:
+                painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
+                min_x, min_y, max_x, max_y = self._composite_world_extent
+                target_rect = self._transform.world_to_screen(self.size()).mapRect(
+                    QRectF(min_x, min_y, max_x - min_x, max_y - min_y)
+                )
+                painter.drawPixmap(target_rect, self._composite_pixmap, QRectF(self._composite_pixmap.rect()))
 
             # --- Layer 2: vector overlay (#636) ----------------------------------
             painter.setRenderHint(QPainter.Antialiasing, True)

--- a/src/wiser/raster/mosaic_compositor.py
+++ b/src/wiser/raster/mosaic_compositor.py
@@ -1,0 +1,153 @@
+"""
+Qt-free per-scene pixel renderer for the Seamless Mosaic feature (EPIC #629, issue
+#637).
+
+This is the read half of the mosaic's **pixel layer**: given one materialized scene
+and the current viewport (a world rectangle in the target CRS plus an output pixel
+size), it warps the scene onto that window at screen resolution and returns an
+``(H, W, 4)`` uint8 **RGBA** array. The alpha channel is the scene's *validity mask*
+-- ``0`` on nodata / outside-footprint pixels, ``255`` where the scene has real data
+-- so the view can stack scenes with native alpha compositing (lower scenes show
+through upper scenes' holes).
+
+Kept Qt-free (GDAL/NumPy only, like :mod:`wiser.raster.mosaic_controller`) so it is
+unit-testable without a running application and can run on a background thread: it
+produces a plain NumPy array, and the GUI side (:mod:`wiser.gui.mosaic_view`) wraps
+that into a ``QImage`` on the main thread.
+
+Why warp rather than a plain ``ReadAsArray``: a mosaic composes scenes onto one shared
+target CRS, so each scene generally has to be reprojected. ``gdal.Warp`` handles the
+reprojection, the downsampling (it reads from the internal overviews built in #634
+because the output is far coarser than the source), the alignment to the requested
+window, and -- via ``dstAlpha=True`` -- the validity mask, all in one call. Compare the
+existing warp seam :func:`wiser.raster.mosaic_controller._warped_resolution`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence, Tuple
+
+import numpy as np
+from osgeo import gdal
+
+if TYPE_CHECKING:
+    from wiser.raster.mosaic_controller import MosaicScene
+
+# Percentile bounds for the per-scene linear contrast stretch. A 2-98% stretch is a
+# common, robust default that ignores a few extreme outliers without needing the
+# main view's live stretch state (this preview is intentionally self-contained).
+_STRETCH_LO_PCT = 2.0
+_STRETCH_HI_PCT = 98.0
+
+
+def render_scene_argb(
+    scene: "MosaicScene",
+    target_wkt: str,
+    world_extent: Tuple[float, float, float, float],
+    out_width: int,
+    out_height: int,
+    resample_alg: int = gdal.GRA_NearestNeighbour,
+) -> np.ndarray:
+    """
+    Warp ``scene`` onto ``world_extent`` at ``out_width`` x ``out_height`` and return
+    an ``(out_height, out_width, 4)`` uint8 RGBA array.
+
+    ``world_extent`` is ``(min_x, min_y, max_x, max_y)`` in the target CRS (the
+    view's visible world rectangle). RGB comes from the dataset's default display
+    bands (1 band -> grayscale, 3 bands -> RGB), contrast-stretched per band over the
+    valid pixels; alpha is the warp's validity mask (0 on nodata / outside coverage).
+
+    A scene whose data does not cover ``world_extent`` comes back fully transparent
+    (alpha all 0), so callers can render it unconditionally.
+    """
+    if out_width <= 0 or out_height <= 0:
+        return np.zeros((max(out_height, 0), max(out_width, 0), 4), dtype=np.uint8)
+
+    min_x, min_y, max_x, max_y = world_extent
+    warped = gdal.Warp(
+        "",
+        scene.gdal_path,
+        format="MEM",
+        dstSRS=target_wkt,
+        outputBounds=(min_x, min_y, max_x, max_y),
+        width=out_width,
+        height=out_height,
+        dstAlpha=True,
+        resampleAlg=resample_alg,
+        multithread=True,
+    )
+    if warped is None:
+        # Warp can decline (e.g. an output window fully disjoint from the source);
+        # treat that as "this scene contributes nothing here".
+        return np.zeros((out_height, out_width, 4), dtype=np.uint8)
+
+    # The alpha band dstAlpha appended is always the last band; the data bands are the
+    # ones before it (the scene's own bands, in order).
+    alpha_index = warped.RasterCount
+    num_data_bands = alpha_index - 1
+    alpha = warped.GetRasterBand(alpha_index).ReadAsArray().astype(np.uint8)
+
+    rgba = np.zeros((out_height, out_width, 4), dtype=np.uint8)
+    rgba[:, :, 3] = alpha
+
+    valid = alpha > 0
+    if num_data_bands <= 0 or not valid.any():
+        # No data bands, or nothing valid in view: leave RGB black, alpha as computed.
+        return rgba
+
+    display_bands = _select_display_bands(scene, num_data_bands)
+    channels = [
+        _stretch_band(
+            warped.GetRasterBand(band_idx + 1).ReadAsArray().astype(np.float32),
+            valid,
+        )
+        for band_idx in display_bands
+    ]
+
+    if len(channels) == 1:  # grayscale: replicate into R=G=B
+        rgba[:, :, 0] = rgba[:, :, 1] = rgba[:, :, 2] = channels[0]
+    else:
+        rgba[:, :, 0], rgba[:, :, 1], rgba[:, :, 2] = channels[0], channels[1], channels[2]
+    # Force invalid pixels fully clear (0, 0, 0, 0) so RGB never bleeds under a
+    # transparent alpha (the flat-band stretch otherwise whitens them).
+    rgba[~valid, :3] = 0
+    return rgba
+
+
+def _select_display_bands(scene: "MosaicScene", num_data_bands: int) -> Sequence[int]:
+    """
+    Pick the 0-based source band indices to render as RGB (or 1 for grayscale).
+
+    Prefers the dataset's default display bands; falls back to the first three bands
+    (or the single band) and clamps any out-of-range index defensively.
+    """
+    bands = None
+    getter = getattr(scene.dataset, "get_default_display_bands", None)
+    if getter is not None:
+        try:
+            bands = getter()
+        except Exception:  # noqa: BLE001 - metadata access must never break a paint
+            bands = None
+
+    if not bands:
+        bands = (0,) if num_data_bands < 3 else (0, 1, 2)
+    # Grayscale if a single band was chosen or the scene only has one band.
+    if len(bands) == 1 or num_data_bands < 3:
+        return (min(int(bands[0]), num_data_bands - 1),)
+    return tuple(min(int(b), num_data_bands - 1) for b in bands[:3])
+
+
+def _stretch_band(band: np.ndarray, valid: np.ndarray) -> np.ndarray:
+    """
+    Linearly stretch ``band`` to uint8 [0, 255] using the 2-98 percentile of its
+    valid pixels. A flat band (no spread) maps to full white so it stays visible.
+    """
+    values = band[valid]
+    lo = float(np.percentile(values, _STRETCH_LO_PCT))
+    hi = float(np.percentile(values, _STRETCH_HI_PCT))
+    if hi <= lo:
+        out = np.full(band.shape, 255.0, dtype=np.float32)
+    else:
+        out = (band - lo) * (255.0 / (hi - lo))
+    np.clip(out, 0.0, 255.0, out=out)
+    return out.astype(np.uint8)


### PR DESCRIPTION
## What does this change do?
Adds a way to actually composite scenes. Adds a cache so certain actions like hiding scenes or changing z order won't do gdal reads, just use cache. Has asynchronous reads for panning and zooming.

## What type of PR is this? (check all applicable) 
- [x] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
A mosaicking feature needs to be able to put multiple datasets visually on top of each other in an efficient manner. This PR does that.

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Screenshots

<img width="375" height="273" alt="image" src="https://github.com/user-attachments/assets/2be54ea6-a140-4c14-b25f-68440d78de5c" />

The pixel layer (seeing the datasets) is new and being able to drag the loaded in scenes and have the z order change. Also there is caching implemented. 


## [optional] Are there any post-merge tasks we need to perform?  
Future work
  - Read in a padded region around where the view port is so panning a little bit won't introduce the black space.
  - Only make the GTiff's that arem aterialized have 3 bands for the display bands. It makes overlays WAY faster.
  - The stretch is computed based on the visual extent. This means when you zoom in there is more and more contrast. We must fix this.