### PR TITLE
feat(project): project-file versioning policy + migration seam (#628)

### DIFF
--- a/src/tests/test_project_versioning.py
+++ b/src/tests/test_project_versioning.py
@@ -52,6 +52,13 @@ def test_register_migration_adds_to_chain(monkeypatch):
     assert result["format_version"] == 2
 
 
+def test_register_migration_rejects_duplicate(monkeypatch):
+    monkeypatch.setattr(migrate_mod, "_MIGRATIONS", {})
+    migrate_mod.register_migration(1, lambda manifest: manifest)
+    with pytest.raises(ValueError):
+        migrate_mod.register_migration(1, lambda manifest: manifest)
+
+
 def test_missing_migration_step_is_refused(monkeypatch):
     monkeypatch.setattr(migrate_mod, "CURRENT_FORMAT_VERSION", 2)
     monkeypatch.setattr(migrate_mod, "_MIGRATIONS", {})

--- a/src/tests/test_project_versioning.py
+++ b/src/tests/test_project_versioning.py
@@ -59,6 +59,13 @@ def test_register_migration_rejects_duplicate(monkeypatch):
         migrate_mod.register_migration(1, lambda manifest: manifest)
 
 
+def test_register_migration_rejects_invalid_from_version(monkeypatch):
+    monkeypatch.setattr(migrate_mod, "_MIGRATIONS", {})
+    for bad in (0, -1):
+        with pytest.raises(ValueError):
+            migrate_mod.register_migration(bad, lambda manifest: manifest)
+
+
 def test_missing_migration_step_is_refused(monkeypatch):
     monkeypatch.setattr(migrate_mod, "CURRENT_FORMAT_VERSION", 2)
     monkeypatch.setattr(migrate_mod, "_MIGRATIONS", {})

--- a/src/tests/test_project_versioning.py
+++ b/src/tests/test_project_versioning.py
@@ -1,0 +1,76 @@
+"""Tests for the project-file versioning policy and migrate-up seam (issue #628).
+
+Exercises the migration mechanism before any real migrations exist: a registered
+chain runs step-by-step, a missing step is refused, a too-new file is refused
+cleanly at the bundle level, and unknown (additively-added) keys pass through
+untouched.  The golden-fixture regression suite is deferred until the format
+stabilizes for the first release (see ``migrate.py``); this locks the mechanism
+it will rely on.
+"""
+
+import pytest
+
+import tests.context  # noqa: F401
+
+from wiser.project import migrate as migrate_mod
+from wiser.project.bundle import ProjectBundle
+from wiser.project.migrate import (
+    CURRENT_FORMAT_VERSION,
+    ProjectFormatError,
+    ProjectTooNewError,
+    migrate_up,
+)
+
+
+def test_migration_chain_applies_in_order(monkeypatch):
+    calls = []
+
+    def v1_to_v2(manifest):
+        calls.append(1)
+        return {**manifest, "added_in_v2": True}
+
+    def v2_to_v3(manifest):
+        calls.append(2)
+        return {**manifest, "added_in_v3": True}
+
+    monkeypatch.setattr(migrate_mod, "CURRENT_FORMAT_VERSION", 3)
+    monkeypatch.setattr(migrate_mod, "_MIGRATIONS", {1: v1_to_v2, 2: v2_to_v3})
+
+    result = migrate_mod.migrate_up({"format_version": 1})
+    assert calls == [1, 2]
+    assert result["added_in_v2"] and result["added_in_v3"]
+    assert result["format_version"] == 3
+
+
+def test_register_migration_adds_to_chain(monkeypatch):
+    monkeypatch.setattr(migrate_mod, "CURRENT_FORMAT_VERSION", 2)
+    monkeypatch.setattr(migrate_mod, "_MIGRATIONS", {})
+    migrate_mod.register_migration(1, lambda manifest: {**manifest, "migrated": True})
+
+    result = migrate_mod.migrate_up({"format_version": 1})
+    assert result["migrated"] is True
+    assert result["format_version"] == 2
+
+
+def test_missing_migration_step_is_refused(monkeypatch):
+    monkeypatch.setattr(migrate_mod, "CURRENT_FORMAT_VERSION", 2)
+    monkeypatch.setattr(migrate_mod, "_MIGRATIONS", {})
+    with pytest.raises(ProjectFormatError):
+        migrate_mod.migrate_up({"format_version": 1})
+
+
+def test_too_new_bundle_is_refused(tmp_path):
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    bundle.write_manifest({"format_version": CURRENT_FORMAT_VERSION + 3, "rois": []})
+
+    reopened = ProjectBundle.open(tmp_path / "proj")
+    with pytest.raises(ProjectTooNewError):
+        reopened.read_manifest()
+
+
+def test_unknown_keys_survive_migration():
+    # An additively-added section needs no bump: migrate-up passes unknown keys
+    # through untouched, and the load orchestrator reads sections with .get.
+    manifest = {"format_version": CURRENT_FORMAT_VERSION, "future_section": {"x": 1}, "rois": []}
+    result = migrate_up(manifest)
+    assert result["future_section"] == {"x": 1}

--- a/src/wiser/project/migrate.py
+++ b/src/wiser/project/migrate.py
@@ -1,12 +1,34 @@
-"""Project-file format versioning and the migrate-up seam.
+"""Project-file format versioning, policy, and the migrate-up seam (issue #628).
 
-The loader only ever understands the *current* schema.  On load, an older
-manifest is transformed step-by-step up to the current shape by a chain of pure
-functions; a manifest newer than this WISER understands is refused cleanly.
+**Guarantee:** any project file written by a released WISER can be opened by
+every later WISER (backward compatibility).  Forward compatibility is *not*
+promised -- a file from a newer WISER is refused cleanly rather than
+mis-interpreted.
 
-This module provides the version constant and the migrate-up mechanism only.
-The migration *policy* (the per-version transform functions) and the golden-file
-regression suite that enforces "old files still load" are owned by issue #628.
+**How it works.** The loader only ever understands the *current* schema.  On
+load, an older manifest is transformed step-by-step up to the current shape by a
+chain of pure ``migrate_vN_to_vN+1`` functions registered here; a manifest newer
+than this WISER understands raises :class:`ProjectTooNewError`.  The rest of the
+load code (every persister) therefore only ever sees the current shape.
+
+**Additive vs. breaking (the rule contributors follow).** A *non-breaking*
+change -- adding a new optional field -- needs **no** version bump and **no**
+migration: every ``from_pyrep`` parses leniently (ignores unknown keys, defaults
+missing ones), and the load orchestrator reads manifest sections with ``.get``,
+so an unknown section is simply ignored.  Bump :data:`CURRENT_FORMAT_VERSION` and
+write a migration **only** for a *breaking* change -- a renamed, removed,
+restructured, or semantically-changed field.
+
+**On a version bump (checklist):**
+1. Write a pure ``migrate_v{N}_to_v{N+1}(manifest) -> manifest`` and
+   :func:`register_migration` it; unit-test it with a minimal before/after dict.
+2. Bump :data:`CURRENT_FORMAT_VERSION` to ``N+1``.
+3. Capture a **golden fixture** -- a real ``.wiserproj`` written by the *previous*
+   release -- and add a regression test that loads it on current code and asserts
+   a correct restore.  This is what converts the guarantee from aspiration into
+   something CI fails on.  (The golden-fixture suite is intentionally deferred
+   until the format stabilizes for the first release -- there is only v1 today and
+   no migration to bridge -- but this checklist is the trigger for adding it.)
 """
 
 from typing import Any, Callable, Dict
@@ -23,9 +45,19 @@ class ProjectTooNewError(ProjectFormatError):
 
 
 # Maps a from-version to the function transforming a manifest dict to the next
-# version.  Empty while v1 is current; issue #628 appends migrations here as the
-# schema evolves (e.g. ``{1: migrate_v1_to_v2}``).
+# version.  Empty while v1 is current; migrations are appended via
+# :func:`register_migration` as the schema evolves (e.g. ``1 -> migrate_v1_to_v2``).
 _MIGRATIONS: Dict[int, Callable[[Dict[str, Any]], Dict[str, Any]]] = {}
+
+
+def register_migration(from_version: int, migrate: Callable[[Dict[str, Any]], Dict[str, Any]]) -> None:
+    """Register the pure function migrating a manifest from ``from_version`` up one.
+
+    Called at import time as the schema evolves.  ``migrate`` must be a pure
+    ``dict -> dict`` transform; pair each with a golden fixture per the module
+    docstring's checklist.
+    """
+    _MIGRATIONS[from_version] = migrate
 
 
 def migrate_up(manifest: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/wiser/project/migrate.py
+++ b/src/wiser/project/migrate.py
@@ -3,7 +3,7 @@
 **Guarantee:** any project file written by a released WISER can be opened by
 every later WISER (backward compatibility).  Forward compatibility is *not*
 promised -- a file from a newer WISER is refused cleanly rather than
-mis-interpreted.
+misinterpreted.
 
 **How it works.** The loader only ever understands the *current* schema.  On
 load, an older manifest is transformed step-by-step up to the current shape by a
@@ -55,9 +55,12 @@ def register_migration(from_version: int, migrate: Callable[[Dict[str, Any]], Di
 
     Called at import time as the schema evolves.  ``migrate`` must be a pure
     ``dict -> dict`` transform; pair each with a golden fixture per the module
-    docstring's checklist.  Rejects a duplicate ``from_version`` rather than
-    silently overwriting it, since that would make the migration chain ambiguous.
+    docstring's checklist.  ``from_version`` must be a positive integer (project
+    ``format_version`` starts at 1); a duplicate ``from_version`` is rejected
+    rather than silently overwritten, since that would make the chain ambiguous.
     """
+    if not isinstance(from_version, int) or from_version < 1:
+        raise ValueError(f"Invalid migration from_version {from_version!r}; expected a positive integer.")
     if from_version in _MIGRATIONS:
         raise ValueError(f"A migration from project format v{from_version} is already registered.")
     _MIGRATIONS[from_version] = migrate

--- a/src/wiser/project/migrate.py
+++ b/src/wiser/project/migrate.py
@@ -55,8 +55,11 @@ def register_migration(from_version: int, migrate: Callable[[Dict[str, Any]], Di
 
     Called at import time as the schema evolves.  ``migrate`` must be a pure
     ``dict -> dict`` transform; pair each with a golden fixture per the module
-    docstring's checklist.
+    docstring's checklist.  Rejects a duplicate ``from_version`` rather than
+    silently overwriting it, since that would make the migration chain ambiguous.
     """
+    if from_version in _MIGRATIONS:
+        raise ValueError(f"A migration from project format v{from_version} is already registered.")
     _MIGRATIONS[from_version] = migrate
 
 


### PR DESCRIPTION
## What does this change do?
Owns the project-file versioning policy and enforces its mechanism: documents the backward-compatibility guarantee and the additive-vs-breaking rule, adds a `register_migration` seam, and tests the migrate-up chain the future golden-file suite will rely on.

## What type of PR is this? (check all applicable)
- [x] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] Chore
- [ ] Revert

## Why is this change needed?
A project-file format that users save will change as WISER evolves. Without an explicit, enforced versioning strategy, either a schema change silently breaks old files, or the load path accretes ad-hoc branching. The bundle (#616) already carries a `format_version` and a migration *seam*, and the load orchestrator checks the version — but neither commits to a *policy* or a *mechanism* proven by tests. This issue owns that.

Closes #628. Part of epic #615. Builds on the `format_version` + migration seam from #616 and is invoked by the load orchestrator #627.

**Stacked on #626** (`feat/proj-626-save-dialog`, PR #681). Its diff shows only the versioning changes — review/merge the stack below it first, after which this rebases onto main.

## How did you implement the change?
- **`project/migrate.py`** — expands the module docstring into the versioning **policy**: the guarantee (*any file written by a released WISER opens in every later WISER*; forward compatibility is not promised), the **additive-vs-breaking rule** (a new *optional* field needs no bump and no migration — `from_pyrep` parses leniently and the load orchestrator reads sections with `.get`; bump the version and write a migration only for a renamed/removed/restructured/semantically-changed field), and the **version-bump checklist**. Adds `register_migration(from_version, fn)` for appending pure `migrate_vN_to_vN+1` transforms to the chain.
- The migrate-up mechanism and refuse-too-new behavior already existed in `migrate_up` / `ProjectBundle.read_manifest`; this PR proves them with tests and documents the policy around them.

**The golden-file regression fixture is intentionally deferred.** Per the epic's own guidance it's the most deferrable scope — there is only format v1 today and no migration to bridge, and the schema may still settle before the first release. The version-bump checklist in `migrate.py` is the trigger to capture a golden `.wiserproj` (written by the previous release) and add a load-it-on-current-code regression test at the first bump.

## Added tests?
- [x] yes

`test_project_versioning.py` (5): a registered migration chain applies step-by-step in order; `register_migration` wires into the chain; a missing chain step is refused (`ProjectFormatError`); a too-new bundle is refused cleanly (`ProjectTooNewError`) at the bundle level; and additively-added unknown keys survive migration untouched. The chain tests monkeypatch `_MIGRATIONS` / `CURRENT_FORMAT_VERSION` (auto-reverted, no leak). Full project suite green (78 passed); ruff + ruff-format clean.

## Added to documentation?
- [x] yes — the versioning policy + version-bump checklist live in the `migrate.py` module docstring where contributors will see them.

## Checklist
- [x] There is an issue associated with this pull request (#628)
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced (ruff + ruff-format clean)
- [ ] Branch is up-to-date with main/master — stacked on `feat/proj-626-save-dialog`; rebases onto main after the stack below it lands
- [ ] All CI checks passed — pending CI

## [optional] Are there any post-merge tasks we need to perform?
- Merge order: the stack merges bottom-up; this is the top — after #681 lands, re-parent/rebase this onto main.
- Deferred: capture the first golden-file fixture + its regression test when `format_version` is first bumped (checklist in `migrate.py`). This is the final piece of epic #615 — once the stack merges, WISER can save and reopen a real `.wiserproj`.