### PR TITLE
feat(project): dependency-aware Save Project dialog + menu wiring (#626)

### DIFF
--- a/src/tests/test_project_save_dialog.py
+++ b/src/tests/test_project_save_dialog.py
@@ -1,0 +1,82 @@
+"""Tests for the Save-Project dialog wiring (issue #626).
+
+The dialog's dependency logic lives in and is tested through
+``wiser.project.save_plan``; here we only check the thin Qt glue -- that a
+RAM-backed dataset becomes a checkable root, a file-backed one does not, and the
+resolver returned by the dialog reflects the checkbox state -- plus a smoke
+import of ``wiser.gui.app`` to catch the menu-wiring edits.
+"""
+
+import tests.context  # noqa: F401
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication
+
+from wiser.gui.save_project_dialog import SaveProjectDialog
+from wiser.project.resolver import Dependency
+
+
+def _qapp():
+    return QApplication.instance() or QApplication([])
+
+
+class _FakeDataset:
+    def __init__(self, ds_id, filepaths, name):
+        self._id = ds_id
+        self._filepaths = filepaths
+        self._name = name
+
+    def get_id(self):
+        return self._id
+
+    def get_filepaths(self):
+        return self._filepaths
+
+    def get_name(self):
+        return self._name
+
+
+class _FakeAppState:
+    def __init__(self, datasets):
+        self._datasets = datasets
+
+    def get_datasets(self):
+        return list(self._datasets)
+
+    def get_collected_spectra(self):
+        return []
+
+    def get_active_spectrum(self):
+        return None
+
+    def get_all_stretches(self):
+        return {}
+
+
+def test_dialog_resolver_reflects_selection():
+    _qapp()
+    app_state = _FakeAppState([_FakeDataset(1, [], "cube")])
+    dialog = SaveProjectDialog(app_state, None)
+
+    # Checked by default -> the dataset is saved.
+    assert dialog.get_resolver().is_saved(Dependency("dataset", 1))
+
+    # Unchecking the root excludes it from the resolver.
+    dialog._roots_table.item(0, 0).setCheckState(Qt.Unchecked)
+    assert not dialog.get_resolver().is_saved(Dependency("dataset", 1))
+
+
+def test_file_backed_dataset_is_not_a_checkable_root():
+    _qapp()
+    app_state = _FakeAppState([_FakeDataset(1, [], "ram"), _FakeDataset(2, ["/data/dem.tif"], "on-disk")])
+    dialog = SaveProjectDialog(app_state, None)
+
+    # Only the RAM-backed dataset gets a checkbox row...
+    assert dialog._roots_table.rowCount() == 1
+    # ...and the file-backed dataset is saved regardless (referenced, not a decision).
+    assert dialog.get_resolver().is_saved(Dependency("dataset", 2))
+
+
+def test_app_module_imports():
+    # Catches syntax/import errors from the app.py menu-wiring edits.
+    import wiser.gui.app  # noqa: F401

--- a/src/tests/test_project_save_dialog.py
+++ b/src/tests/test_project_save_dialog.py
@@ -36,9 +36,27 @@ class _FakeDataset:
         return self._name
 
 
+class _EmptyHistory:
+    def get_records(self):
+        return []
+
+
+class _FakeROI:
+    def __init__(self, roi_id, name):
+        self._id = roi_id
+        self._name = name
+
+    def get_id(self):
+        return self._id
+
+    def get_name(self):
+        return self._name
+
+
 class _FakeAppState:
-    def __init__(self, datasets):
+    def __init__(self, datasets, rois=()):
         self._datasets = datasets
+        self._rois = list(rois)
 
     def get_datasets(self):
         return list(self._datasets)
@@ -51,6 +69,21 @@ class _FakeAppState:
 
     def get_all_stretches(self):
         return {}
+
+    def get_rois(self):
+        return list(self._rois)
+
+    def get_pca_history(self):
+        return _EmptyHistory()
+
+    def get_mnf_history(self):
+        return _EmptyHistory()
+
+    def get_linear_unmix_history(self):
+        return _EmptyHistory()
+
+    def get_kmeans_history(self):
+        return _EmptyHistory()
 
 
 def test_dialog_resolver_reflects_selection():
@@ -75,6 +108,39 @@ def test_file_backed_dataset_is_not_a_checkable_root():
     assert dialog._roots_table.rowCount() == 1
     # ...and the file-backed dataset is saved regardless (referenced, not a decision).
     assert dialog.get_resolver().is_saved(Dependency("dataset", 2))
+
+
+def _top_labels(tree):
+    return [tree.topLevelItem(i).text(0) for i in range(tree.topLevelItemCount())]
+
+
+def test_inventory_tree_lists_saved_datasets_and_rois():
+    _qapp()
+    app_state = _FakeAppState(
+        [_FakeDataset(1, [], "ram"), _FakeDataset(2, ["/data/dem.tif"], "on-disk")],
+        rois=[_FakeROI(5, "crater")],
+    )
+    dialog = SaveProjectDialog(app_state, None)
+
+    labels = _top_labels(dialog._inventory)
+    assert dialog._inventory.topLevelItemCount() == 3
+    assert any("on-disk" in t for t in labels)  # file-backed dataset is visible, not empty
+    assert any("ram" in t for t in labels)
+    assert any("crater" in t for t in labels)
+
+
+def test_inventory_tree_drops_excluded_ram_dataset():
+    _qapp()
+    app_state = _FakeAppState(
+        [_FakeDataset(1, [], "ram"), _FakeDataset(2, ["/data/dem.tif"], "on-disk")],
+    )
+    dialog = SaveProjectDialog(app_state, None)
+    assert dialog._inventory.topLevelItemCount() == 2
+
+    dialog._roots_table.item(0, 0).setCheckState(Qt.Unchecked)  # exclude the RAM dataset
+    labels = _top_labels(dialog._inventory)
+    assert dialog._inventory.topLevelItemCount() == 1
+    assert any("on-disk" in t for t in labels)  # only the file-backed dataset remains
 
 
 def test_app_module_imports():

--- a/src/tests/test_project_save_plan.py
+++ b/src/tests/test_project_save_plan.py
@@ -1,0 +1,129 @@
+"""Unit tests for the Save-dialog planning model (issue #626).
+
+Covers the RAM-vs-file-backed root split and the dependency cascade preview: with
+every dataset saved everything is faithful, and excluding a RAM-backed dataset
+freezes its dependent spectra to snapshots and drops its stretches.
+"""
+
+import numpy as np
+
+import tests.context  # noqa: F401
+
+from wiser.project.save_plan import (
+    resolver_for_selection,
+    save_plan,
+    savable_dataset_roots,
+)
+from wiser.raster.loader import RasterDataLoader
+from wiser.raster.spectrum import SpectrumAtPoint
+from wiser.raster.stretch import StretchLinear
+
+
+class _FakeDataset:
+    def __init__(self, ds_id, filepaths):
+        self._id = ds_id
+        self._filepaths = filepaths
+
+    def get_id(self):
+        return self._id
+
+    def get_filepaths(self):
+        return self._filepaths
+
+
+class _FakeAppState:
+    def __init__(self):
+        self._loader = RasterDataLoader()
+        self._datasets = {}
+        self._collected = []
+        self._active = None
+        self._stretches = {}
+        self._next_id = 1
+
+    def get_loader(self):
+        return self._loader
+
+    def add_dataset(self, dataset):
+        ds_id = self._next_id
+        self._next_id += 1
+        dataset.set_id(ds_id)
+        self._datasets[ds_id] = dataset
+        return ds_id
+
+    def register(self, dataset):
+        """Add an already-id'd (possibly fake) dataset."""
+        self._datasets[dataset.get_id()] = dataset
+
+    def get_datasets(self):
+        return list(self._datasets.values())
+
+    def get_collected_spectra(self):
+        return list(self._collected)
+
+    def get_active_spectrum(self):
+        return self._active
+
+    def collect_spectrum(self, spectrum):
+        self._collected.append(spectrum)
+
+    def get_all_stretches(self):
+        return dict(self._stretches)
+
+    def set_stretches(self, ds_id, bands, stretches):
+        for band, stretch in zip(bands, stretches):
+            self._stretches[(ds_id, band)] = stretch
+
+
+def _ram_dataset(app_state, name="cube"):
+    arr = np.arange(4 * 5 * 6, dtype=np.float32).reshape((4, 5, 6))
+    ds = app_state.get_loader().dataset_from_numpy_array(arr, None)
+    ds.set_name(name)
+    app_state.add_dataset(ds)
+    return ds
+
+
+def test_savable_dataset_roots_splits_ram_and_file():
+    app = _FakeAppState()
+    ram = _ram_dataset(app)  # in-memory -> falsy get_filepaths()
+    app.register(_FakeDataset(99, ["/data/dem.tif"]))  # file-backed
+
+    ram_backed, file_backed = savable_dataset_roots(app)
+    assert [d.get_id() for d in ram_backed] == [ram.get_id()]
+    assert [d.get_id() for d in file_backed] == [99]
+
+
+def test_save_plan_all_faithful_when_nothing_excluded():
+    app = _FakeAppState()
+    ds = _ram_dataset(app)
+    app.collect_spectrum(SpectrumAtPoint(ds, (2, 3), (1, 1)))
+    app.set_stretches(ds.get_id(), (0,), [StretchLinear(0.2, 0.8)])
+
+    plan = save_plan(app, resolver_for_selection(app, excluded_dataset_ids=[]))
+    assert {row["policy"] for row in plan} == {"faithful"}
+
+
+def test_save_plan_snapshots_and_drops_on_excluded_dataset():
+    app = _FakeAppState()
+    ds = _ram_dataset(app)
+    app.collect_spectrum(SpectrumAtPoint(ds, (2, 3), (1, 1)))
+    app.set_stretches(ds.get_id(), (0,), [StretchLinear(0.2, 0.8)])
+
+    plan = save_plan(app, resolver_for_selection(app, excluded_dataset_ids=[ds.get_id()]))
+    policies = {row["policy"] for row in plan}
+    assert policies == {"snapshot", "drop"}
+
+    by_policy = {row["policy"]: row for row in plan}
+    assert by_policy["snapshot"]["item"]  # the dataset-backed spectrum
+    assert "stretch" in by_policy["drop"]["item"]
+
+
+def test_self_contained_spectrum_not_in_plan():
+    from wiser.raster.spectrum import NumPyArraySpectrum
+
+    app = _FakeAppState()
+    _ram_dataset(app)
+    app.collect_spectrum(NumPyArraySpectrum(np.array([0.1, 0.2], dtype=np.float32), name="numpy"))
+
+    # A numpy spectrum has no dataset dependency, so it never appears in the plan.
+    plan = save_plan(app, resolver_for_selection(app, excluded_dataset_ids=[]))
+    assert plan == []

--- a/src/tests/test_project_save_plan.py
+++ b/src/tests/test_project_save_plan.py
@@ -11,11 +11,13 @@ import tests.context  # noqa: F401
 
 from wiser.project.save_plan import (
     resolver_for_selection,
+    save_inventory,
     save_plan,
     savable_dataset_roots,
 )
 from wiser.raster.loader import RasterDataLoader
-from wiser.raster.spectrum import SpectrumAtPoint
+from wiser.raster.roi import RegionOfInterest
+from wiser.raster.spectrum import ROIAverageSpectrum, SpectrumAtPoint
 from wiser.raster.stretch import StretchLinear
 
 
@@ -30,6 +32,23 @@ class _FakeDataset:
     def get_filepaths(self):
         return self._filepaths
 
+    def get_name(self):
+        return None
+
+
+class _History:
+    def __init__(self, records):
+        self._records = records
+
+    def get_records(self):
+        return list(self._records)
+
+
+class _FakeRunRecord:
+    def __init__(self, run_id, input_dataset_id):
+        self.run_id = run_id
+        self.input_dataset_id = input_dataset_id
+
 
 class _FakeAppState:
     def __init__(self):
@@ -38,6 +57,8 @@ class _FakeAppState:
         self._collected = []
         self._active = None
         self._stretches = {}
+        self._rois = []
+        self._runs = {"pca": [], "mnf": [], "unmixing": [], "kmeans": []}
         self._next_id = 1
 
     def get_loader(self):
@@ -72,6 +93,27 @@ class _FakeAppState:
     def set_stretches(self, ds_id, bands, stretches):
         for band, stretch in zip(bands, stretches):
             self._stretches[(ds_id, band)] = stretch
+
+    def get_rois(self):
+        return list(self._rois)
+
+    def add_roi(self, roi):
+        self._rois.append(roi)
+
+    def add_run_record(self, tool, record):
+        self._runs[tool].append(record)
+
+    def get_pca_history(self):
+        return _History(self._runs["pca"])
+
+    def get_mnf_history(self):
+        return _History(self._runs["mnf"])
+
+    def get_linear_unmix_history(self):
+        return _History(self._runs["unmixing"])
+
+    def get_kmeans_history(self):
+        return _History(self._runs["kmeans"])
 
 
 def _ram_dataset(app_state, name="cube"):
@@ -127,3 +169,82 @@ def test_self_contained_spectrum_not_in_plan():
     # A numpy spectrum has no dataset dependency, so it never appears in the plan.
     plan = save_plan(app, resolver_for_selection(app, excluded_dataset_ids=[]))
     assert plan == []
+
+
+def test_save_inventory_groups_dependents_under_dataset():
+    app = _FakeAppState()
+    ds = _ram_dataset(app)
+    app.collect_spectrum(SpectrumAtPoint(ds, (2, 3), (1, 1)))
+    app.set_stretches(ds.get_id(), (0,), [StretchLinear(0.2, 0.8)])
+    app.add_run_record("pca", _FakeRunRecord(run_id=7, input_dataset_id=ds.get_id()))
+
+    inv = save_inventory(app, resolver_for_selection(app, excluded_dataset_ids=[]))
+    assert [node["kind"] for node in inv] == ["dataset"]
+    node = inv[0]
+    assert node["id"] == ds.get_id()
+    assert node["backing"] == "ram"
+    types = sorted(child["type"] for child in node["children"])
+    assert types == ["run", "spectrum", "stretch"]
+    assert all(child["policy"] == "faithful" for child in node["children"])
+    assert any("7" in child["label"] for child in node["children"] if child["type"] == "run")
+
+
+def test_save_inventory_excludes_unsaved_dataset():
+    app = _FakeAppState()
+    ds = _ram_dataset(app)
+    app.set_stretches(ds.get_id(), (0,), [StretchLinear(0.2, 0.8)])
+
+    inv = save_inventory(app, resolver_for_selection(app, excluded_dataset_ids=[ds.get_id()]))
+    assert inv == []
+
+
+def test_save_inventory_includes_file_backed_dataset():
+    app = _FakeAppState()
+    app.register(_FakeDataset(99, ["/data/dem.tif"]))
+
+    inv = save_inventory(app, resolver_for_selection(app, excluded_dataset_ids=[]))
+    assert [node["id"] for node in inv] == [99]
+    assert inv[0]["backing"] == "file"
+
+
+def test_save_inventory_lists_roi_average_under_roi_not_dataset():
+    app = _FakeAppState()
+    ds = _ram_dataset(app)
+    roi = RegionOfInterest("rim")
+    roi.set_id(50)
+    app.add_roi(roi)
+    app.collect_spectrum(ROIAverageSpectrum(ds, roi))
+
+    inv = save_inventory(app, resolver_for_selection(app, excluded_dataset_ids=[]))
+    ds_node = next(node for node in inv if node["kind"] == "dataset")
+    roi_node = next(node for node in inv if node["kind"] == "roi")
+    # The ROI-average hangs off the ROI, never doubled under its dataset.
+    assert all(child["type"] != "spectrum" for child in ds_node["children"])
+    assert [child["type"] for child in roi_node["children"]] == ["spectrum"]
+    assert roi_node["children"][0]["policy"] == "faithful"
+
+
+def test_save_inventory_roi_average_snapshots_when_dataset_cut():
+    app = _FakeAppState()
+    ds = _ram_dataset(app)
+    roi = RegionOfInterest("rim")
+    roi.set_id(50)
+    app.add_roi(roi)
+    app.collect_spectrum(ROIAverageSpectrum(ds, roi))
+
+    inv = save_inventory(app, resolver_for_selection(app, excluded_dataset_ids=[ds.get_id()]))
+    # The dataset is cut (no dataset root); the ROI still saves, its child frozen.
+    assert [node["kind"] for node in inv] == ["roi"]
+    assert inv[0]["children"][0]["policy"] == "snapshot"
+
+
+def test_save_inventory_omits_rootless_items():
+    from wiser.raster.spectrum import NumPyArraySpectrum
+
+    app = _FakeAppState()
+    ds = _ram_dataset(app)
+    app.collect_spectrum(NumPyArraySpectrum(np.array([0.1, 0.2], dtype=np.float32), name="numpy"))
+
+    inv = save_inventory(app, resolver_for_selection(app, excluded_dataset_ids=[]))
+    assert [node["id"] for node in inv] == [ds.get_id()]
+    assert inv[0]["children"] == []  # the self-contained spectrum hangs off nothing

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -36,6 +36,9 @@ from wiser.raster.spectrum import (
     SpectrumAtPoint,
     SpectrumAverageMode,
 )
+from wiser.project.bundle import ProjectBundle
+from wiser.project.migrate import ProjectTooNewError
+from wiser.project.orchestrate import load_project, save_project
 from wiser.utils.primitives import PriorityClass
 from wiser.utils.task_stage_utils import get_save_external_dataset_pipeline
 from wiser.utils.task_system import SemanticTask
@@ -60,6 +63,7 @@ from .rasterpane import RecenterMode
 from .reference_creator_dialog import ReferenceCreatorDialog
 from .mosaic_dialog import SeamlessMosaicDialog
 from .save_dataset import SaveDatasetDialog
+from .save_project_dialog import SaveProjectDialog
 from .similarity_transform_dialog import SimilarityTransformDialog
 from .spectrum_plot import SpectrumPlot
 from .util import *
@@ -142,6 +146,10 @@ class DataVisualizerApp(QMainWindow):
         self._app_state: ApplicationState = ApplicationState(self, config=config)
         self._data_cache = DataCache()
         self._app_state.set_data_cache(self._data_cache)
+
+        # Path of the project file the session was last saved to / opened from,
+        # so "Save Project" re-saves in place.  ``None`` until a Save As / Open.
+        self._current_project_path: Optional[str] = None
 
         self._activity_monitor: ActivityMonitorDialog = ActivityMonitorDialog(parent=self)
         self._activity_monitor_button: ActivityMonitorButton = ActivityMonitorButton(
@@ -313,6 +321,22 @@ class DataVisualizerApp(QMainWindow):
         # File menu
 
         self._file_menu = self.menuBar().addMenu(self.tr("&File"))
+
+        act = self._file_menu.addAction(self.tr("Open Project..."))
+        act.setStatusTip(self.tr("Open a WISER project file, replacing the current session"))
+        act.triggered.connect(self.on_open_project)
+
+        act = self._file_menu.addAction(self.tr("Save Project"))
+        act.setShortcuts(QKeySequence.Save)
+        act.setStatusTip(self.tr("Save the current session to its project file"))
+        act.triggered.connect(self.on_save_project)
+
+        act = self._file_menu.addAction(self.tr("Save Project As..."))
+        act.setShortcuts(QKeySequence.SaveAs)
+        act.setStatusTip(self.tr("Save the current session to a new project file"))
+        act.triggered.connect(self.on_save_project_as)
+
+        self._file_menu.addSeparator()
 
         act = self._file_menu.addAction(self.tr("&Open..."))
         act.setShortcuts(QKeySequence.Open)
@@ -651,6 +675,103 @@ class DataVisualizerApp(QMainWindow):
             # BugSnag reporting configuration.  Do that here.
             auto_notify = self._app_state.config().get("general.online_bug_reporting")
             bug_reporting.set_enabled(auto_notify)
+
+    def on_save_project(self, checked=False):
+        """Save the session to its current project file, or prompt if there is none."""
+        if self._current_project_path is None:
+            self.on_save_project_as()
+            return
+        try:
+            save_project(self._app_state, self._current_project_path)
+        except Exception as e:
+            logger.exception("Failed to save project")
+            QMessageBox.critical(
+                self,
+                self.tr("Save Failed"),
+                self.tr("Could not save the project:\n\n{0}").format(e),
+            )
+
+    def on_save_project_as(self, checked=False):
+        """Prompt for what to include and where, then save a new project file."""
+        dialog = SaveProjectDialog(self._app_state, parent=self)
+        if dialog.exec() != QDialog.Accepted:
+            return
+        resolver = dialog.get_resolver()
+
+        (path, _) = QFileDialog.getSaveFileName(
+            self,
+            self.tr("Save Project As"),
+            self._app_state.get_current_dir(),
+            self.tr("WISER project files (*{0})").format(ProjectBundle.EXTENSION),
+        )
+        if not path:
+            return
+        if not path.endswith(ProjectBundle.EXTENSION):
+            path += ProjectBundle.EXTENSION
+
+        try:
+            save_project(self._app_state, path, resolver)
+        except Exception as e:
+            logger.exception("Failed to save project")
+            QMessageBox.critical(
+                self,
+                self.tr("Save Failed"),
+                self.tr("Could not save the project:\n\n{0}").format(e),
+            )
+            return
+        self._current_project_path = path
+        self._app_state.update_cwd_from_path(path)
+
+    def on_open_project(self, checked=False):
+        """Open a project file, replacing the current session after confirmation."""
+        reply = QMessageBox.question(
+            self,
+            self.tr("Open Project"),
+            self.tr("Opening a project discards the current session.  Continue?"),
+        )
+        if reply != QMessageBox.Yes:
+            return
+
+        (path, _) = QFileDialog.getOpenFileName(
+            self,
+            self.tr("Open Project"),
+            self._app_state.get_current_dir(),
+            self.tr("WISER project files (*{0})").format(ProjectBundle.EXTENSION),
+        )
+        if not path:
+            return
+
+        try:
+            report = load_project(path, self._app_state)
+        except ProjectTooNewError as e:
+            QMessageBox.critical(self, self.tr("Cannot Open Project"), str(e))
+            return
+        except Exception as e:
+            logger.exception("Failed to open project")
+            QMessageBox.critical(
+                self,
+                self.tr("Open Failed"),
+                self.tr("Could not open the project:\n\n{0}").format(e),
+            )
+            return
+
+        self._current_project_path = path
+        self._app_state.update_cwd_from_path(path)
+        self._warn_dropped_on_load(report)
+
+    def _warn_dropped_on_load(self, report):
+        """Warn about any items that could not be restored during a load."""
+        dropped = {section: items for section, items in report.items() if items}
+        if not dropped:
+            return
+        lines = [
+            self.tr("{0}: {1} item(s)").format(section, len(items)) for section, items in dropped.items()
+        ]
+        QMessageBox.warning(
+            self,
+            self.tr("Project Opened With Warnings"),
+            self.tr("Some items could not be restored:\n\n{0}").format("\n".join(lines)),
+        )
 
     def show_open_file_dialog(self, evt):
         """

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -710,7 +710,7 @@ class DataVisualizerApp(QMainWindow):
         )
         if not path:
             return
-        if not path.endswith(ProjectBundle.EXTENSION):
+        if not path.lower().endswith(ProjectBundle.EXTENSION):
             path += ProjectBundle.EXTENSION
 
         try:
@@ -754,9 +754,11 @@ class DataVisualizerApp(QMainWindow):
         try:
             report = load_project(path, self._app_state, extract_dir=self._project_extract_dir)
         except ProjectTooNewError as e:
+            self._clear_project_extract_dir()
             QMessageBox.critical(self, self.tr("Cannot Open Project"), str(e))
             return
         except Exception as e:
+            self._clear_project_extract_dir()
             logger.exception("Failed to open project")
             QMessageBox.critical(
                 self,

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -1,7 +1,9 @@
 import logging
 import platform
 import pprint
+import shutil
 import sys
+import tempfile
 import traceback
 import webbrowser
 from functools import partial
@@ -150,6 +152,7 @@ class DataVisualizerApp(QMainWindow):
         # Path of the project file the session was last saved to / opened from,
         # so "Save Project" re-saves in place.  ``None`` until a Save As / Open.
         self._current_project_path: Optional[str] = None
+        self._project_extract_dir: Optional[str] = None
 
         self._activity_monitor: ActivityMonitorDialog = ActivityMonitorDialog(parent=self)
         self._activity_monitor_button: ActivityMonitorButton = ActivityMonitorButton(
@@ -647,6 +650,7 @@ class DataVisualizerApp(QMainWindow):
 
         # TODO(donnie):  Maybe save Qt state?
         delete_all_files_in_folder(TEMP_FOLDER_PATH)
+        self._clear_project_extract_dir()
         self._app_state.cancel_all_running_processes()
         self._app_services.close()
         super().closeEvent(event)
@@ -741,8 +745,14 @@ class DataVisualizerApp(QMainWindow):
         if not path:
             return
 
+        # A zipped project extracts to a directory that must outlive the load,
+        # since sidecar datasets are read from it lazily.  The app owns it: clear
+        # the previous session's directory and hand load_project a fresh one.
+        self._clear_project_extract_dir()
+        self._project_extract_dir = tempfile.mkdtemp(prefix="wiser-project-")
+
         try:
-            report = load_project(path, self._app_state)
+            report = load_project(path, self._app_state, extract_dir=self._project_extract_dir)
         except ProjectTooNewError as e:
             QMessageBox.critical(self, self.tr("Cannot Open Project"), str(e))
             return
@@ -758,6 +768,12 @@ class DataVisualizerApp(QMainWindow):
         self._current_project_path = path
         self._app_state.update_cwd_from_path(path)
         self._warn_dropped_on_load(report)
+
+    def _clear_project_extract_dir(self):
+        """Remove the temp directory a zipped project was extracted into, if any."""
+        if self._project_extract_dir:
+            shutil.rmtree(self._project_extract_dir, ignore_errors=True)
+            self._project_extract_dir = None
 
     def _warn_dropped_on_load(self, report):
         """Warn about any items that could not be restored during a load."""

--- a/src/wiser/gui/save_project_dialog.py
+++ b/src/wiser/gui/save_project_dialog.py
@@ -23,11 +23,18 @@ from PySide6.QtWidgets import (
     QLabel,
     QTableWidget,
     QTableWidgetItem,
+    QTreeWidget,
+    QTreeWidgetItem,
     QVBoxLayout,
 )
 
 from wiser.project.resolver import SavePolicy
-from wiser.project.save_plan import resolver_for_selection, save_plan, savable_dataset_roots
+from wiser.project.save_plan import (
+    resolver_for_selection,
+    save_inventory,
+    save_plan,
+    savable_dataset_roots,
+)
 
 if TYPE_CHECKING:
     from wiser.gui.app_state import ApplicationState
@@ -84,6 +91,15 @@ class SaveProjectDialog(QDialog):
         self._consequences.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
         layout.addWidget(self._consequences)
 
+        layout.addWidget(QLabel(self.tr("Will be saved:")))
+        self._inventory = QTreeWidget(self)
+        self._inventory.setColumnCount(1)
+        self._inventory.setHeaderHidden(True)
+        self._inventory.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._inventory.header().setSectionResizeMode(QHeaderView.ResizeToContents)
+        self._inventory.header().setStretchLastSection(False)
+        layout.addWidget(self._inventory)
+
         buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
@@ -108,6 +124,28 @@ class SaveProjectDialog(QDialog):
         for i, row in enumerate(affected):
             self._consequences.setItem(i, 0, QTableWidgetItem(row["item"]))
             self._consequences.setItem(i, 1, QTableWidgetItem(self._policy_text(row["policy"])))
+        self._refresh_inventory()
+
+    def _refresh_inventory(self) -> None:
+        resolver = resolver_for_selection(self._app_state, self._excluded_dataset_ids())
+        self._inventory.clear()
+        for node in save_inventory(self._app_state, resolver):
+            top = QTreeWidgetItem(self._inventory)
+            top.setText(0, self._node_label(node))
+            top.setData(0, Qt.UserRole, node["id"])
+            for child in node["children"]:
+                item = QTreeWidgetItem(top)
+                label = child["label"]
+                if child["policy"] == SavePolicy.SNAPSHOT.value:
+                    label = self.tr("{0} (snapshot)").format(label)
+                item.setText(0, label)
+            top.setExpanded(True)
+
+    def _node_label(self, node) -> str:
+        if node["kind"] == "dataset":
+            backing = self.tr("file") if node["backing"] == "file" else self.tr("in-memory")
+            return self.tr("Dataset {0} ({1})").format(node["label"], backing)
+        return self.tr("ROI {0}").format(node["label"])
 
     def get_resolver(self) -> "DependencyResolver":
         """The resolver for the user's current selection (call after ``exec()``)."""

--- a/src/wiser/gui/save_project_dialog.py
+++ b/src/wiser/gui/save_project_dialog.py
@@ -1,0 +1,122 @@
+"""Dependency-aware Save-Project dialog (issue #626).
+
+Presents the only real decision when saving a project: which in-memory
+("RAM-backed") datasets to include.  File-backed datasets are referenced by path
+for free; everything else cascades from the dataset choice, so the dialog shows a
+live consequence list -- the dataset-backed spectra that will freeze to a
+snapshot and the stretches that will be dropped -- recomputed as the user toggles
+a dataset.  The chosen :class:`~wiser.project.resolver.DependencyResolver` is
+handed to :func:`~wiser.project.orchestrate.save_project`.
+
+The dialog is a thin view over :mod:`wiser.project.save_plan`; all the
+dependency logic (and its tests) live there.
+"""
+
+from typing import TYPE_CHECKING, List
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QDialogButtonBox,
+    QHeaderView,
+    QLabel,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from wiser.project.resolver import SavePolicy
+from wiser.project.save_plan import resolver_for_selection, save_plan, savable_dataset_roots
+
+if TYPE_CHECKING:
+    from wiser.gui.app_state import ApplicationState
+    from wiser.project.resolver import DependencyResolver
+
+
+class SaveProjectDialog(QDialog):
+    def __init__(self, app_state: "ApplicationState", parent=None):
+        super().__init__(parent)
+        self._app_state = app_state
+        self._ram_datasets, self._file_datasets = savable_dataset_roots(app_state)
+        self.setWindowTitle(self.tr("Save Project"))
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(
+            QLabel(
+                self.tr(
+                    "Choose which in-memory datasets to include. File-backed datasets are "
+                    "referenced automatically, and everything else follows from your choice."
+                )
+            )
+        )
+
+        self._roots_table = QTableWidget(len(self._ram_datasets), 2, self)
+        self._roots_table.setHorizontalHeaderLabels([self.tr("Include"), self.tr("In-memory dataset")])
+        self._roots_table.verticalHeader().setVisible(False)
+        self._roots_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._roots_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
+        for row, dataset in enumerate(self._ram_datasets):
+            check = QTableWidgetItem()
+            check.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
+            check.setCheckState(Qt.Checked)
+            self._roots_table.setItem(row, 0, check)
+            label = dataset.get_name() or self.tr("dataset {0}").format(dataset.get_id())
+            self._roots_table.setItem(row, 1, QTableWidgetItem(label))
+        # Connect after populating so seeding the checkboxes doesn't fire refresh.
+        self._roots_table.itemChanged.connect(self._refresh_consequences)
+        layout.addWidget(self._roots_table)
+
+        if self._file_datasets:
+            layout.addWidget(
+                QLabel(
+                    self.tr("{0} file-backed dataset(s) will be referenced (not copied).").format(
+                        len(self._file_datasets)
+                    )
+                )
+            )
+
+        layout.addWidget(QLabel(self.tr("Consequences of your selection:")))
+        self._consequences = QTableWidget(0, 2, self)
+        self._consequences.setHorizontalHeaderLabels([self.tr("Item"), self.tr("Result")])
+        self._consequences.verticalHeader().setVisible(False)
+        self._consequences.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._consequences.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        layout.addWidget(self._consequences)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self._refresh_consequences()
+
+    def _excluded_dataset_ids(self) -> List[int]:
+        excluded = []
+        for row, dataset in enumerate(self._ram_datasets):
+            item = self._roots_table.item(row, 0)
+            if item is not None and item.checkState() != Qt.Checked:
+                excluded.append(dataset.get_id())
+        return excluded
+
+    def _refresh_consequences(self, *args) -> None:
+        resolver = resolver_for_selection(self._app_state, self._excluded_dataset_ids())
+        affected = [
+            row for row in save_plan(self._app_state, resolver) if row["policy"] != SavePolicy.FAITHFUL.value
+        ]
+        self._consequences.setRowCount(len(affected))
+        for i, row in enumerate(affected):
+            self._consequences.setItem(i, 0, QTableWidgetItem(row["item"]))
+            self._consequences.setItem(i, 1, QTableWidgetItem(_policy_text(row["policy"])))
+
+    def get_resolver(self) -> "DependencyResolver":
+        """The resolver for the user's current selection (call after ``exec()``)."""
+        return resolver_for_selection(self._app_state, self._excluded_dataset_ids())
+
+
+def _policy_text(policy: str) -> str:
+    if policy == SavePolicy.SNAPSHOT.value:
+        return "frozen to a snapshot"
+    if policy == SavePolicy.DROP.value:
+        return "dropped"
+    return policy

--- a/src/wiser/gui/save_project_dialog.py
+++ b/src/wiser/gui/save_project_dialog.py
@@ -107,16 +107,15 @@ class SaveProjectDialog(QDialog):
         self._consequences.setRowCount(len(affected))
         for i, row in enumerate(affected):
             self._consequences.setItem(i, 0, QTableWidgetItem(row["item"]))
-            self._consequences.setItem(i, 1, QTableWidgetItem(_policy_text(row["policy"])))
+            self._consequences.setItem(i, 1, QTableWidgetItem(self._policy_text(row["policy"])))
 
     def get_resolver(self) -> "DependencyResolver":
         """The resolver for the user's current selection (call after ``exec()``)."""
         return resolver_for_selection(self._app_state, self._excluded_dataset_ids())
 
-
-def _policy_text(policy: str) -> str:
-    if policy == SavePolicy.SNAPSHOT.value:
-        return "frozen to a snapshot"
-    if policy == SavePolicy.DROP.value:
-        return "dropped"
-    return policy
+    def _policy_text(self, policy: str) -> str:
+        if policy == SavePolicy.SNAPSHOT.value:
+            return self.tr("frozen to a snapshot")
+        if policy == SavePolicy.DROP.value:
+            return self.tr("dropped")
+        return policy

--- a/src/wiser/project/save_plan.py
+++ b/src/wiser/project/save_plan.py
@@ -78,4 +78,6 @@ def _dependent_spectra(app_state: "ApplicationState") -> List[Any]:
 
 
 def _spectrum_label(spectrum: Any) -> str:
-    return spectrum.get_name() or "spectrum"
+    # Fall back to the id so multiple unnamed spectra get distinguishable rows in
+    # the consequences table rather than all reading "spectrum".
+    return spectrum.get_name() or f"spectrum {spectrum.get_id()}"

--- a/src/wiser/project/save_plan.py
+++ b/src/wiser/project/save_plan.py
@@ -1,0 +1,81 @@
+"""Save planning for the dependency-aware Save dialog (issue #626).
+
+The Save dialog lets the user decide which in-memory ("RAM-backed") datasets to
+include in a project; everything else cascades from that choice.  This module is
+the dialog's headless model: it splits the datasets into the RAM-backed roots the
+user actually decides on and the file-backed ones that are auto-included, builds a
+:class:`~wiser.project.resolver.DependencyResolver` from a chosen exclusion set,
+and previews the consequence for every dependent item -- reconstructed
+faithfully, frozen to a snapshot, or dropped -- so the dialog can warn before it
+writes and pass the same resolver on to :func:`~wiser.project.orchestrate.save_project`.
+
+Only dataset-dependent items cascade: a dataset-backed spectrum freezes to a
+snapshot when its dataset is cut, and a per-band stretch is dropped when its
+dataset is cut.  Run records always save (they are self-contained), and library
+members are self-contained numpy, so neither appears in the cascade.
+"""
+
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Tuple
+
+from .persisters.spectra import spectrum_dependencies
+from .resolver import Dependency, DependencyResolver, cascade_report
+
+if TYPE_CHECKING:
+    from wiser.gui.app_state import ApplicationState
+
+
+def savable_dataset_roots(app_state: "ApplicationState") -> Tuple[List[Any], List[Any]]:
+    """Split the datasets into ``(ram_backed, file_backed)``.
+
+    Only the RAM-backed datasets are decision points: they are written into the
+    bundle, so the user chooses whether to include them.  File-backed datasets are
+    referenced by path and always included for free.
+    """
+    ram_backed: List[Any] = []
+    file_backed: List[Any] = []
+    for dataset in app_state.get_datasets():
+        (file_backed if dataset.get_filepaths() else ram_backed).append(dataset)
+    return ram_backed, file_backed
+
+
+def resolver_for_selection(
+    app_state: "ApplicationState", excluded_dataset_ids: Iterable[int]
+) -> DependencyResolver:
+    """Build a resolver treating every dataset as saved except the excluded ids."""
+    excluded = set(excluded_dataset_ids)
+    saved = {ds.get_id() for ds in app_state.get_datasets() if ds.get_id() not in excluded}
+    return DependencyResolver(saved)
+
+
+def save_plan(app_state: "ApplicationState", resolver: DependencyResolver) -> List[Dict[str, Any]]:
+    """Preview each dataset-dependent item's fate under ``resolver``.
+
+    Returns the JSON-friendly cascade report (``{"item", "policy", "reason"}``
+    dicts) the Save dialog renders: every dataset-backed spectrum and every
+    stretch, tagged faithful / snapshot / drop.  The dialog shows the whole table
+    (or filters to the non-faithful rows for a warnings summary).
+    """
+    named = []
+    for spectrum in _dependent_spectra(app_state):
+        deps = spectrum_dependencies(spectrum)
+        if not deps:
+            continue  # a self-contained numpy spectrum is not a decision point
+        named.append((_spectrum_label(spectrum), resolver.classify(deps, snapshotable=True)))
+    for (ds_id, band_index), stretch in app_state.get_all_stretches().items():
+        if stretch is None:
+            continue
+        decision = resolver.classify([Dependency("dataset", ds_id)], snapshotable=False)
+        named.append((f"stretch (dataset {ds_id}, band {band_index})", decision))
+    return cascade_report(named)
+
+
+def _dependent_spectra(app_state: "ApplicationState") -> List[Any]:
+    spectra = list(app_state.get_collected_spectra())
+    active = app_state.get_active_spectrum()
+    if active is not None:
+        spectra.append(active)
+    return spectra
+
+
+def _spectrum_label(spectrum: Any) -> str:
+    return spectrum.get_name() or "spectrum"

--- a/src/wiser/project/save_plan.py
+++ b/src/wiser/project/save_plan.py
@@ -7,7 +7,7 @@ user actually decides on and the file-backed ones that are auto-included, builds
 :class:`~wiser.project.resolver.DependencyResolver` from a chosen exclusion set,
 and previews the consequence for every dependent item -- reconstructed
 faithfully, frozen to a snapshot, or dropped -- so the dialog can warn before it
-writes and pass the same resolver on to :func:`~wiser.project.orchestrate.save_project`.
+writes and passes the same resolver on to :func:`~wiser.project.orchestrate.save_project`.
 
 Only dataset-dependent items cascade: a dataset-backed spectrum freezes to a
 snapshot when its dataset is cut, and a per-band stretch is dropped when its

--- a/src/wiser/project/save_plan.py
+++ b/src/wiser/project/save_plan.py
@@ -17,6 +17,8 @@ members are self-contained numpy, so neither appears in the cascade.
 
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Tuple
 
+from wiser.raster.spectrum import ROIAverageSpectrum
+
 from .persisters.spectra import spectrum_dependencies
 from .resolver import Dependency, DependencyResolver, cascade_report
 
@@ -81,3 +83,92 @@ def _spectrum_label(spectrum: Any) -> str:
     # Fall back to the id so multiple unnamed spectra get distinguishable rows in
     # the consequences table rather than all reading "spectrum".
     return spectrum.get_name() or f"spectrum {spectrum.get_id()}"
+
+
+def save_inventory(app_state: "ApplicationState", resolver: DependencyResolver) -> List[Dict[str, Any]]:
+    """What the project will contain, grouped by the dataset or ROI it hangs off.
+
+    Each saved dataset (file-backed, or RAM-backed and not excluded) and each ROI
+    (always saved) is a root node carrying its saved dependents: a dataset lists its
+    point/area spectra, per-band stretches, and the run records taken on it; an ROI
+    lists its ROI-average spectra.  Rootless saved items -- self-contained spectra,
+    libraries, user CRS, band-math -- are not shown, since the tree answers "what
+    hangs off each dataset/ROI", which is the decision the dialog is about.  A child
+    that freezes (an ROI-average whose dataset was cut) carries a ``snapshot`` policy
+    so the view can flag it.
+    """
+    spectra = _dependent_spectra(app_state)
+    nodes: List[Dict[str, Any]] = []
+
+    for dataset in app_state.get_datasets():
+        ds_id = dataset.get_id()
+        if not resolver.is_saved(Dependency("dataset", ds_id)):
+            continue  # excluded RAM dataset: not written, so not a root
+        nodes.append(
+            {
+                "kind": "dataset",
+                "id": ds_id,
+                "label": dataset.get_name() or f"dataset {ds_id}",
+                "backing": "file" if dataset.get_filepaths() else "ram",
+                "children": _dataset_children(app_state, resolver, ds_id, spectra),
+            }
+        )
+
+    for roi in app_state.get_rois():
+        nodes.append(
+            {
+                "kind": "roi",
+                "id": roi.get_id(),
+                "label": roi.get_name() or f"ROI {roi.get_id()}",
+                "backing": None,
+                "children": _roi_children(resolver, roi.get_id(), spectra),
+            }
+        )
+
+    return nodes
+
+
+def _dataset_children(
+    app_state: "ApplicationState", resolver: DependencyResolver, ds_id: int, spectra: List[Any]
+) -> List[Dict[str, Any]]:
+    children: List[Dict[str, Any]] = []
+    for (owner_id, band), stretch in app_state.get_all_stretches().items():
+        if stretch is not None and owner_id == ds_id:
+            children.append({"label": f"stretch (band {band})", "type": "stretch", "policy": "faithful"})
+    for spectrum in spectra:
+        # An ROI-average spectrum is listed under its ROI, not its dataset.
+        if isinstance(spectrum, ROIAverageSpectrum):
+            continue
+        deps = spectrum_dependencies(spectrum)
+        if any(dep.kind == "dataset" and dep.id == ds_id for dep in deps):
+            policy = resolver.classify(deps, snapshotable=True).policy.value
+            children.append({"label": _spectrum_label(spectrum), "type": "spectrum", "policy": policy})
+    for label, record in _run_records(app_state):
+        # Records reference their input dataset softly; they always save.
+        if record.input_dataset_id == ds_id:
+            children.append({"label": label, "type": "run", "policy": "faithful"})
+    return children
+
+
+def _roi_children(resolver: DependencyResolver, roi_id: int, spectra: List[Any]) -> List[Dict[str, Any]]:
+    children: List[Dict[str, Any]] = []
+    for spectrum in spectra:
+        if not isinstance(spectrum, ROIAverageSpectrum):
+            continue
+        roi = spectrum.get_roi()
+        if roi is not None and roi.get_id() == roi_id:
+            policy = resolver.classify(spectrum_dependencies(spectrum), snapshotable=True).policy.value
+            children.append({"label": _spectrum_label(spectrum), "type": "spectrum", "policy": policy})
+    return children
+
+
+def _run_records(app_state: "ApplicationState") -> Iterable[Tuple[str, Any]]:
+    histories = (
+        ("PCA", app_state.get_pca_history()),
+        ("MNF", app_state.get_mnf_history()),
+        ("Unmixing", app_state.get_linear_unmix_history()),
+        ("K-Means", app_state.get_kmeans_history()),
+    )
+    for label, history in histories:
+        for record in history.get_records():
+            yield f"{label} run {record.run_id}", record


### PR DESCRIPTION
## What does this change do?
Completes the Save flow with a dependency-aware Save Project dialog and the File-menu wiring (Open Project / Save Project / Save Project As). The dialog lets the user choose which in-memory datasets to include and previews the consequences live before writing.

## What type of PR is this? (check all applicable)
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] Chore
- [ ] Revert

## Why is this change needed?
Even with the persisters and orchestrator built, the user needs to understand and control what gets saved — especially which in-memory datasets to include, since those are the only roots that require a decision and everything else cascades from them. Without a clear UI, users would unknowingly drop dataset-backed spectra or stretches when they skip a dataset, and would not understand why something "didn't save."

Closes #626. Part of epic #615. Builds on the resolver #617, the orchestrator's save flow (#627), and all item persisters.

**Stacked on the orchestrator** (`feat/proj-627-orchestrate`, PR #680). Its diff shows only the dialog + wiring — review/merge the stack below it first, after which this rebases onto main.

## How did you implement the change?
- **`project/save_plan.py`** — the dialog's headless, unit-tested model: `savable_dataset_roots` (RAM- vs file-backed split — file-backed datasets are referenced for free, so only RAM-backed ones are decision points), `resolver_for_selection` (build a `DependencyResolver` from the user's exclusions), and `save_plan` (the live FAITHFUL/SNAPSHOT/DROP cascade — dataset-backed spectra that will freeze to a snapshot, stretches that will drop; runs and library members are self-contained and don't cascade).
- **`gui/save_project_dialog.py`** — a hand-built modal `SaveProjectDialog` (a checkable `QTableWidget` of RAM-dataset roots + a consequences table refreshed live on toggle, via `save_plan`), returning the chosen resolver from `get_resolver()`. Hand-built rather than a generated `Ui_*` to avoid the `.ui`/`pyside6-uic` toolchain.
- **`gui/app.py`** — File-menu actions **Open Project**, **Save Project** (`Ctrl+S`), **Save Project As** (`Ctrl+Shift+S`) with handlers that drive `save_project` / `load_project`; a `_current_project_path` field so Save re-saves in place; Open Project confirms before discarding the session and warns about any dropped items on load; a too-new file is reported cleanly (`ProjectTooNewError`).

Scoped-out for v1 (follow-ups, not blocking): excluding in-memory *libraries* from the dialog (all libraries currently save); Save As is two dialogs (options then file picker); a zipped project opens by extracting to a temp dir the app should later own/clean; `Ctrl+S` re-saves everything rather than reusing the last exclusion set.

## Added tests?
- [x] yes

`test_project_save_plan.py` (4): the RAM/file split, all-faithful when nothing is excluded, snapshot+drop when a dataset is excluded, and a self-contained spectrum staying out of the plan. `test_project_save_dialog.py` (3): the dialog's resolver reflects the checkbox state, a file-backed dataset is not a checkable root (constructed under a headless `QApplication`), and an `import wiser.gui.app` smoke test for the menu wiring. Full project suite green (78 passed); ruff + ruff-format clean.

## Added to documentation?
- [x] no documentation needed

## Checklist
- [x] There is an issue associated with this pull request (#626)
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced (ruff + ruff-format clean)
- [ ] Branch is up-to-date with main/master — stacked on `feat/proj-627-orchestrate`; rebases onto main after the stack below it lands
- [ ] All CI checks passed — pending CI

## [optional] Are there any post-merge tasks we need to perform?
- Merge order: the stack merges bottom-up; after #680 lands, re-parent/rebase this onto main.
- Follow-ups: library exclusion in the dialog, a single-step Save As, a session-owned extract dir for zipped projects, and `Ctrl+S` reusing the last resolver.
- The remaining epic work is #628 (versioning), stacked on this.