### PR TITLE
feat(mosaic): Only materialize 3 band geotiff for display

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -6,13 +6,15 @@ intended for developers reading, debugging, or extending the tool.
 
 ```{note}
 This is an in-progress feature (EPIC #629). As of this writing, scene ingestion,
-materialization, common-grid/CRS resolution, the **vector overlay** (footprints,
-bounding box, overlap highlight), the **static-scene pixel compositor** (the composited
-preview, with an off-thread debounced per-scene cache), the **control panel**
-(drag-to-reorder z-order, resolution mode, resampling method, and the band-metadata
-chooser), and the **full-resolution export path** (streaming ENVI compositor on the
-common grid — see [The Export Path](#the-export-path)) are implemented and wired into
-the GUI.
+materialization (a **display-only** preview artifact baked eagerly at ingest with the
+full-band cube materialized **lazily at export** — see [Display-Only Preview and Frozen
+Metadata](#display-only-preview-and-frozen-metadata)), common-grid/CRS resolution, the
+**vector overlay** (footprints, bounding box, overlap highlight), the **static-scene
+pixel compositor** (the composited preview, with an off-thread debounced per-scene
+cache), the **control panel** (drag-to-reorder z-order, resolution mode, resampling
+method, and the band-metadata chooser), and the **full-resolution export path**
+(streaming ENVI compositor on the common grid — see [The Export
+Path](#the-export-path)) are implemented and wired into the GUI.
 ```
 
 For the design rationale and full child-issue breakdown, see `EPIC_seamless_mosaic.md`
@@ -43,23 +45,29 @@ The feature is built from three cooperating layers:
   [The Geometry Overlay](#the-geometry-overlay-vector-layer)).
 
 Every scene, regardless of its original backing (GDAL file, NumPy array, PDR, etc.),
-is first turned into a warpable, disk-backed tiled GeoTIFF by a `SceneMaterializer` —
-the `RasterDataSet` is the source of truth for metadata, so materialization stamps
+is turned into a warpable, disk-backed tiled GeoTIFF by a `SceneMaterializer` — the
+`RasterDataSet` is the source of truth for metadata, so materialization stamps
 SRS/geotransform/nodata/band metadata from the dataset object, not from its `_impl`.
+As of #677 there are **two** materialization moments: at ingest the pane bakes a
+small **display-only** GeoTIFF (just the 1 or 3 display bands) that the preview reads,
+and at export the full-band cube is materialized **lazily**, stamped from a metadata
+snapshot **frozen at ingest**. See [Display-Only Preview and Frozen
+Metadata](#display-only-preview-and-frozen-metadata).
 
 **Core files:**
 
 | File | Responsibility |
 |------|----------------|
 | `src/wiser/gui/mosaic_dialog.py` | `SeamlessMosaicDialog` — top-level dialog shell, owns the session `SceneMaterializer` |
-| `src/wiser/gui/mosaic_pane.py` | `MosaicPane` — control panel; ingestion orchestration, scene list (drag-reorder + visibility), resolution / CRS / resampling / band-metadata controls |
+| `src/wiser/gui/mosaic_pane.py` | `MosaicPane` — control panel; ingestion orchestration (display-band resolution + metadata freeze), scene list (drag-reorder + visibility), resolution / CRS / resampling / band-metadata controls, export (drift warning) |
 | `src/wiser/gui/mosaic_view.py` | `MosaicView` — the two-layer paint surface (pixel + vector), currently a stub |
 | `src/wiser/gui/mosaic_crs_dialog.py` | `ReprojectPromptDialog` — modal target-CRS chooser |
-| `src/wiser/raster/mosaic_controller.py` | `MosaicController`, `MosaicScene`, `CommonGrid`, `ResolutionMode` — the non-GUI model |
+| `src/wiser/gui/app.py` | `App.get_current_display_bands` — narrow accessor for the main view's live per-dataset band selection (the display-band resolver injected into the mosaic) |
+| `src/wiser/raster/mosaic_controller.py` | `MosaicController`, `MosaicScene`, `SceneMetadataSnapshot`, `CommonGrid`, `ResolutionMode` — the non-GUI model |
 | `src/wiser/raster/mosaic_ingestion.py` | `validate_scene`, `build_overviews`, `compute_footprint_wkt` — Qt-free ingestion gates |
-| `src/wiser/raster/mosaic_compositor.py` | `render_scene_argb` — Qt-free per-scene warp→RGBA renderer (alpha = validity) for the pixel layer |
-| `src/wiser/raster/mosaic_export.py` | `export_mosaic` — warps each scene onto the common grid and streams the mosaic to ENVI |
-| `src/wiser/raster/mosaic_materialize.py` | `SceneMaterializer`, `materialize_to_tiled_geotiff` — the object-model adapter |
+| `src/wiser/raster/mosaic_compositor.py` | `render_scene_argb` — Qt-free per-scene warp→RGBA renderer (alpha = validity) for the pixel layer; reads the display-only artifact's bands in order |
+| `src/wiser/raster/mosaic_export.py` | `export_mosaic` — lazily materializes each scene's full-band cube (from live pixels + frozen snapshot), warps onto the common grid, streams to ENVI |
+| `src/wiser/raster/mosaic_materialize.py` | `SceneMaterializer` (`build_display_source`), `materialize_to_tiled_geotiff`, `materialize_display_only_to_tiled_geotiff`, `materialize_full_band_from_snapshot` — the object-model adapter |
 | `src/wiser/utils/progress.py` | `ProgressReporter` — Qt-free progress plumbing shared with any scheduler task |
 | `src/wiser/gui/progress_task.py` | `run_with_progress` — reusable modal + Activity Monitor bridge for scheduler tasks |
 
@@ -119,6 +127,8 @@ classDiagram
         mosaic_materialize.py
         -_tmp : TemporaryDirectory
         -_cache : dict
+        -_display_cache : dict
+        +build_display_source(dataset, display_bands, progress) str
         +gdal_source(dataset, progress) str
         +close()
     }
@@ -173,6 +183,14 @@ classDiagram
         +gdal_path : str
         +footprint_wkt : str
         +has_overviews : bool
+        +snapshot : SceneMetadataSnapshot
+    }
+
+    class SceneMetadataSnapshot {
+        <<dataclass>>
+        +spatial : SpatialMetadata
+        +spectral : SpectralMetadata
+        +display_bands : tuple
     }
 
     class CommonGrid {
@@ -186,6 +204,7 @@ classDiagram
     MosaicController --> MosaicScene : owns list (bottom-to-top)
     MosaicController --> CommonGrid : owns cached result
     MosaicScene --> RasterDataSet : wraps
+    MosaicScene --> SceneMetadataSnapshot : frozen at ingest
 ```
 
 The controller's scene list is **bottom-to-top**: index 0 renders first (bottom),
@@ -230,13 +249,15 @@ sequenceDiagram
     alt validation fails
         Pane-->>User: QMessageBox.warning
     else validation passes
-        Pane->>Sched: run_with_progress(_ingest_scene, dataset, materializer)
+        Pane->>Pane: resolve display bands (main-view selection → find_display_bands)
+        Pane->>Pane: SceneMetadataSnapshot.from_dataset(dataset, display_bands)
+        Pane->>Sched: run_with_progress(_ingest_scene, dataset, materializer, snapshot)
         Note over Pane: ProgressDialog shown, block_window disabled
         Sched->>Ingest: run on scheduler thread
-        Ingest->>Mat: gdal_source(dataset) → materialize/warp-ready GeoTIFF
+        Ingest->>Mat: build_display_source(dataset, snapshot.display_bands) → display-only GeoTIFF
         Ingest->>Ingest: build_overviews(gdal_path)
         Ingest->>Ingest: compute_footprint_wkt(gdal_path)
-        Ingest-->>Sched: MosaicScene(dataset, gdal_path, footprint_wkt, has_overviews=True)
+        Ingest-->>Sched: MosaicScene(dataset, gdal_path, footprint_wkt, has_overviews=True, snapshot)
         Sched-->>Pane: on_success(scene) [GUI thread]
         Pane->>Ctrl: add_scene(scene)
         Pane->>Pane: _refresh_scene_list()
@@ -244,6 +265,12 @@ sequenceDiagram
         Pane->>Pane: _mosaic_view.update()
     end
 ```
+
+Note the display-band resolution and the metadata snapshot are computed on the **GUI
+thread** before the worker starts (both must read live main-view / dataset state at
+add-time); only the display-only materialization, overviews, and footprint run on the
+background thread. See [Display-Only Preview and Frozen
+Metadata](#display-only-preview-and-frozen-metadata).
 
 ### Validation (`validate_scene`, `mosaic_ingestion.py`)
 
@@ -260,34 +287,41 @@ still valid) and dtype mismatches across scenes (the future compositor promotes 
 widest common type at warp time). See `# TODO(#640)` in the source for a planned
 warn-but-allow path for band-count mismatches.
 
-### Materialization (`SceneMaterializer.gdal_source`, `mosaic_materialize.py`)
+### Materialization (`SceneMaterializer.build_display_source`, `mosaic_materialize.py`)
 
-Every scene — GDAL-backed or not — is materialized to a disk-backed, tiled GeoTIFF
-(`TILED=YES`, 256×256 blocks) under a per-session temp directory
-(`wiser.utils.primitives.temp_dir()`), **not** `/vsimem` (RAM-backed), so GDAL reads
-only the requested windows. Metadata (geotransform, SRS, nodata, per-band wavelength,
-bad bands, default display bands) is stamped from the `RasterDataSet` object, mirroring
-the georeferencer's numpy→GDAL-dataset trick but disk-backed. A per-scene dedup cache
-(keyed by dataset id, or `id(dataset)` as a fallback) keeps this to one write per scene
-per session — re-adding the same dataset is a cache hit.
+At ingest each scene — GDAL-backed or not — is materialized to a **display-only**
+disk-backed, tiled GeoTIFF (`TILED=YES`, 256×256 blocks) under a per-session temp
+directory (`wiser.utils.primitives.temp_dir()`), **not** `/vsimem` (RAM-backed), so
+GDAL reads only the requested windows. It contains only the frozen **display bands**
+(1 for grayscale, 3 for RGB — bands 1/2/3 *are* R/G/B), so every warp and overview
+level touches 1–3 bands instead of all N — the whole point of #677 (see [Display-Only
+Preview and Frozen Metadata](#display-only-preview-and-frozen-metadata)). Metadata
+(geotransform, SRS, nodata, per-band wavelength) is stamped from the `RasterDataSet`
+object band-remapped onto the kept bands, with nodata preserved so the preview alpha
+mask still works. A per-scene dedup cache keyed by `(dataset id, display bands)` keeps
+this to one write per scene/band-choice per session.
 
-The user's original dataset is **never modified**; the materialized copy is a
-WISER-owned temp artifact.
+The full-band GeoTIFF (`materialize_to_tiled_geotiff` /
+`materialize_full_band_from_snapshot`) is materialized **lazily at export**, not here.
+The user's original dataset is **never modified**; the materialized copies are all
+WISER-owned temp artifacts.
 
 ### Overviews (`build_overviews`, `mosaic_ingestion.py`)
 
 Builds internal pyramid overviews (`NEAREST`, levels `[2, 4, 8, 16]`) directly inside
-the materialized temp GeoTIFF (`GA_Update` + `BuildOverviews`), so preview rendering
-has no first-paint stutter. Because materialization already produces a WISER-owned
-temp copy, overviews can be written internally rather than as external `.ovr`
-sidecars.
+the materialized **display-only** temp GeoTIFF (`GA_Update` + `BuildOverviews`), so
+preview rendering has no first-paint stutter. Because materialization already produces
+a WISER-owned temp copy, overviews can be written internally rather than as external
+`.ovr` sidecars — and with only 1–3 bands the pyramid is a fraction of the full-cube
+cost.
 
 ### Footprint (`compute_footprint_wkt`, `mosaic_ingestion.py`)
 
-Derives the valid-pixel outline via `gdal.Footprint(..., format="WKT")`, in the
-scene's **own** CRS (no reprojection here — that happens later, in the grid builder).
-With a nodata value set, this traces the true valid-pixel boundary; without one, it
-falls back to the full raster rectangle.
+Derives the valid-pixel outline via `gdal.Footprint(..., format="WKT")` on the
+display-only artifact, in the scene's **own** CRS (no reprojection here — that happens
+later, in the grid builder). The nodata is preserved on the display-only file, so with
+a nodata value set this traces the true valid-pixel boundary; without one, it falls
+back to the full raster rectangle.
 
 ### Progress reporting
 
@@ -307,6 +341,83 @@ GDAL's own `0..1` callbacks). The reporter is Qt-free; `run_with_progress`
 
 `_ingest_scene` is intentionally plain — it prints nothing and does not use the
 logging module; progress and errors are the only channel out of a scheduler worker.
+
+---
+
+## Display-Only Preview and Frozen Metadata
+
+Issue #677 splits scene materialization into two artifacts and freezes the dataset
+metadata at ingest, so the preview is fast and the whole session is deterministic
+against concurrent edits in main WISER.
+
+### Two artifacts, two moments
+
+The preview compositor only ever reads the **display bands** (1 for grayscale, 3 for
+RGB), so carrying every non-display band through each `gdal.Warp` and every overview
+level was pure overhead — a large multiplier for hyperspectral scenes. So:
+
+- **At ingest** the pane bakes a **display-only** GeoTIFF containing just the resolved
+  display bands (`SceneMaterializer.build_display_source` →
+  `materialize_display_only_to_tiled_geotiff`). Its bands 1/2/3 *are* R/G/B, nodata is
+  preserved for the alpha mask, and overviews + footprint are built on it. This is what
+  `scene.gdal_path` points at and what the pixel layer reads. The session dedup cache
+  holds **only** these small artifacts.
+- **At export** the full-band cube is materialized **lazily and uncached**
+  (`materialize_full_band_from_snapshot`), the only moment all bands are actually needed
+  — see [The Export Path](#the-export-path).
+
+Band selection therefore moves from **read time to materialize time**: the compositor no
+longer picks 3-of-N, it reads the small file's bands in order.
+
+### Which display bands get baked in
+
+The display-only file uses the bands **currently shown in the main view** for that
+dataset, not `dataset.get_default_display_bands()` — a dataset may have no defaults, and
+even when it does the user may have changed the displayed bands via the band chooser, a
+choice the mosaic should honor. Those bands are **GUI state** (`RasterPane._display_bands`),
+so at ingest `MosaicPane._resolve_display_bands` resolves them in order:
+
+1. the main view's current selection for the dataset, via the injected resolver
+   (`App.get_current_display_bands` — a narrow public accessor, so the mosaic does not
+   reach into `RasterPane` internals);
+2. otherwise `find_display_bands(dataset)` (`dataset.py`) — the defaults → human-eye
+   wavelength → first 1/3 bands fallback chain (also covers "never shown in the main
+   view").
+
+### Freezing the metadata (`SceneMetadataSnapshot`)
+
+`RasterDataSet` metadata (data-ignore, wavelengths, default display bands) can be edited
+in main WISER while the mosaic dialog is open (via `dataset_editor_dialog.py`), and
+`RasterDataSet` is **not** a `QObject` — it emits no change signal, only sets a dirty
+flag. So at ingest the pane snapshots the relevant metadata onto the scene:
+`SceneMetadataSnapshot.from_dataset(dataset, display_bands)` **deep-copies** the dataset's
+`SpatialMetadata` and `SpectralMetadata` (a shallow copy would share the dataset's
+internal `band_info` list) and stores the resolved `display_bands` alongside. Both the
+display-only materialization and the lazy full-band export stamp **from this snapshot**,
+never the live dataset, so a mid-session edit cannot silently change the mosaic. The
+display-band resolution and the snapshot are both built on the **GUI thread** before the
+worker starts, since both read live main-view / dataset state at add-time.
+
+Data-ignore is **not** cosmetic here: changing it moves the footprint, the alpha validity
+mask, and potentially the common grid — which is exactly why freezing (rather than
+consuming a live value at export) is the safe default.
+
+### Drift warning on export
+
+Because the snapshot may diverge from a later live edit, `_on_export_clicked` compares
+each visible scene's frozen `snapshot.spectral` against a freshly-read
+`dataset.get_spectral_metadata()` (`_scene_metadata_drifted`, using `SpectralMetadata`'s
+own `__eq__`) and, if any drifted, shows a **warn-and-proceed** dialog naming them: the
+export will use the frozen values, so the user can proceed knowingly or cancel and re-add
+the scene to pick up the edit.
+
+### Out of scope (follow-up)
+
+The nicer end-state is to *listen* for changes and re-run the affected ingest phases
+(a main-view display-band change already emits `RasterPane.display_bands_change`; the
+dataset-model edits do not, so they need new signal infrastructure). The frozen snapshot
+is a prerequisite either way — it is how "did it change?" is detected — but the reactive
+re-ingest is deliberately deferred.
 
 ---
 
@@ -455,12 +566,14 @@ an `(h, w, 4)` uint8 RGBA array. A single `gdal.Warp` does four jobs at once:
   outside-coverage pixels, so the alpha channel *is* the validity mask (no manual
   mask-band read). This mirrors the warp seam already used by `_warped_resolution`.
 
-RGB comes from the dataset's `get_default_display_bands()` (1 band → grayscale, 3 →
-RGB), contrast-stretched per band over the valid pixels (2–98 percentile). Invalid
-pixels are forced fully clear `(0,0,0,0)` so nothing bleeds under a transparent alpha.
-It is Qt-free (produces a NumPy array) so it is unit-testable without a running app and
-can run on a background thread; the view wraps the array into a `QImage` on the GUI
-thread.
+Since #677 `scene.gdal_path` is the **display-only** artifact whose bands already *are*
+the resolved display bands, so RGB is read straight from bands 1..N **in order** (1 band
+→ grayscale, 3 → RGB) — `render_scene_argb` no longer picks 3-of-N or consults the
+dataset's display bands (that decision moved upstream to materialize time). Each band is
+contrast-stretched over the valid pixels (2–98 percentile); invalid pixels are forced
+fully clear `(0,0,0,0)` so nothing bleeds under a transparent alpha. It is Qt-free
+(produces a NumPy array) so it is unit-testable without a running app and can run on a
+background thread; the view wraps the array into a `QImage` on the GUI thread.
 
 ### The per-scene cache and `composite()`
 
@@ -719,18 +832,29 @@ CRS logic.
 ### The compositor (`export_mosaic`, Qt-free)
 
 `export_mosaic(scenes, grid, target_wkt, resample_alg, output_nodata,
-band_metadata_dataset, out_path, progress)` is two GDAL stages, both lazy until the final
-streamed write:
+band_metadata_snapshot, out_path, progress)` is now three lazy stages per scene, all
+lazy until the final streamed write:
 
-1. **Warp each visible scene onto the common grid as a warped VRT**
+0. **Materialize the full-band cube lazily** (#677, `_warp_scene_to_grid_vrt` is fed
+   from `materialize_full_band_from_snapshot`). The preview reads a display-only
+   artifact, so export is the only moment all bands are actually needed. Each scene's
+   full-band GeoTIFF is materialized here into the export temp dir from the **live**
+   `scene.dataset` pixels but stamped with the scene's **frozen** `snapshot` metadata
+   (geotransform, SRS, nodata, band metadata) — so a mid-session metadata edit never
+   silently alters the product and the export stays aligned with the ingest-frozen
+   footprint / common grid. This full-band artifact is **not** cached — it is discarded
+   after the streamed write, keeping the session's temp footprint to the small
+   display-only files.
+
+1. **Warp each full-band scene onto the common grid as a warped VRT**
    (`_warp_scene_to_grid_vrt`). `gdal raster mosaic` does **not** reproject, so this
    per-scene `gdal.Warp(..., format="VRT")` is what applies the CRS transform + resample +
    grid alignment — mirroring the preview warp in `render_scene_argb`, but keeping the raw
-   band values (no percentile stretch, no `dstAlpha`). Each scene's Data Ignore Value
-   becomes the warp `srcNodata` and `output_nodata` becomes the `dstNodata`, so invalid /
-   outside-footprint pixels are marked for the compositor. VRTs are lazy — no pixels are
-   materialized here. A scene whose window is disjoint from the grid warps to `None` and
-   is simply skipped.
+   band values (no percentile stretch, no `dstAlpha`). The scene's **frozen** Data Ignore
+   Value (from the snapshot) becomes the warp `srcNodata` and `output_nodata` becomes the
+   `dstNodata`, so invalid / outside-footprint pixels are marked for the compositor. VRTs
+   are lazy — no pixels are materialized here. A scene whose window is disjoint from the
+   grid warps to `None` and is simply skipped.
 
 2. **Composite + stream to ENVI** (`_run_raster_mosaic`) via
    `gdal.Run("raster", "mosaic", input=[...], output=..., output_format="ENVI", ...)`
@@ -740,18 +864,21 @@ streamed write:
    block-by-block, so no full-image buffer is held in RAM. GDAL's own progress callback is
    forwarded through the `ProgressReporter`.
 
-The VRTs live in a `TemporaryDirectory` scoped around the mosaic call — they are only
-referenced until `gdal.Run` finishes the streamed write, then discarded.
+Both the lazily-materialized full-band tiffs and the warped VRTs live in a
+`TemporaryDirectory` scoped around the mosaic call — they are only referenced until
+`gdal.Run` finishes the streamed write, then discarded.
 
 ### Band-metadata stamping and the ENVI-header patch
 
 `gdal raster mosaic` writes correct pixels, geotransform, and `map info`, but no spectral
 metadata, so `_patch_envi_band_metadata` reopens the GDAL-written `.hdr` and rewrites it
 with WISER's own ENVI header helpers (`envi.load_envi_header` / `write_envi_header`),
-stamping the canonical band metadata from `controller.get_band_metadata_source()`:
-wavelengths / units, band names, the bad-band list (`bbl`), and the output nodata. This
-keeps the exported file self-describing so it re-opens in WISER with the right spectral
-labels.
+stamping the canonical band metadata from the **frozen snapshot** of the scene chosen by
+`controller.get_band_metadata_source()` (its `band_metadata_snapshot`): wavelengths /
+units, band names, the bad-band list (`bbl`), and the output nodata. Reading from the
+snapshot rather than the live dataset keeps the export deterministic against concurrent
+edits. This keeps the exported file self-describing so it re-opens in WISER with the
+right spectral labels.
 
 One subtlety is called out because it caused a crash-on-open regression:
 
@@ -761,9 +888,9 @@ One subtlety is called out because it caused a crash-on-open regression:
 > leaving that placeholder (or copying an out-of-range source value) makes the exported
 > file raise `GDALDataset::GetRasterBand(4) - Illegal band #` when opened in a raster
 > view. `_resolve_default_bands` therefore always resolves the field explicitly: it keeps
-> the canonical source's default display bands only when every index is in range for the
-> output, and otherwise **clears** it so WISER derives display bands from the stamped
-> wavelengths (truecolor) or the first bands.
+> the snapshot's frozen resolved `display_bands` (the canonical display choice) only when
+> every index is in range for the output, and otherwise **clears** it so WISER derives
+> display bands from the stamped wavelengths (truecolor) or the first bands.
 
 The result is **not** loaded back into the running session — export writes the file and
 the user opens it manually via **File → Open** (a deliberate product decision), which is
@@ -771,16 +898,21 @@ why the on-disk header must be fully self-describing.
 
 ### GUI wiring and threading
 
-`MosaicPane._on_export_clicked` (GUI thread) requires ≥1 visible scene, resolves the grid
-via `_ensure_common_grid()` (surfacing `TargetCrsRequired`/`UnmappableCrsError` as a
+`MosaicPane._on_export_clicked` (GUI thread) requires ≥1 visible scene, **warns on
+metadata drift** (`_scene_metadata_drifted`: any visible scene whose live dataset
+spectral metadata differs from its frozen snapshot — a warn-and-proceed prompt, since
+the export will use the frozen values; see [Display-Only Preview and Frozen
+Metadata](#display-only-preview-and-frozen-metadata)), resolves the grid via
+`_ensure_common_grid()` (surfacing `TargetCrsRequired`/`UnmappableCrsError` as a
 warning), asks for an output path with `QFileDialog.getSaveFileName`, resolves the output
-nodata (`_resolve_output_nodata`: the band-metadata dataset's Data Ignore Value, else the
-top-most visible scene that has one), snapshots the controller state, and hands the heavy
-work to a scheduler thread via the same `run_with_progress` bridge the ingestion path uses
-(progress modal + Activity Monitor row + cancellation, blocking only the mosaic dialog).
-The module-level worker `_export_mosaic_task` just calls `export_mosaic` and returns the
-written path; `_on_export_finished` shows a confirmation dialog. Like `_ingest_scene`, the
-worker never logs — progress and raised exceptions are its only channels out.
+nodata (`_resolve_output_nodata`: the band-metadata scene's **frozen** Data Ignore Value,
+else the top-most visible scene that has one), snapshots the controller state, and hands
+the heavy work to a scheduler thread via the same `run_with_progress` bridge the ingestion
+path uses (progress modal + Activity Monitor row + cancellation, blocking only the mosaic
+dialog). The module-level worker `_export_mosaic_task` just calls `export_mosaic` and
+returns the written path; `_on_export_finished` shows a confirmation dialog. Like
+`_ingest_scene`, the worker never logs — progress and raised exceptions are its only
+channels out.
 
 ---
 
@@ -808,7 +940,16 @@ worker never logs — progress and raised exceptions are its only channels out.
   preservation (pure `QTransform` math, no widget shown).
 - `src/tests/test_mosaic_compositor.py` — the Qt-free `render_scene_argb`: alpha is 0
   exactly on the nodata collar and 255 on the valid interior, RGBA shape/dtype, valid
-  pixels get color, a disjoint viewport comes back fully transparent (no Qt).
+  pixels get color, a disjoint viewport comes back fully transparent (no Qt); plus (#677)
+  it reads the display-only bands **in order** (column gradient → R, row gradient → G)
+  and **ignores** the dataset's display bands (a post-ingest display-band edit can't
+  change the preview).
+- `src/tests/test_mosaic_materialize.py` — the materialization adapter: full-band
+  round-trip metadata + tiled layout, window reads, `RasterDataSet` overriding its GDAL
+  backing, dedup, temp-dir lifecycle; plus (#677) `build_display_source` bakes only the
+  chosen bands in order with nodata preserved, is cached by `(scene, bands)`, rejects
+  non-1/3 band counts, and `materialize_full_band_from_snapshot` takes live pixels but
+  **frozen** nodata/metadata.
 - `src/tests/test_mosaic_view_gui.py` — the overlay **and** pixel-layer wiring end to
   end, driven through the real `MosaicPane` ingestion path: geometry cache populates /
   re-invalidates; `composite()` stacks known ARGB layers (top opaque wins, holes reveal
@@ -826,12 +967,15 @@ worker never logs — progress and raised exceptions are its only channels out.
   footprint is the output nodata), Nearest-Neighbor value preservation (exact source
   values), band count + canonical metadata round-tripped through the written ENVI, and the
   `default bands` guards (GDAL's 1-based RGB placeholder is cleared; an out-of-range source
-  default is dropped so the file opens without an `Illegal band #` crash).
+  default is dropped so the file opens without an `Illegal band #` crash); plus (#677)
+  export stamps the **frozen** default bands even after the live dataset is edited.
 - `src/tests/test_mosaic_export_gui.py` — the Export button end to end via `WiserTestModel`:
   ingest two scenes, patch the save dialog, click Export, and assert the ENVI `.img`/`.hdr`
   are written on the common grid with nodata carried through while **nothing is loaded back
-  into WISER** (dataset count unchanged); plus the no-scenes guard (informs and never
-  reaches the file picker).
+  into WISER** (dataset count unchanged); the no-scenes guard (informs and never reaches the
+  file picker); and (#677) the metadata-drift warning — a post-ingest edit surfaces the
+  warn-and-proceed prompt, where declining aborts before the file picker and accepting
+  proceeds past it.
 - `src/tests/test_mosaic_ingestion.py` — `validate_scene`, `build_overviews`,
   `compute_footprint_wkt`, and progress-reporting behavior.
 - `src/tests/test_mosaic_crs_dialog.py` — `ReprojectPromptDialog` in isolation

--- a/src/tests/test_mosaic_compositor.py
+++ b/src/tests/test_mosaic_compositor.py
@@ -144,3 +144,65 @@ def test_rgb_scene_uses_three_display_bands(tmp_path):
     assert np.all(rgba[valid, 0] == 255)
     assert np.all(rgba[valid, 1] == 255)
     assert np.all(rgba[valid, 2] == 255)
+
+
+def _write_gradient_tiff(path):
+    """
+    Write an all-valid 3-band GeoTIFF whose bands carry *distinguishable* patterns so
+    channel ordering is observable after the per-band stretch:
+      * band 1 = column index  (increases left -> right)
+      * band 2 = row index     (increases top -> bottom)
+      * band 3 = flat constant
+    Returns the projection WKT.
+    """
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(_EPSG)
+    ds = gdal.GetDriverByName("GTiff").Create(path, _SIZE, _SIZE, 3, gdal.GDT_Float32)
+    ox, oy = _ORIGIN
+    ds.SetGeoTransform([ox, _PIXEL, 0.0, oy, 0.0, -_PIXEL])
+    ds.SetProjection(srs.ExportToWkt())
+    cols = np.tile(np.arange(_SIZE, dtype=np.float32), (_SIZE, 1))  # varies along x
+    rows = np.tile(np.arange(_SIZE, dtype=np.float32).reshape(_SIZE, 1), (1, _SIZE))  # along y
+    flat = np.full((_SIZE, _SIZE), 3.0, dtype=np.float32)
+    for b, arr in enumerate((cols, rows, flat)):
+        ds.GetRasterBand(b + 1).WriteArray(arr)
+    ds.FlushCache()
+    ds = None
+    return srs.ExportToWkt()
+
+
+def test_reads_display_bands_in_order(tmp_path):
+    """
+    #677: the compositor reads the display-only artifact's bands *in order* (band
+    1/2/3 = R/G/B) rather than picking bands from the dataset. A column gradient in
+    band 1 must land in R and a row gradient in band 2 must land in G.
+    """
+    path = os.path.join(str(tmp_path), "gradient.tif")
+    wkt = _write_gradient_tiff(path)
+    scene = MosaicScene(dataset=_DatasetStub(wkt, (0, 1, 2)), gdal_path=path)
+
+    rgba = render_scene_argb(scene, wkt, _source_extent(), _SIZE, _SIZE)
+
+    # R came from band 1 (column gradient): rightmost column brighter than leftmost.
+    assert rgba[:, -1, 0].mean() > rgba[:, 0, 0].mean()
+    # G came from band 2 (row gradient): bottom row brighter than top.
+    assert rgba[-1, :, 1].mean() > rgba[0, :, 1].mean()
+
+
+def test_preview_ignores_dataset_display_bands(tmp_path):
+    """
+    #677: band selection moved to materialize time, so the compositor no longer reads
+    the dataset's display bands. Two scenes which should map to the same display bands
+    do.
+    """
+    path = os.path.join(str(tmp_path), "gradient.tif")
+    wkt = _write_gradient_tiff(path)
+    ext = _source_extent()
+
+    sane = MosaicScene(dataset=_DatasetStub(wkt, (0, 1, 2)), gdal_path=path)
+    garbage = MosaicScene(dataset=_DatasetStub(wkt, (9, 9, 9)), gdal_path=path)
+
+    np.testing.assert_array_equal(
+        render_scene_argb(sane, wkt, ext, _SIZE, _SIZE),
+        render_scene_argb(garbage, wkt, ext, _SIZE, _SIZE),
+    )

--- a/src/tests/test_mosaic_export.py
+++ b/src/tests/test_mosaic_export.py
@@ -280,6 +280,45 @@ def test_out_of_range_default_bands_are_dropped(tmp_path: Path) -> None:
     assert all(0 <= int(b) < reloaded.num_bands() for b in find_display_bands(reloaded))
 
 
+def test_export_metadata_frozen_against_live_edit(tmp_path: Path) -> None:
+    """
+    #677: export stamps the header from the ingest-time snapshot, so a metadata edit
+    made in main WISER *after* a scene was added is not applied. Freeze a scene with
+    default bands [2, 1, 0], then edit the live dataset, and confirm the exported file
+    keeps the frozen choice.
+    """
+    band_source = make_numpy_scene(
+        origin=ORIGIN_A,
+        base_value=0.0,
+        wavelengths=[450.0, 550.0, 650.0],
+        wavelength_units="nm",
+        default_display_bands=[2, 1, 0],
+    )
+    scene_a = _materialized_scene(band_source, tmp_path, "a")  # snapshot frozen here
+    scene_b = _materialized_scene(make_numpy_scene(origin=ORIGIN_B, base_value=1000.0), tmp_path, "b")
+
+    # Edit the live dataset AFTER ingest; these must NOT reach the export.
+    band_source.set_default_display_bands((0, 1, 2))
+    band_source.set_data_ignore_value(4242.0)
+
+    out = tmp_path / "mosaic.img"
+    export_mosaic(
+        [scene_a, scene_b],
+        _union_grid(),
+        wkt_for_epsg(EPSG),
+        gdal.GRA_NearestNeighbour,
+        NODATA,
+        scene_a.snapshot,
+        out,
+    )
+
+    reloaded = RasterDataLoader().load_from_file(path=str(out), data_cache=None)[0]
+    # The frozen [2, 1, 0] is stamped, not the live edit [0, 1, 2].
+    assert list(reloaded.default_display_bands()) == [2, 1, 0]
+    # The output nodata is the export nodata we passed, unaffected by the live edit.
+    assert reloaded.get_data_ignore_value() == pytest.approx(NODATA)
+
+
 def test_empty_scene_list_raises(tmp_path: Path) -> None:
     with pytest.raises(MosaicExportError):
         export_mosaic(

--- a/src/tests/test_mosaic_export.py
+++ b/src/tests/test_mosaic_export.py
@@ -25,10 +25,10 @@ from osgeo import gdal
 import tests.context  # noqa: F401  (sets up sys.path for `wiser` imports)
 
 from tests.mosaic_fixtures import make_numpy_scene, wkt_for_epsg
-from wiser.raster.dataset import RasterDataSet
+from wiser.raster.dataset import RasterDataSet, find_display_bands
 from wiser.raster.dataset_impl import NumPyRasterDataImpl
 from wiser.raster.loader import RasterDataLoader
-from wiser.raster.mosaic_controller import CommonGrid, MosaicScene
+from wiser.raster.mosaic_controller import CommonGrid, MosaicScene, SceneMetadataSnapshot
 from wiser.raster.mosaic_export import MosaicExportError, export_mosaic
 from wiser.raster.mosaic_materialize import materialize_to_tiled_geotiff
 
@@ -63,10 +63,17 @@ def _union_grid(width_px: int = 8, height_px: int = 6) -> CommonGrid:
 
 
 def _materialized_scene(dataset: RasterDataSet, tmp_path: Path, name: str) -> MosaicScene:
-    """Materialize ``dataset`` to a tiled GeoTIFF and wrap it as a MosaicScene."""
+    """
+    Wrap ``dataset`` as a MosaicScene with a frozen ingest snapshot (#677).
+
+    Export lazily re-materializes each scene's full-band cube from ``scene.dataset`` +
+    ``scene.snapshot``, so it no longer reads ``gdal_path``; we still materialize a
+    tiled GeoTIFF (some tests poke at it) and attach the snapshot the export path needs.
+    """
     path = tmp_path / f"{name}.tif"
     materialize_to_tiled_geotiff(dataset, path)
-    return MosaicScene(dataset=dataset, gdal_path=str(path))
+    snapshot = SceneMetadataSnapshot.from_dataset(dataset, find_display_bands(dataset))
+    return MosaicScene(dataset=dataset, gdal_path=str(path), snapshot=snapshot)
 
 
 def _numpy_scene_from_cube(cube: np.ndarray, origin, tmp_path: Path, name: str) -> MosaicScene:
@@ -100,7 +107,7 @@ def test_z_order_top_scene_wins_overlap(tmp_path: Path) -> None:
         wkt_for_epsg(EPSG),
         gdal.GRA_NearestNeighbour,
         NODATA,
-        scene_a.dataset,
+        scene_a.snapshot,
         out,
     )
     band = _read_band(out)
@@ -128,7 +135,7 @@ def test_z_order_reversed_flips_winner(tmp_path: Path) -> None:
         wkt_for_epsg(EPSG),
         gdal.GRA_NearestNeighbour,
         NODATA,
-        scene_a.dataset,
+        scene_a.snapshot,
         out,
     )
     band = _read_band(out)
@@ -154,7 +161,7 @@ def test_nodata_hole_in_top_reveals_lower(tmp_path: Path) -> None:
         wkt_for_epsg(EPSG),
         gdal.GRA_NearestNeighbour,
         NODATA,
-        scene_a.dataset,
+        scene_a.snapshot,
         out,
     )
     band = _read_band(out)
@@ -185,7 +192,7 @@ def test_band_count_and_metadata_round_trip(tmp_path: Path) -> None:
         wkt_for_epsg(EPSG),
         gdal.GRA_NearestNeighbour,
         NODATA,
-        band_source,
+        scene_a.snapshot,
         out,
     )
 
@@ -225,7 +232,7 @@ def test_gdal_rgb_default_bands_placeholder_is_cleared(tmp_path: Path) -> None:
         wkt_for_epsg(EPSG),
         gdal.GRA_NearestNeighbour,
         NODATA,
-        band_source,
+        scene_a.snapshot,
         out,
     )
 
@@ -257,7 +264,7 @@ def test_out_of_range_default_bands_are_dropped(tmp_path: Path) -> None:
         wkt_for_epsg(EPSG),
         gdal.GRA_NearestNeighbour,
         NODATA,
-        band_source,
+        scene_a.snapshot,
         out,
     )
 
@@ -295,6 +302,6 @@ def test_unresolved_grid_raises(tmp_path: Path) -> None:
             wkt_for_epsg(EPSG),
             gdal.GRA_NearestNeighbour,
             NODATA,
-            scene_a.dataset,
+            scene_a.snapshot,
             tmp_path / "x.img",
         )

--- a/src/tests/test_mosaic_export_gui.py
+++ b/src/tests/test_mosaic_export_gui.py
@@ -141,6 +141,38 @@ class TestMosaicExportGui(unittest.TestCase):
 
         self.test_model.close_seamless_mosaic_dialog()
 
+    def test_export_warns_on_metadata_drift_and_can_cancel(self):
+        """#677: editing a scene's dataset metadata after ingest surfaces a drift
+        warning on export; declining it aborts before the file picker."""
+        _dlg, pane, controller = self._open_with_two_scenes()
+        # Edit a scene's live dataset nodata AFTER it was added -> snapshot drift.
+        controller.get_scenes()[0].dataset.set_data_ignore_value(12345.0)
+
+        with mock.patch.object(
+            QMessageBox, "warning", return_value=QMessageBox.No
+        ) as warn, mock.patch.object(QFileDialog, "getSaveFileName") as save_dialog:
+            pane._export_button.click()
+            QTest.qWait(200)
+
+        warn.assert_called_once()  # the drift warning was shown
+        save_dialog.assert_not_called()  # declining aborted before the file picker
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_export_drift_warning_proceed_reaches_file_picker(self):
+        """#677: accepting the drift warning proceeds past it to the file picker."""
+        _dlg, pane, controller = self._open_with_two_scenes()
+        controller.get_scenes()[0].dataset.set_data_ignore_value(999.0)
+
+        with mock.patch.object(
+            QMessageBox, "warning", return_value=QMessageBox.Yes
+        ) as warn, mock.patch.object(QFileDialog, "getSaveFileName", return_value=("", "")) as save_dialog:
+            pane._export_button.click()
+            QTest.qWait(200)
+
+        warn.assert_called_once()  # the drift warning was shown
+        save_dialog.assert_called_once()  # accepting proceeded to the file picker
+        self.test_model.close_seamless_mosaic_dialog()
+
     def test_export_with_no_scenes_informs_and_writes_nothing(self):
         dlg = self.test_model.open_seamless_mosaic_dialog()
         pane = dlg.get_mosaic_pane()

--- a/src/tests/test_mosaic_materialize.py
+++ b/src/tests/test_mosaic_materialize.py
@@ -21,10 +21,12 @@ from osgeo import gdal, osr
 import tests.context  # noqa: F401  (sets up sys.path for `wiser` imports)
 
 from tests.mosaic_fixtures import make_numpy_scene, wkt_for_epsg, write_gtiff
-from wiser.raster.dataset import RasterDataSet
+from wiser.raster.dataset import RasterDataSet, find_display_bands
 from wiser.raster.dataset_impl import GTiff_GDALRasterDataImpl
+from wiser.raster.mosaic_controller import SceneMetadataSnapshot
 from wiser.raster.mosaic_materialize import (
     SceneMaterializer,
+    materialize_full_band_from_snapshot,
     materialize_to_tiled_geotiff,
     read_materialized_geotiff,
 )
@@ -172,6 +174,91 @@ def test_dedup_single_write() -> None:
         assert first == second
         tifs = list(materializer.temp_path.glob("*.tif"))
         assert len(tifs) == 1
+
+
+# -- display-only materialization (#677) -------------------------------------
+
+
+def test_build_display_source_bakes_only_display_bands(tmp_path: Path) -> None:
+    """The display-only artifact holds exactly the chosen bands, in order, with the
+    nodata preserved so the preview alpha mask still works."""
+    scene = make_numpy_scene(width=8, height=6, num_bands=5, nodata=-9999.0)
+    display_bands = (1, 3, 4)  # an arbitrary 3-of-5 selection
+
+    with SceneMaterializer() as materializer:
+        path = materializer.build_display_source(scene, display_bands)
+        ds = gdal.Open(path)
+        try:
+            assert ds.RasterCount == 3
+            assert ds.GetRasterBand(1).GetNoDataValue() == pytest.approx(-9999.0)
+            # Output band k is source band display_bands[k] (band 1/2/3 = R/G/B).
+            for out_index, src_band in enumerate(display_bands):
+                expected = np.asarray(scene.get_band_data(src_band, filter_data_ignore_value=False))
+                np.testing.assert_array_equal(ds.GetRasterBand(out_index + 1).ReadAsArray(), expected)
+        finally:
+            ds = None
+
+
+def test_build_display_source_grayscale_single_band(tmp_path: Path) -> None:
+    scene = make_numpy_scene(num_bands=4)
+    with SceneMaterializer() as materializer:
+        path = materializer.build_display_source(scene, (2,))
+        ds = gdal.Open(path)
+        try:
+            assert ds.RasterCount == 1
+            expected = np.asarray(scene.get_band_data(2, filter_data_ignore_value=False))
+            np.testing.assert_array_equal(ds.GetRasterBand(1).ReadAsArray(), expected)
+        finally:
+            ds = None
+
+
+def test_build_display_source_cache_keyed_by_bands() -> None:
+    """The display cache is keyed by (scene, display bands): same bands hit, different
+    bands produce a distinct artifact (so a remove -> edit-bands -> re-add is correct)."""
+    scene = make_numpy_scene(num_bands=3)
+    with SceneMaterializer() as materializer:
+        first = materializer.build_display_source(scene, (0, 1, 2))
+        first_again = materializer.build_display_source(scene, (0, 1, 2))
+        different = materializer.build_display_source(scene, (2, 1, 0))
+
+        assert first == first_again  # same bands -> cache hit, no new file
+        assert first != different  # different bands -> distinct artifact
+        assert len(list(materializer.temp_path.glob("*.tif"))) == 2
+
+
+def test_build_display_source_rejects_non_1_or_3_bands() -> None:
+    scene = make_numpy_scene(num_bands=3)
+    with SceneMaterializer() as materializer:
+        with pytest.raises(ValueError):
+            materializer.build_display_source(scene, (0, 1))
+
+
+# -- lazy full-band export materialization from the frozen snapshot (#677) ----
+
+
+def test_full_band_from_snapshot_pixels_live_metadata_frozen(tmp_path: Path) -> None:
+    """Export-time materialization takes pixels from the live dataset but stamps the
+    nodata / metadata from the ingest snapshot, so a later live edit does not leak in."""
+    scene = make_numpy_scene(num_bands=3, nodata=-9999.0)
+    snapshot = SceneMetadataSnapshot.from_dataset(scene, find_display_bands(scene))
+
+    # Edit the live dataset's nodata *after* freezing the snapshot.
+    scene.set_data_ignore_value(-1.0)
+
+    dest = tmp_path / "full.tif"
+    materialize_full_band_from_snapshot(scene, snapshot, dest)
+
+    ds = gdal.Open(str(dest))
+    try:
+        assert ds.RasterCount == 3
+        # nodata is the FROZEN value, not the post-ingest live edit.
+        assert ds.GetRasterBand(1).GetNoDataValue() == pytest.approx(-9999.0)
+        # pixels come from the live dataset (all bands present, in order).
+        for b in range(3):
+            expected = np.asarray(scene.get_band_data(b, filter_data_ignore_value=False))
+            np.testing.assert_array_equal(ds.GetRasterBand(b + 1).ReadAsArray(), expected)
+    finally:
+        ds = None
 
 
 def test_temp_dir_lifecycle() -> None:

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -1080,10 +1080,33 @@ class DataVisualizerApp(QMainWindow):
         else:
             self._similarity_transform_dialog.show()
 
+    def get_current_display_bands(self, dataset: RasterDataSet) -> Optional[Tuple[int, ...]]:
+        """
+        Return the display bands currently selected for ``dataset`` in the main view,
+        or ``None`` if the dataset is not currently shown there.
+
+        This is the live per-dataset band selection the user sees in the main view
+        (kept in ``RasterPane._display_bands``, mutated by the band chooser). The
+        Seamless Mosaic uses it -- in preference to the dataset's stored defaults --
+        to decide which bands to bake into a scene's display-only preview (#677),
+        honoring a user's band-chooser choice rather than silently reverting to
+        defaults. ``None`` means "never shown in the main view", in which case the
+        mosaic falls back to ``find_display_bands(dataset)``.
+
+        Exposed as a narrow public accessor so the mosaic depends on this surface
+        rather than reaching into the main view's ``RasterPane`` internals.
+        """
+        if dataset is None:
+            return None
+        return self._main_view.get_display_bands().get(dataset.get_id())
+
     def show_seamless_mosaic_dialog(self, in_test_mode=False):
         if self._seamless_mosaic_dialog is None:
             self._seamless_mosaic_dialog = SeamlessMosaicDialog(
-                self._app_state, self._app_services, parent=self
+                self._app_state,
+                self._app_services,
+                display_bands_resolver=self.get_current_display_bands,
+                parent=self,
             )
         # Non-modal: the mosaic is a long-lived, multi-step workflow (add scenes,
         # reorder, export), so it stays open alongside the main window.

--- a/src/wiser/gui/mosaic_dialog.py
+++ b/src/wiser/gui/mosaic_dialog.py
@@ -11,7 +11,7 @@ All real workflow (add scenes, reorder, choose grid/CRS/resampling, export) land
 later issues via the :class:`MosaicPane` and :class:`MosaicController`.
 """
 
-from typing import Optional
+from typing import Callable, Optional, Tuple, TYPE_CHECKING
 
 from PySide6.QtCore import *
 from PySide6.QtGui import *
@@ -22,6 +22,14 @@ from .app_services import AppServices
 from .mosaic_pane import MosaicPane
 
 from wiser.raster.mosaic_materialize import SceneMaterializer
+
+if TYPE_CHECKING:
+    from wiser.raster.dataset import RasterDataSet
+
+# Resolves a dataset to the display bands currently shown for it in the main view
+# (or None if not shown). Injected by the app so the mosaic can honor the user's live
+# band-chooser choice when baking display-only preview artifacts (#677).
+DisplayBandsResolver = Callable[["RasterDataSet"], Optional[Tuple[int, ...]]]
 
 
 class SeamlessMosaicDialog(QDialog):
@@ -37,11 +45,13 @@ class SeamlessMosaicDialog(QDialog):
         self,
         app_state: ApplicationState,
         app_services: AppServices,
+        display_bands_resolver: Optional[DisplayBandsResolver] = None,
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent=parent)
         self._app_state = app_state
         self._app_services = app_services
+        self._display_bands_resolver = display_bands_resolver
 
         self.setModal(False)
         self.setWindowTitle(self.tr("Seamless Mosaic"))
@@ -62,6 +72,7 @@ class SeamlessMosaicDialog(QDialog):
             app_state=app_state,
             app_services=app_services,
             materializer=self._materializer,
+            display_bands_resolver=display_bands_resolver,
             parent=self,
         )
 

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -672,6 +672,32 @@ class MosaicPane(QWidget):
             )
             return
 
+        # Warn (and let the user proceed) if any visible scene's live dataset metadata
+        # has drifted from the ingest-time snapshot (#677): the mosaic uses the frozen
+        # values, so a data-ignore / wavelength / display-band edit made in main WISER
+        # after the scene was added is NOT applied to the export. Data-ignore in
+        # particular is not cosmetic, so surfacing this avoids a silent surprise.
+        drifted = [scene for scene in visible if self._scene_metadata_drifted(scene)]
+        if drifted:
+            names = ", ".join(
+                scene.dataset.get_name() or f"Dataset {scene.dataset.get_id()}" for scene in drifted
+            )
+            answer = QMessageBox.warning(
+                self,
+                self.tr("Dataset metadata changed since ingest"),
+                self.tr(
+                    "These scenes were edited in WISER after being added to the mosaic:\n"
+                    "{0}\n\n"
+                    "The mosaic uses the metadata frozen when each scene was added, so "
+                    "those changes will NOT be applied to the export. Remove and re-add a "
+                    "scene to pick up its new metadata.\n\nExport anyway?"
+                ).format(names),
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if answer != QMessageBox.Yes:
+                return
+
         # Resolve the output grid first (may prompt for a target CRS), then confirm it
         # actually produced a usable extent before asking for an output path.
         if not self._ensure_common_grid():
@@ -717,6 +743,24 @@ class MosaicPane(QWidget):
             description=self.tr("Compositing mosaic…"),
             meta={"scenes": str(len(visible))},
         )
+
+    @staticmethod
+    def _scene_metadata_drifted(scene: MosaicScene) -> bool:
+        """
+        True if ``scene``'s live dataset spectral metadata (data-ignore, wavelengths,
+        default display bands) has drifted from the snapshot frozen at ingest (#677).
+
+        Compares the frozen ``SpectralMetadata`` against a freshly-read one via its
+        ``__eq__``. Any comparison error is treated as "no drift" so a metadata quirk
+        can never block an export.
+        """
+        snapshot = scene.snapshot
+        if snapshot is None:
+            return False
+        try:
+            return snapshot.spectral != scene.dataset.get_spectral_metadata()
+        except Exception:  # noqa: BLE001 - a drift check must never block export
+            return False
 
     @staticmethod
     def _resolve_output_nodata(

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -16,7 +16,7 @@ rebuild when the output geometry changes.
 """
 
 from pathlib import Path
-from typing import Optional, Sequence, TYPE_CHECKING
+from typing import Callable, Optional, Sequence, Tuple, TYPE_CHECKING
 
 from osgeo import gdal, osr
 
@@ -30,11 +30,13 @@ from .mosaic_crs_dialog import ReprojectPromptDialog
 from .mosaic_view import MosaicView
 from .progress_task import run_with_progress
 
+from wiser.raster.dataset import find_display_bands
 from wiser.raster.mosaic_controller import (
     CommonGrid,
     MosaicController,
     MosaicScene,
     ResolutionMode,
+    SceneMetadataSnapshot,
     TargetCrsRequired,
     UnmappableCrsError,
 )
@@ -55,6 +57,7 @@ if TYPE_CHECKING:
 def _ingest_scene(
     dataset: "RasterDataSet",
     materializer: "SceneMaterializer",
+    snapshot: Optional[SceneMetadataSnapshot] = None,
     progress: Optional[ProgressReporter] = None,
 ) -> MosaicScene:
     """
@@ -65,6 +68,13 @@ def _ingest_scene(
     phases (weighted by their rough cost) so the overall bar advances smoothly;
     each phase reports fine-grained progress internally. Returns the fully-populated
     :class:`MosaicScene` for the main thread to append to the controller.
+
+    ``snapshot`` is the dataset metadata **frozen at ingest** (#677), built on the GUI
+    thread in :meth:`MosaicPane._on_add_scene_clicked` (the display-band resolution and
+    the deep-copy of the dataset's metadata must both happen against the live main-view
+    / dataset state at add-time). It is carried through and stamped onto the returned
+    :class:`MosaicScene`; later steps materialize the display-only artifact and export
+    from this snapshot rather than the live dataset.
     """
     progress = progress or ProgressReporter()
     materialize_progress, overview_progress, footprint_progress = progress.split(
@@ -83,6 +93,7 @@ def _ingest_scene(
         gdal_path=gdal_path,
         footprint_wkt=footprint_wkt,
         has_overviews=True,
+        snapshot=snapshot,
     )
 
 
@@ -132,12 +143,18 @@ class MosaicPane(QWidget):
         app_state: ApplicationState,
         app_services: Optional[AppServices] = None,
         materializer: Optional["SceneMaterializer"] = None,
+        display_bands_resolver: Optional[Callable[["RasterDataSet"], Optional[Tuple[int, ...]]]] = None,
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent=parent)
         self._app_state = app_state
         self._app_services = app_services
         self._materializer = materializer
+        # Resolves a dataset to the bands currently shown for it in the main view, or
+        # None if not shown there. Used at ingest to pick the display bands baked into
+        # a scene's display-only preview (#677); falls back to find_display_bands when
+        # this is None (e.g. a bare pane in a unit test) or returns None.
+        self._display_bands_resolver = display_bands_resolver
         self._controller = MosaicController()
         # Holds the in-flight ingestion task (progress modal + background work) so it
         # is not garbage-collected mid-run; overwritten on the next add.
@@ -388,6 +405,15 @@ class MosaicPane(QWidget):
             QMessageBox.warning(self, self.tr("Cannot add scene"), str(exc))
             return
 
+        # Freeze the dataset metadata at ingest (#677) on the GUI thread: the display
+        # bands are resolved from the *live* main-view selection (GUI state, unsafe to
+        # read off-thread), and the dataset's spatial/spectral metadata is deep-copied
+        # so a mid-session edit in main WISER cannot silently alter this mosaic. The
+        # snapshot rides along to the background worker and both the display-only
+        # materialization and the lazy export stamp from it.
+        display_bands = self._resolve_display_bands(dataset)
+        snapshot = SceneMetadataSnapshot.from_dataset(dataset, display_bands)
+
         # Run the ingestion on the scheduler with a progress dialog and a mirrored
         # Activity Monitor row. Pass the window (the SeamlessMosaicDialog) as the block
         # target so only it is disabled while ingesting; the rest of WISER stays live.
@@ -398,11 +424,31 @@ class MosaicPane(QWidget):
             _ingest_scene,
             dataset,
             self._materializer,
+            snapshot,
             on_success=self._on_scene_ingested,
             on_error=self._on_scene_failed,
             description=self.tr("Materializing scene…"),
             meta={"bands": str(dataset.num_bands())},
         )
+
+    def _resolve_display_bands(self, dataset: "RasterDataSet") -> Tuple[int, ...]:
+        """
+        Resolve which display bands to bake into ``dataset``'s display-only preview,
+        per issue #677's ordering:
+
+          1. the main view's current selection for the dataset (honoring a
+             band-chooser choice), via the injected ``display_bands_resolver``;
+          2. otherwise ``find_display_bands(dataset)`` -- the robust defaults ->
+             human-eye wavelength -> first 1/3 bands fallback chain -- which also
+             covers "never shown in the main view" and "no defaults".
+
+        Runs on the GUI thread (the resolver reads live main-view state).
+        """
+        if self._display_bands_resolver is not None:
+            bands = self._display_bands_resolver(dataset)
+            if bands:
+                return tuple(int(b) for b in bands)
+        return tuple(int(b) for b in find_display_bands(dataset))
 
     def _on_scene_ingested(self, scene: MosaicScene) -> None:
         self._controller.add_scene(scene)

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -112,7 +112,7 @@ def _export_mosaic_task(
     target_wkt: str,
     resample_alg: int,
     output_nodata: Optional[float],
-    band_metadata_dataset: Optional["RasterDataSet"],
+    band_metadata_snapshot: Optional[SceneMetadataSnapshot],
     out_path: str,
     progress: Optional[ProgressReporter] = None,
 ) -> str:
@@ -121,9 +121,10 @@ def _export_mosaic_task(
     grid and stream the mosaic to ``out_path`` as ENVI.
 
     Runs on a scheduler thread (no Qt here). Delegates to the Qt-free
-    :func:`wiser.raster.mosaic_export.export_mosaic` and returns the written path as
-    a string for the main thread's success callback. The result is intentionally
-    *not* loaded back into WISER — the user opens the file manually.
+    :func:`wiser.raster.mosaic_export.export_mosaic`, which lazily materializes each
+    scene's full-band cube from the live dataset + frozen snapshot (#677), and returns
+    the written path as a string for the main thread's success callback. The result is
+    intentionally *not* loaded back into WISER — the user opens the file manually.
     """
     result = export_mosaic(
         scenes,
@@ -131,7 +132,7 @@ def _export_mosaic_task(
         target_wkt,
         resample_alg,
         output_nodata,
-        band_metadata_dataset,
+        band_metadata_snapshot,
         Path(out_path),
         progress=progress,
     )
@@ -694,8 +695,8 @@ class MosaicPane(QWidget):
             return
 
         band_source = self._controller.get_band_metadata_source()
-        band_metadata_dataset = band_source.dataset if band_source is not None else None
-        output_nodata = self._resolve_output_nodata(band_metadata_dataset, visible)
+        band_metadata_snapshot = band_source.snapshot if band_source is not None else None
+        output_nodata = self._resolve_output_nodata(band_source, visible)
 
         # Snapshot the controller state on the GUI thread and hand the heavy work to a
         # scheduler thread; block only the mosaic dialog while it runs.
@@ -709,7 +710,7 @@ class MosaicPane(QWidget):
             target_wkt=self._controller.get_target_crs(),
             resample_alg=self._controller.get_resample_alg(),
             output_nodata=output_nodata,
-            band_metadata_dataset=band_metadata_dataset,
+            band_metadata_snapshot=band_metadata_snapshot,
             out_path=path,
             on_success=self._on_export_finished,
             on_error=self._on_export_failed,
@@ -719,22 +720,26 @@ class MosaicPane(QWidget):
 
     @staticmethod
     def _resolve_output_nodata(
-        band_metadata_dataset: Optional["RasterDataSet"],
+        band_source: Optional[MosaicScene],
         visible_scenes: Sequence[MosaicScene],
     ) -> Optional[float]:
         """
-        Pick the output Data Ignore Value: the canonical band-metadata dataset's if it
-        has one, else the top-most visible scene that has one (top → bottom), else
-        ``None`` (no scene defines a nodata, so nodata compositing is a no-op).
+        Pick the output Data Ignore Value from the **frozen** per-scene snapshots
+        (#677): the canonical band-metadata scene's if it has one, else the top-most
+        visible scene that has one (top → bottom), else ``None`` (no scene defines a
+        nodata, so nodata compositing is a no-op).
+
+        Reading the frozen value (not the live dataset) keeps the export deterministic:
+        it matches the nodata baked into the footprint / common grid at ingest.
         """
-        if band_metadata_dataset is not None:
-            nodata = band_metadata_dataset.get_data_ignore_value()
+        if band_source is not None and band_source.snapshot is not None:
+            nodata = band_source.snapshot.data_ignore_value
             if nodata is not None:
                 return nodata
         for scene in reversed(list(visible_scenes)):
-            nodata = scene.dataset.get_data_ignore_value()
-            if nodata is not None:
-                return nodata
+            snapshot = scene.snapshot
+            if snapshot is not None and snapshot.data_ignore_value is not None:
+                return snapshot.data_ignore_value
         return None
 
     def _on_export_finished(self, out_path: str) -> None:

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -61,8 +61,9 @@ def _ingest_scene(
     progress: Optional[ProgressReporter] = None,
 ) -> MosaicScene:
     """
-    Background I/O for one scene: materialize to a warpable temp GeoTIFF, build
-    internal overviews on it, and compute the valid-pixel footprint.
+    Background I/O for one scene: materialize the **display-only** warpable temp
+    GeoTIFF (just the frozen display bands), build internal overviews on it, and
+    compute the valid-pixel footprint.
 
     Runs on a scheduler thread (no Qt here). ``progress`` is split across the three
     phases (weighted by their rough cost) so the overall bar advances smoothly;
@@ -72,17 +73,25 @@ def _ingest_scene(
     ``snapshot`` is the dataset metadata **frozen at ingest** (#677), built on the GUI
     thread in :meth:`MosaicPane._on_add_scene_clicked` (the display-band resolution and
     the deep-copy of the dataset's metadata must both happen against the live main-view
-    / dataset state at add-time). It is carried through and stamped onto the returned
-    :class:`MosaicScene`; later steps materialize the display-only artifact and export
-    from this snapshot rather than the live dataset.
+    / dataset state at add-time). Its ``display_bands`` are what gets baked into the
+    display-only artifact -- so overviews and the footprint are computed on a file with
+    only 1--3 bands, which is the whole speedup -- and it is stamped onto the returned
+    :class:`MosaicScene` for the lazy full-band export to read from. When ``snapshot``
+    is ``None`` (a direct caller bypassing the GUI path) it is frozen here from the
+    live dataset so the scene still carries one.
     """
+    if snapshot is None:
+        snapshot = SceneMetadataSnapshot.from_dataset(dataset, find_display_bands(dataset))
+
     progress = progress or ProgressReporter()
     materialize_progress, overview_progress, footprint_progress = progress.split(
-        (0.5, "Materializing scene"),
+        (0.5, "Materializing display bands"),
         (0.35, "Building overviews"),
         (0.15, "Computing footprint"),
     )
-    gdal_path = materializer.gdal_source(dataset, progress=materialize_progress)
+    gdal_path = materializer.build_display_source(
+        dataset, snapshot.display_bands, progress=materialize_progress
+    )
     progress.raise_if_cancelled()
     build_overviews(gdal_path, progress=overview_progress)
     progress.raise_if_cancelled()

--- a/src/wiser/raster/mosaic_compositor.py
+++ b/src/wiser/raster/mosaic_compositor.py
@@ -25,7 +25,7 @@ existing warp seam :func:`wiser.raster.mosaic_controller._warped_resolution`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, Tuple
+from typing import TYPE_CHECKING, Tuple
 
 import numpy as np
 from osgeo import gdal
@@ -53,9 +53,12 @@ def render_scene_argb(
     an ``(out_height, out_width, 4)`` uint8 RGBA array.
 
     ``world_extent`` is ``(min_x, min_y, max_x, max_y)`` in the target CRS (the
-    view's visible world rectangle). RGB comes from the dataset's default display
-    bands (1 band -> grayscale, 3 bands -> RGB), contrast-stretched per band over the
-    valid pixels; alpha is the warp's validity mask (0 on nodata / outside coverage).
+    view's visible world rectangle). ``scene.gdal_path`` is the **display-only**
+    artifact (#677) whose bands already *are* the resolved display bands, so RGB is
+    read straight from bands 1..N in order (1 band -> grayscale, 3 bands -> RGB) --
+    the "which source bands" decision was made upstream at materialize time, not here.
+    Each band is contrast-stretched over the valid pixels; alpha is the warp's
+    validity mask (0 on nodata / outside coverage).
 
     A scene whose data does not cover ``world_extent`` comes back fully transparent
     (alpha all 0), so callers can render it unconditionally.
@@ -95,46 +98,25 @@ def render_scene_argb(
         # No data bands, or nothing valid in view: leave RGB black, alpha as computed.
         return rgba
 
-    display_bands = _select_display_bands(scene, num_data_bands)
+    # The display-only artifact holds exactly the display bands (1 or 3), so read them
+    # all, in order -- band 1/2/3 are R/G/B. Cap at 3 defensively; a well-formed
+    # display-only file never has more.
     channels = [
         _stretch_band(
             warped.GetRasterBand(band_idx + 1).ReadAsArray().astype(np.float32),
             valid,
         )
-        for band_idx in display_bands
+        for band_idx in range(min(num_data_bands, 3))
     ]
 
-    if len(channels) == 1:  # grayscale: replicate into R=G=B
+    if len(channels) == 1:  # grayscale (single display band): replicate into R=G=B
         rgba[:, :, 0] = rgba[:, :, 1] = rgba[:, :, 2] = channels[0]
-    else:
+    else:  # bands are already R, G, B
         rgba[:, :, 0], rgba[:, :, 1], rgba[:, :, 2] = channels[0], channels[1], channels[2]
     # Force invalid pixels fully clear (0, 0, 0, 0) so RGB never bleeds under a
     # transparent alpha (the flat-band stretch otherwise whitens them).
     rgba[~valid, :3] = 0
     return rgba
-
-
-def _select_display_bands(scene: "MosaicScene", num_data_bands: int) -> Sequence[int]:
-    """
-    Pick the 0-based source band indices to render as RGB (or 1 for grayscale).
-
-    Prefers the dataset's default display bands; falls back to the first three bands
-    (or the single band) and clamps any out-of-range index defensively.
-    """
-    bands = None
-    getter = getattr(scene.dataset, "get_default_display_bands", None)
-    if getter is not None:
-        try:
-            bands = getter()
-        except Exception:  # noqa: BLE001 - metadata access must never break a paint
-            bands = None
-
-    if not bands:
-        bands = (0,) if num_data_bands < 3 else (0, 1, 2)
-    # Grayscale if a single band was chosen or the scene only has one band.
-    if len(bands) == 1 or num_data_bands < 3:
-        return (min(int(bands[0]), num_data_bands - 1),)
-    return tuple(min(int(b), num_data_bands - 1) for b in bands[:3])
 
 
 def _stretch_band(band: np.ndarray, valid: np.ndarray) -> np.ndarray:

--- a/src/wiser/raster/mosaic_controller.py
+++ b/src/wiser/raster/mosaic_controller.py
@@ -21,6 +21,7 @@ renders last (top) and wins z-order overlap.
 
 from __future__ import annotations
 
+import copy
 import enum
 import math
 from dataclasses import dataclass, field
@@ -31,9 +32,12 @@ from osgeo import gdal, ogr, osr
 from wiser.raster.utils import can_transform_between_srs
 
 if TYPE_CHECKING:
-    # Type-only import; RasterDataSet is itself Qt-free, but keeping this under
-    # TYPE_CHECKING avoids any runtime import cost and keeps the seam obvious.
-    from wiser.raster.dataset import RasterDataSet
+    # Type-only imports. ``wiser.raster.dataset`` pulls in Qt at import time (via
+    # ``dataset_editor_dialog``), so keeping these under TYPE_CHECKING is what keeps
+    # this controller Qt-free and unit-testable without a running application. The
+    # snapshot below is built by calling the dataset's own metadata accessors +
+    # ``copy.deepcopy``, so it never needs these classes at runtime.
+    from wiser.raster.dataset import RasterDataSet, SpatialMetadata, SpectralMetadata
 
 
 class TargetCrsRequired(Exception):
@@ -72,6 +76,100 @@ class ResolutionMode(enum.Enum):
 
 
 @dataclass
+class SceneMetadataSnapshot:
+    """
+    The dataset metadata **frozen at ingest** for one mosaic scene (issue #677).
+
+    ``RasterDataSet`` metadata (data-ignore value, wavelengths / band names, default
+    display bands, geotransform, SRS, …) can be edited in main WISER (via
+    ``dataset_editor_dialog.py``) while the mosaic dialog is open, and
+    ``RasterDataSet`` emits no change signal. To keep a mosaic session deterministic,
+    the dataset's metadata is snapshotted onto the :class:`MosaicScene` at ingest and
+    both the display-only preview materialization and the lazy full-band export
+    materialization stamp **from this snapshot**, never from the live dataset. Export
+    additionally compares the live dataset against this snapshot and warns the user if
+    it has drifted (a cheap ``==`` on the metadata objects, which both implement it).
+
+    Rather than re-enumerate individual fields, this houses the dataset's own
+    :class:`~wiser.raster.dataset.SpatialMetadata` and
+    :class:`~wiser.raster.dataset.SpectralMetadata` value objects — which already
+    carry the full spatial (geotransform, SRS) and spectral (band info, bad bands,
+    default display bands, nodata, wavelengths + units, band count) picture — plus:
+
+      * ``display_bands`` — the resolved 0-based band indices (a 1- or 3-tuple) shown
+        for this scene, resolved at ingest from the main view's current selection or
+        :func:`~wiser.raster.dataset.find_display_bands`. This is **GUI state, not
+        dataset state**, so it lives here rather than inside the spectral metadata: it
+        is the bands baked into the display-only artifact (band 1/2/3 *are* R/G/B) and
+        the canonical display-band choice for export.
+
+    The spatial/spectral objects are **deep-copied** at construction so later live
+    edits to the dataset cannot mutate the snapshot (``get_spectral_metadata`` shares
+    the dataset's internal ``band_info`` list by reference, so a shallow copy would
+    not be safe). Treated as immutable by convention thereafter.
+    """
+
+    spatial: "SpatialMetadata"
+    spectral: "SpectralMetadata"
+    display_bands: Tuple[int, ...]
+
+    @classmethod
+    def from_dataset(
+        cls,
+        dataset: "RasterDataSet",
+        display_bands: Tuple[int, ...],
+    ) -> "SceneMetadataSnapshot":
+        """
+        Build a snapshot from ``dataset`` and the already-resolved ``display_bands``.
+
+        ``display_bands`` is resolved by the caller (the GUI ingest path) from the
+        main view's current selection or :func:`~wiser.raster.dataset.find_display_bands`
+        — it is intentionally *not* read from the dataset here, since the displayed
+        bands are GUI state, not dataset state. The spatial and spectral metadata are
+        read from the ``RasterDataSet`` object and **deep-copied** so later live edits
+        cannot mutate the snapshot.
+        """
+        return cls(
+            spatial=copy.deepcopy(dataset.get_spatial_metadata()),
+            spectral=copy.deepcopy(dataset.get_spectral_metadata()),
+            display_bands=tuple(int(b) for b in display_bands),
+        )
+
+    # -- convenience accessors (delegate to the housed value objects) ----------
+    #
+    # Later steps (display-only materialize #677-step4, lazy full-band export
+    # #677-step7) read these; exposing them here keeps those call sites readable.
+
+    @property
+    def geo_transform(self) -> Tuple[float, float, float, float, float, float]:
+        return self.spatial.get_geo_transform()
+
+    @property
+    def wkt_spatial_reference(self) -> Optional[str]:
+        return self.spatial.get_wkt_spatial_reference()
+
+    @property
+    def data_ignore_value(self):
+        return self.spectral.get_data_ignore_value()
+
+    @property
+    def band_info(self):
+        return self.spectral.get_band_info()
+
+    @property
+    def bad_bands(self):
+        return self.spectral.get_bad_bands()
+
+    @property
+    def default_display_bands(self):
+        return self.spectral.get_default_display_bands()
+
+    @property
+    def num_bands(self) -> int:
+        return self.spectral.get_num_bands()
+
+
+@dataclass
 class MosaicScene:
     """
     One scene in the mosaic.
@@ -82,12 +180,17 @@ class MosaicScene:
       * ``gdal_path`` — the materialized, warpable tiled GeoTIFF (a WISER-owned temp
         copy from :class:`~wiser.raster.mosaic_materialize.SceneMaterializer`; the
         user's opened dataset is never modified). Overviews are built *internally*
-        into this same file, so there is exactly one artifact file per scene.
+        into this same file, so there is exactly one artifact file per scene. Since
+        #677 this is the **display-only** artifact (just the 1 or 3 display bands),
+        which is what the preview compositor reads; the full-band GeoTIFF is
+        materialized lazily at export time and is not stored here.
       * ``footprint_wkt`` — the valid-pixel polygon as WKT in the dataset's own CRS.
       * ``has_overviews`` — whether pyramid overviews were built on ``gdal_path``.
+      * ``snapshot`` — the dataset metadata frozen at ingest (#677); see
+        :class:`SceneMetadataSnapshot`. ``None`` on a bare scaffolding scene.
 
-    All three default to ``None``/``False`` so a bare ``MosaicScene(dataset=...)``
-    (as used by the scaffolding tests) is still valid.
+    All artifact fields default to ``None``/``False`` so a bare
+    ``MosaicScene(dataset=...)`` (as used by the scaffolding tests) is still valid.
     """
 
     dataset: "RasterDataSet"
@@ -95,6 +198,7 @@ class MosaicScene:
     gdal_path: Optional[str] = None
     footprint_wkt: Optional[str] = None
     has_overviews: bool = False
+    snapshot: Optional[SceneMetadataSnapshot] = None
 
 
 @dataclass

--- a/src/wiser/raster/mosaic_export.py
+++ b/src/wiser/raster/mosaic_export.py
@@ -47,11 +47,11 @@ from typing import List, Optional, Sequence, TYPE_CHECKING
 from osgeo import gdal
 
 from wiser.raster.loaders import envi
+from wiser.raster.mosaic_materialize import materialize_full_band_from_snapshot
 from wiser.utils.progress import ProgressReporter, gdal_progress_callback
 
 if TYPE_CHECKING:
-    from wiser.raster.dataset import RasterDataSet
-    from wiser.raster.mosaic_controller import CommonGrid, MosaicScene
+    from wiser.raster.mosaic_controller import CommonGrid, MosaicScene, SceneMetadataSnapshot
 
 
 class MosaicExportError(RuntimeError):
@@ -64,7 +64,7 @@ def export_mosaic(
     target_wkt: str,
     resample_alg: int,
     output_nodata: Optional[float],
-    band_metadata_dataset: Optional["RasterDataSet"],
+    band_metadata_snapshot: Optional["SceneMetadataSnapshot"],
     out_path: Path,
     progress: Optional[ProgressReporter] = None,
 ) -> Path:
@@ -73,14 +73,20 @@ def export_mosaic(
     ``out_path`` as an ENVI raster. Returns ``out_path``.
 
     ``scenes`` must be the visible scenes in **bottom-to-top** z-order (the order
-    :meth:`MosaicController.get_scenes` returns, filtered to visible), each with a
-    materialized ``gdal_path``. ``grid`` is the resolved
-    :class:`~wiser.raster.mosaic_controller.CommonGrid` (extent + width/height in
+    :meth:`MosaicController.get_scenes` returns, filtered to visible), each carrying
+    its ingest-time :class:`~wiser.raster.mosaic_controller.SceneMetadataSnapshot`.
+    Each scene's **full-band** GeoTIFF is materialized here, lazily, from the live
+    ``scene.dataset`` pixels but stamped with the frozen ``scene.snapshot`` metadata
+    (#677) -- so a mid-session metadata edit never silently alters the exported
+    product, and the export stays aligned with the frozen footprint / common grid.
+    The scenes' display-only preview ``gdal_path`` is intentionally *not* used here.
+
+    ``grid`` is the resolved :class:`CommonGrid` (extent + width/height in
     ``target_wkt`` units). ``resample_alg`` is a ``gdal.GRA_*`` constant.
-    ``output_nodata`` is the Data Ignore Value carried through to the output (and
-    used to mark invalid pixels for compositing); ``None`` disables nodata handling
-    (only sensible when no scene has a nodata value). ``band_metadata_dataset`` is
-    the scene dataset whose canonical band metadata is stamped onto the output.
+    ``output_nodata`` is the Data Ignore Value carried through to the output (and used
+    to mark invalid pixels for compositing); ``None`` disables nodata handling.
+    ``band_metadata_snapshot`` is the frozen snapshot whose canonical band metadata is
+    stamped onto the output header.
 
     Nothing is loaded back into the running application; the caller owns the file.
     """
@@ -94,24 +100,38 @@ def export_mosaic(
 
     out_path = Path(out_path)
 
-    # Warping to lazy VRTs is cheap (no pixels); the streamed ENVI write is the
-    # heavy phase, so give it the bulk of the progress range.
-    prep, compose = progress.split((0.1, "Preparing scenes"), (0.9, "Compositing mosaic"))
+    # Materializing each scene's full band cube is the heavy per-scene phase; the
+    # streamed ENVI compose is the heavy shared phase. Split the bar roughly evenly.
+    prep, compose = progress.split((0.5, "Preparing scenes"), (0.5, "Compositing mosaic"))
 
-    # The warped VRTs reference the composited output only until the streamed write
+    # The full-band tiffs and warped VRTs are referenced only until the streamed write
     # completes inside gdal.Run, so a temp dir scoped around the mosaic call is enough.
     with tempfile.TemporaryDirectory(prefix="wiser_mosaic_export_") as tmp_str:
         tmp_dir = Path(tmp_str)
         vrt_paths: List[str] = []
         total = len(scenes)
-        for i, scene in enumerate(scenes):
+        # One equal progress slice per scene (materialize + warp); split normalizes.
+        scene_progs = prep.split_weights([(1.0, "Preparing scene") for _ in range(total)])
+        for i, (scene, scene_prog) in enumerate(zip(scenes, scene_progs)):
             progress.raise_if_cancelled()
+            snapshot = scene.snapshot
+            if snapshot is None:
+                raise MosaicExportError("A scene is missing its ingest metadata snapshot; cannot export.")
+            # Lazily materialize the full-band cube (uncached) from live pixels + frozen
+            # metadata, then warp that onto the common grid as a lazy VRT.
+            full_band_path = tmp_dir / f"scene_{i}_full.tif"
+            materialize_full_band_from_snapshot(scene.dataset, snapshot, full_band_path, progress=scene_prog)
             vrt = _warp_scene_to_grid_vrt(
-                scene, grid, target_wkt, resample_alg, output_nodata, tmp_dir / f"scene_{i}.vrt"
+                str(full_band_path),
+                snapshot,
+                grid,
+                target_wkt,
+                resample_alg,
+                output_nodata,
+                tmp_dir / f"scene_{i}.vrt",
             )
             if vrt is not None:
                 vrt_paths.append(vrt)
-            prep.report(i + 1, total, "Preparing scenes")
 
         if not vrt_paths:
             raise MosaicExportError("No scenes overlap the output grid; nothing to export.")
@@ -122,13 +142,14 @@ def export_mosaic(
     # The pixels are fully written; patch the text header with canonical band
     # metadata so the file re-opens in WISER with the right spectral labels.
     progress.raise_if_cancelled()
-    _patch_envi_band_metadata(out_path, band_metadata_dataset, output_nodata)
+    _patch_envi_band_metadata(out_path, band_metadata_snapshot, output_nodata)
 
     return out_path
 
 
 def _warp_scene_to_grid_vrt(
-    scene: "MosaicScene",
+    src_path: str,
+    snapshot: "SceneMetadataSnapshot",
     grid: "CommonGrid",
     target_wkt: str,
     resample_alg: int,
@@ -136,23 +157,17 @@ def _warp_scene_to_grid_vrt(
     vrt_path: Path,
 ) -> Optional[str]:
     """
-    Warp one scene's materialized GeoTIFF onto the common grid as a lazy warped
-    VRT, returning its path (or ``None`` if the scene does not overlap the grid).
+    Warp one scene's full-band GeoTIFF (at ``src_path``) onto the common grid as a
+    lazy warped VRT, returning its path (or ``None`` if it does not overlap the grid).
 
-    The scene's own Data Ignore Value becomes the warp source nodata (so its
-    invalid pixels stay invalid), and ``output_nodata`` becomes the destination
-    nodata (so outside-footprint fill is marked invalid for the compositor and the
-    final output nodata is consistent).
+    The scene's **frozen** Data Ignore Value (from ``snapshot``) becomes the warp
+    source nodata (so its invalid pixels stay invalid), and ``output_nodata`` becomes
+    the destination nodata (so outside-footprint fill is marked invalid for the
+    compositor and the final output nodata is consistent).
     """
     min_x, min_y, max_x, max_y = grid.extent
 
-    src_nodata: Optional[float] = None
-    getter = getattr(scene.dataset, "get_data_ignore_value", None)
-    if getter is not None:
-        try:
-            src_nodata = getter()
-        except Exception:  # noqa: BLE001 - metadata access must not break export
-            src_nodata = None
+    src_nodata = snapshot.data_ignore_value
 
     warp_kwargs = dict(
         format="VRT",
@@ -168,7 +183,7 @@ def _warp_scene_to_grid_vrt(
     if output_nodata is not None:
         warp_kwargs["dstNodata"] = output_nodata
 
-    warped = gdal.Warp(str(vrt_path), scene.gdal_path, **warp_kwargs)
+    warped = gdal.Warp(str(vrt_path), src_path, **warp_kwargs)
     if warped is None:
         # Warp can decline when the output window is fully disjoint from the source;
         # that scene simply contributes nothing to the mosaic.
@@ -205,13 +220,14 @@ def _run_raster_mosaic(
 
 def _patch_envi_band_metadata(
     out_path: Path,
-    band_metadata_dataset: Optional["RasterDataSet"],
+    band_metadata_snapshot: Optional["SceneMetadataSnapshot"],
     output_nodata: Optional[float],
 ) -> None:
     """
     Rewrite the GDAL-written ENVI header for ``out_path`` in place, stamping the
     canonical band metadata (wavelengths / units / band names / bad-band list /
-    default display bands) and the output nodata.
+    default display bands) from the frozen ``band_metadata_snapshot`` (#677) and the
+    output nodata.
 
     ``gdal raster mosaic`` writes correct pixels, geotransform, and ``map info``,
     but no spectral metadata, so this fills that in using WISER's own ENVI header
@@ -222,7 +238,7 @@ def _patch_envi_band_metadata(
     hdr_filename, _img_filename = envi.find_envi_filenames(str(out_path))
     metadata = envi.load_envi_header(hdr_filename)
 
-    _apply_band_metadata(metadata, band_metadata_dataset)
+    _apply_band_metadata(metadata, band_metadata_snapshot)
 
     if output_nodata is not None:
         metadata["data ignore value"] = output_nodata
@@ -230,7 +246,7 @@ def _patch_envi_band_metadata(
     envi.write_envi_header(hdr_filename, metadata)
 
 
-def _resolve_default_bands(band_metadata_dataset: Optional["RasterDataSet"]) -> Optional[list]:
+def _resolve_default_bands(band_metadata_snapshot: Optional["SceneMetadataSnapshot"]) -> Optional[list]:
     """
     Choose the ``default bands`` (0-based band indices) to write to the export header,
     or ``None`` to omit them entirely.
@@ -238,41 +254,43 @@ def _resolve_default_bands(band_metadata_dataset: Optional["RasterDataSet"]) -> 
     ``gdal raster mosaic`` writes a **1-based** ``default bands`` placeholder (e.g.
     ``{1, 2, 3}`` for RGB inputs). WISER reads ``default bands`` verbatim -- it does no
     1-based->0-based conversion and no bounds check -- so leaving GDAL's placeholder (or
-    stamping an out-of-range source value) makes the exported file crash the raster view
-    on open (``Illegal band #``). We therefore keep the canonical source's default
-    display bands only when every index is in range for the output, and otherwise clear
-    the field so WISER derives display bands from the stamped wavelengths (truecolor) or
-    the first bands.
+    stamping an out-of-range value) makes the exported file crash the raster view on
+    open (``Illegal band #``). We therefore use the snapshot's frozen resolved
+    ``display_bands`` (the canonical display choice) only when every index is in range
+    for the output, and otherwise clear the field so WISER derives display bands from
+    the stamped wavelengths (truecolor) or the first bands.
     """
-    if band_metadata_dataset is None:
+    if band_metadata_snapshot is None:
         return None
-    defaults = band_metadata_dataset.default_display_bands()
-    num_bands = band_metadata_dataset.num_bands()
+    defaults = band_metadata_snapshot.display_bands
+    num_bands = band_metadata_snapshot.num_bands
     if defaults and all(0 <= int(band) < num_bands for band in defaults):
         return list(defaults)
     return None
 
 
-def _apply_band_metadata(metadata: dict, band_metadata_dataset: Optional["RasterDataSet"]) -> None:
+def _apply_band_metadata(metadata: dict, band_metadata_snapshot: Optional["SceneMetadataSnapshot"]) -> None:
     """
-    Merge the canonical band metadata from ``band_metadata_dataset`` into an ENVI
+    Merge the canonical band metadata from ``band_metadata_snapshot`` into an ENVI
     header ``metadata`` dict, mirroring the per-band conventions of
     :meth:`ENVI_GDALRasterDataImpl.save_dataset_as` (default display bands, band names,
     wavelength / wavelength units, ``bbl``).
 
-    ``band_metadata_dataset`` may be ``None`` (no canonical source); even then the
+    ``band_metadata_snapshot`` may be ``None`` (no canonical source); even then the
     ``default bands`` field is resolved -- see below -- so this is always called.
     """
     # Always resolve `default bands` explicitly (see _resolve_default_bands): GDAL's
     # ENVI writer stamps a 1-based placeholder that WISER cannot read, so it must be
     # replaced or cleared here regardless of whether we have a band-metadata source.
-    metadata["default bands"] = _resolve_default_bands(band_metadata_dataset)
+    metadata["default bands"] = _resolve_default_bands(band_metadata_snapshot)
 
-    if band_metadata_dataset is None:
+    if band_metadata_snapshot is None:
         return
 
-    band_info = band_metadata_dataset.band_list()
-    num_bands = band_metadata_dataset.num_bands()
+    # snapshot.band_info is a deep copy of the source dataset's band_list() (identical
+    # shape), so the same key access applies band-for-band.
+    band_info = band_metadata_snapshot.band_info
+    num_bands = band_metadata_snapshot.num_bands
 
     names: List[str] = []
     wavelengths: List[str] = []
@@ -297,6 +315,6 @@ def _apply_band_metadata(metadata: dict, band_metadata_dataset: Optional["Raster
             metadata["wavelength units"] = envi.wiser_unitstr_to_envi_str(units)
 
     # Bad-band list (bbl): only meaningful when at least one band is flagged bad.
-    bad_bands = band_metadata_dataset.get_bad_bands()
+    bad_bands = band_metadata_snapshot.bad_bands
     if bad_bands and 0 in bad_bands:
         metadata["bbl"] = list(bad_bands)

--- a/src/wiser/raster/mosaic_materialize.py
+++ b/src/wiser/raster/mosaic_materialize.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 import tempfile
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence, Tuple
 
 import numpy as np
 from osgeo import gdal, gdal_array
@@ -204,6 +204,136 @@ def materialize_to_tiled_geotiff(
     )
 
 
+def _stamp_display_only_metadata(
+    gdal_dataset: gdal.Dataset,
+    source_dataset: RasterDataSet,
+    display_bands: Tuple[int, ...],
+) -> None:
+    """
+    Stamp metadata onto a **display-only** artifact whose bands are, in order, the
+    source dataset's ``display_bands``.
+
+    Like :func:`_stamp_metadata_from_dataset` this copies geotransform + SRS from the
+    ``RasterDataSet`` and the nodata value onto every output band (so the alpha /
+    validity mask still works in the preview compositor). It differs in that per-band
+    spectral metadata is **band-remapped**: output band ``k`` carries the wavelength /
+    name of source band ``display_bands[k]``. ``DEFAULT_BANDS`` is written as the
+    identity mapping because bands 1..N of this file *are* the display bands (band
+    1/2/3 = R/G/B) -- there is no longer an N-of-M selection to record. The bad-band
+    list is intentionally omitted: it is defined over the full band set and is
+    meaningless for a 1/3-band display slice.
+    """
+    geo_transform = source_dataset.get_geo_transform()
+    if geo_transform is not None:
+        gdal_dataset.SetGeoTransform([float(v) for v in geo_transform])
+
+    wkt = source_dataset.get_wkt_spatial_reference()
+    if wkt:
+        gdal_dataset.SetProjection(wkt)
+
+    nodata = source_dataset.get_data_ignore_value()
+    if nodata is not None:
+        for i in range(1, gdal_dataset.RasterCount + 1):
+            gdal_dataset.GetRasterBand(i).SetNoDataValue(float(nodata))
+
+    band_info = source_dataset.band_list()
+    for out_index, src_band in enumerate(display_bands):
+        band = gdal_dataset.GetRasterBand(out_index + 1)
+        info = band_info[src_band] if 0 <= src_band < len(band_info) else {}
+
+        name = info.get("wavelength_name")
+        if name is not None:
+            band.SetDescription(str(name))
+
+        value, units = _band_wavelength_value_and_units(info)
+        if value is not None:
+            band.SetMetadataItem("wavelength", str(value))
+        if units is not None:
+            band.SetMetadataItem("wavelength_units", str(units))
+
+    # Identity default bands (0-based): this file's bands already *are* the display
+    # bands, so grayscale is {0} and RGB is {0,1,2}.
+    identity = range(gdal_dataset.RasterCount)
+    gdal_dataset.SetMetadataItem("DEFAULT_BANDS", ",".join(str(b) for b in identity))
+
+
+def materialize_display_only_to_tiled_geotiff(
+    dataset: RasterDataSet,
+    dest_path: Path,
+    display_bands: Sequence[int],
+    progress: Optional[ProgressReporter] = None,
+) -> None:
+    """
+    Write a **display-only** tiled GeoTIFF at ``dest_path`` containing only the source
+    dataset's ``display_bands`` (a 1- or 3-tuple of 0-based band indices), in order.
+
+    This is the preview artifact for the mosaic pixel layer (#677): the compositor only
+    ever reads the display bands, so baking just those bands makes every warp and every
+    overview level touch 1--3 bands instead of all N -- a large speedup for
+    hyperspectral scenes. Because the file physically contains only the display bands,
+    band selection moves from read time to materialize time: bands 1/2/3 *are* R/G/B.
+
+    The nodata value is preserved on each output band so the warp's alpha (validity
+    mask) still works. Data/metadata are sourced from the ``RasterDataSet`` object (not
+    its on-disk backing), and bands are written one at a time to bound peak memory.
+
+    ``progress`` reports per-output-band completion; it defaults to a no-op reporter.
+    """
+    progress = progress or ProgressReporter()
+    gdal.UseExceptions()
+
+    display_bands = tuple(int(b) for b in display_bands)
+    if len(display_bands) not in (1, 3):
+        raise ValueError(f"display_bands must contain 1 or 3 band indices; got {display_bands!r}")
+
+    width = dataset.get_width()
+    height = dataset.get_height()
+    num_out_bands = len(display_bands)
+    gdal_type, write_dtype = _gdal_type_and_write_dtype(dataset.get_elem_type())
+
+    driver = gdal.GetDriverByName("GTiff")
+    options = [
+        "TILED=YES",
+        f"BLOCKXSIZE={_BLOCK_SIZE}",
+        f"BLOCKYSIZE={_BLOCK_SIZE}",
+    ]
+
+    out_ds: Optional[gdal.Dataset] = driver.Create(
+        str(dest_path), width, height, num_out_bands, gdal_type, options=options
+    )
+    if out_ds is None:
+        raise RuntimeError(f"GDAL failed to create display-only GeoTIFF at {dest_path}")
+
+    try:
+        # Write one output band at a time, reading the corresponding source band, to
+        # keep peak memory to a single (height, width) band.
+        for out_index, src_band in enumerate(display_bands):
+            progress.raise_if_cancelled()
+            # filter_data_ignore_value=False keeps the raw values (including the nodata
+            # sentinel) so the materialized file mirrors the source and nodata masking
+            # stays exact.
+            band_arr = dataset.get_band_data(src_band, filter_data_ignore_value=False)
+            band_arr = np.asarray(band_arr, dtype=write_dtype)
+            out_ds.GetRasterBand(out_index + 1).WriteArray(band_arr)
+            del band_arr
+            progress.report(out_index + 1, num_out_bands, "Materializing display bands")
+
+        _stamp_display_only_metadata(out_ds, dataset, display_bands)
+        out_ds.FlushCache()
+    finally:
+        out_ds = None
+
+    logger.info(
+        "Materialized display-only GeoTIFF for dataset id=%s to %s (%dx%d, bands %s of %d)",
+        dataset.get_id(),
+        dest_path,
+        width,
+        height,
+        display_bands,
+        dataset.num_bands(),
+    )
+
+
 def read_materialized_geotiff(path: Path) -> RasterDataSet:
     """
     Reconstruct a :class:`RasterDataSet` from a GeoTIFF written by
@@ -259,8 +389,12 @@ class SceneMaterializer:
         root = temp_dir()
         root.mkdir(parents=True, exist_ok=True)
         self._tmp = tempfile.TemporaryDirectory(dir=str(root), prefix="mosaic_")
-        # Maps a scene key (dataset id, else object identity) to its temp .tif.
+        # Maps a scene key (dataset id, else object identity) to its full-band temp .tif.
         self._cache: Dict[int, Path] = {}
+        # Maps (scene key, display-band tuple) to its display-only temp .tif (#677). The
+        # session cache holds display-only artifacts; the full-band GeoTIFF is
+        # materialized on demand at export and is intentionally not cached here.
+        self._display_cache: Dict[Tuple[int, Tuple[int, ...]], Path] = {}
 
     @property
     def temp_path(self) -> Path:
@@ -299,9 +433,42 @@ class SceneMaterializer:
         self._cache[key] = dest
         return str(dest)
 
+    def build_display_source(
+        self,
+        dataset: RasterDataSet,
+        display_bands: Sequence[int],
+        progress: Optional[ProgressReporter] = None,
+    ) -> str:
+        """
+        Return a path to a warpable, disk-backed **display-only** tiled GeoTIFF for
+        ``dataset`` containing only ``display_bands`` (a 1- or 3-tuple of 0-based band
+        indices), materializing it on first request and reusing the cached result
+        thereafter (#677).
+
+        This is what the preview compositor reads. The cache is keyed by
+        ``(scene key, display bands)`` so re-adding the same dataset with a different
+        frozen band choice yields a distinct artifact rather than a stale hit.
+        ``progress`` is forwarded to :func:`materialize_display_only_to_tiled_geotiff`;
+        a cache hit does no work and reports immediate completion.
+        """
+        bands = tuple(int(b) for b in display_bands)
+        key = (self._scene_key(dataset), bands)
+        cached = self._display_cache.get(key)
+        if cached is not None and cached.exists():
+            if progress is not None:
+                progress.report(1, 1)
+            return str(cached)
+
+        band_tag = "-".join(str(b) for b in bands)
+        dest = self.temp_path / f"scene_{self._scene_key(dataset)}_display_{band_tag}.tif"
+        materialize_display_only_to_tiled_geotiff(dataset, dest, bands, progress=progress)
+        self._display_cache[key] = dest
+        return str(dest)
+
     def close(self) -> None:
         """Deterministically remove the session temporary directory."""
         self._cache.clear()
+        self._display_cache.clear()
         self._tmp.cleanup()
 
     def __enter__(self) -> "SceneMaterializer":

--- a/src/wiser/raster/mosaic_materialize.py
+++ b/src/wiser/raster/mosaic_materialize.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 import tempfile
 from pathlib import Path
-from typing import Dict, Optional, Sequence, Tuple
+from typing import Dict, Optional, Sequence, TYPE_CHECKING, Tuple
 
 import numpy as np
 from osgeo import gdal, gdal_array
@@ -35,6 +35,11 @@ from wiser.raster.dataset import RasterDataSet
 from wiser.raster.dataset_impl import GTiff_GDALRasterDataImpl
 from wiser.utils.primitives import temp_dir
 from wiser.utils.progress import ProgressReporter
+
+if TYPE_CHECKING:
+    # Type-only: the snapshot is read attribute-by-attribute at runtime, so no runtime
+    # import of mosaic_controller is needed (and this avoids any import ordering churn).
+    from wiser.raster.mosaic_controller import SceneMetadataSnapshot
 
 logger = logging.getLogger(__name__)
 
@@ -196,6 +201,127 @@ def materialize_to_tiled_geotiff(
 
     logger.info(
         "Materialized dataset id=%s to tiled GeoTIFF %s (%dx%d, %d bands)",
+        dataset.get_id(),
+        dest_path,
+        width,
+        height,
+        num_bands,
+    )
+
+
+def _stamp_metadata_from_snapshot(
+    gdal_dataset: gdal.Dataset,
+    snapshot: "SceneMetadataSnapshot",
+) -> None:
+    """
+    Stamp spatial + spectral metadata onto ``gdal_dataset`` from a frozen
+    :class:`~wiser.raster.mosaic_controller.SceneMetadataSnapshot` (#677) instead of a
+    live :class:`RasterDataSet`.
+
+    The snapshot mirror of :func:`_stamp_metadata_from_dataset`: the housed
+    ``SpatialMetadata`` / ``SpectralMetadata`` supply the geotransform, SRS, nodata,
+    per-band wavelength / name, and bad-band list exactly as they were at ingest. The
+    ``DEFAULT_BANDS`` field is written from the snapshot's frozen resolved
+    ``display_bands`` (the canonical display choice for export), not the dataset's
+    stored defaults.
+    """
+    geo_transform = snapshot.geo_transform
+    if geo_transform is not None:
+        gdal_dataset.SetGeoTransform([float(v) for v in geo_transform])
+
+    wkt = snapshot.wkt_spatial_reference
+    if wkt:
+        gdal_dataset.SetProjection(wkt)
+
+    nodata = snapshot.data_ignore_value
+    if nodata is not None:
+        for i in range(1, gdal_dataset.RasterCount + 1):
+            gdal_dataset.GetRasterBand(i).SetNoDataValue(float(nodata))
+
+    # snapshot.band_info is a deep copy of the dataset's band_list() (identical shape),
+    # so the same wavelength/name extraction applies band-for-band.
+    for i, info in enumerate(snapshot.band_info):
+        if i >= gdal_dataset.RasterCount:
+            break
+        band = gdal_dataset.GetRasterBand(i + 1)
+
+        name = info.get("wavelength_name")
+        if name is not None:
+            band.SetDescription(str(name))
+
+        value, units = _band_wavelength_value_and_units(info)
+        if value is not None:
+            band.SetMetadataItem("wavelength", str(value))
+        if units is not None:
+            band.SetMetadataItem("wavelength_units", str(units))
+
+    defaults = snapshot.display_bands
+    if defaults:
+        gdal_dataset.SetMetadataItem("DEFAULT_BANDS", ",".join(str(b) for b in defaults))
+
+    bad = snapshot.bad_bands
+    if bad:
+        gdal_dataset.SetMetadataItem("BAD_BANDS", ",".join(str(b) for b in bad))
+
+
+def materialize_full_band_from_snapshot(
+    dataset: RasterDataSet,
+    snapshot: "SceneMetadataSnapshot",
+    dest_path: Path,
+    progress: Optional[ProgressReporter] = None,
+) -> None:
+    """
+    Write a **full-band** tiled GeoTIFF at ``dest_path`` with pixels read from the live
+    ``dataset`` but all metadata stamped from ``snapshot`` (#677).
+
+    This is the lazy, export-time materialization: every band is needed for the output
+    product, but the spatial reference, geotransform, nodata, and band metadata come
+    from the ingest-time snapshot -- never the live dataset -- so a mid-session metadata
+    edit in main WISER cannot silently alter the exported mosaic. Freezing the nodata
+    and geotransform in particular keeps the export aligned with the footprint / common
+    grid that were computed at ingest.
+
+    Not cached: the export caller owns ``dest_path`` and discards it once the mosaic has
+    streamed. Bands are written one at a time to bound peak memory; ``progress`` reports
+    per-band completion and defaults to a no-op reporter.
+    """
+    progress = progress or ProgressReporter()
+    gdal.UseExceptions()
+
+    width = dataset.get_width()
+    height = dataset.get_height()
+    num_bands = dataset.num_bands()
+    gdal_type, write_dtype = _gdal_type_and_write_dtype(dataset.get_elem_type())
+
+    driver = gdal.GetDriverByName("GTiff")
+    options = [
+        "TILED=YES",
+        f"BLOCKXSIZE={_BLOCK_SIZE}",
+        f"BLOCKYSIZE={_BLOCK_SIZE}",
+    ]
+
+    out_ds: Optional[gdal.Dataset] = driver.Create(
+        str(dest_path), width, height, num_bands, gdal_type, options=options
+    )
+    if out_ds is None:
+        raise RuntimeError(f"GDAL failed to create full-band GeoTIFF at {dest_path}")
+
+    try:
+        for band_index in range(num_bands):
+            progress.raise_if_cancelled()
+            band_arr = dataset.get_band_data(band_index, filter_data_ignore_value=False)
+            band_arr = np.asarray(band_arr, dtype=write_dtype)
+            out_ds.GetRasterBand(band_index + 1).WriteArray(band_arr)
+            del band_arr
+            progress.report(band_index + 1, num_bands, "Materializing scene")
+
+        _stamp_metadata_from_snapshot(out_ds, snapshot)
+        out_ds.FlushCache()
+    finally:
+        out_ds = None
+
+    logger.info(
+        "Materialized full-band export GeoTIFF for dataset id=%s to %s (%dx%d, %d bands)",
         dataset.get_id(),
         dest_path,
         width,


### PR DESCRIPTION
## What does this change do?
Only materialize in a 3 band geotiff for display that way it is faster to build and make changes to the datasets that we display to the user.

We only load in 3 bands of the dataset. First checking main view's display bands, then checking default, then visible, then (0, 1, 2) bands. 

The rendering and previewing steps use the 3 band materialized dataset  but when we do the full warp we materialize the full dataset and warp it.  We snapshot the metadata when we load in the dataset because the metadata can change between export and loading in the dataset since the mosaic is non blocking UI (user can interact with main window still).

Closes #677

## What type of PR is this? (check all applicable) 
- [X] Feature
- [ ] Bug Fix
- [X] Documentation Update
- [ ] Style
- [X] Code Refactor
- [ ] Performance Improvements
- [X] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Added tests?
- [X] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [X] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->