### PR TITLE
refac: Refactor geo referencer mainly to be able to be used outside the georeferencer dialog

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/georeferencer-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/georeferencer-internals.md
@@ -30,13 +30,24 @@ objects, the transform is a `gdal.Transformer` / `gdal.Warp` call, and CRSs are
 `osr.SpatialReference` objects.
 
 The dialog is created lazily from `App.show_geo_reference_dialog` in
-`src/wiser/gui/app.py`, passed the shared `ApplicationState` and the main view.
+`src/wiser/gui/app.py`, passed the shared `ApplicationState` and `app_services` (the latter
+provides the work scheduler and progress infrastructure used to run warps off the GUI
+thread). The old `main_view` constructor argument was dead and has been removed.
+
+As of WISER#684 the dialog is a thin UI/controller: the GDAL warp engine, GCP file I/O,
+and the CRS model have each been extracted into Qt-free modules under `src/wiser/raster/`
+(mirroring the Seamless Mosaic's `mosaic_export.py` split), so warp correctness, GCP
+round-tripping, and CRS resolution are all unit-testable without a running app.
 
 **Core files:**
 
 | File | Responsibility |
 |------|----------------|
-| `src/wiser/gui/geo_reference_dialog.py` | Dialog/controller, GCP table, CRS classes, residual + warp pipeline |
+| `src/wiser/gui/geo_reference_dialog.py` | Dialog/controller and GCP table; delegates warp, GCP I/O, and CRS to the modules below |
+| `src/wiser/gui/geo_reference_config.py` | `GeoReferencerConfig` — presets + lock flags to drive the dialog programmatically |
+| `src/wiser/raster/georef_warp.py` | Qt-free warp engine: `build_warp_kwargs`, `compute_residuals`, `warp_dataset_to_path` (+ `TRANSFORM_TYPES`, `RESAMPLE_ALGORITHMS`) |
+| `src/wiser/raster/gcp_io.py` | Qt-free GCP persistence: `read_gcp_file`, `write_qgis_points`, `write_envi_pts` |
+| `src/wiser/raster/crs_model.py` | Shared Qt-free CRS hierarchy (`GeneralCRS` and subclasses, `COMMON_SRS`) |
 | `src/wiser/gui/geo_reference_task_delegate.py` | Input event state machine, GCP data model |
 | `src/wiser/gui/geo_reference_pane.py` | `GeoReferencerPane` — a stripped-down `RasterPane` |
 | `src/wiser/raster/dataset.py` | Pixel ↔ spatial coordinate helpers used to build GCPs |
@@ -57,11 +68,12 @@ classDiagram
         geo_reference_dialog.py
         +gcp_pair_added : Signal
         +gcp_add_attempt : Signal
+        +warp_completed : Signal
         -_table_entry_list : list~GeoRefTableEntry~
-        -_warp_kwargs : dict
-        +_georeference()
+        +set_target_dataset() / set_reference_dataset()
+        +_apply_config(GeoReferencerConfig)
+        +_schedule_residual_recompute()
         +_create_warped_output()
-        +accept()
     }
 
     class GeoReferencerPane {
@@ -108,6 +120,7 @@ classDiagram
 
     class GeneralCRS {
         <<abstract>>
+        crs_model.py
         +get_osr_crs()
     }
     class AuthorityCodeCRS
@@ -153,9 +166,10 @@ final warp.
   enable/disable, per-row color, and inline coordinate edits
 - The output controls: output CRS chooser (`cbox_srs`), resampling algorithm
   (`cbox_interpolation`), transform type (`cbox_poly_order`), and the save path
-- Triggering `_georeference()` (recompute residuals) on every relevant change, and
-  `_create_warped_output()` when the dialog is accepted
-- Saving/loading GCPs to/from disk
+- Scheduling a debounced, off-thread residual recompute (`_schedule_residual_recompute()`)
+  on every relevant change, and launching the threaded output warp
+  (`_create_warped_output()`) from the **Run Warp** button
+- Saving/loading GCPs to/from disk (thin wrappers over `wiser.raster.gcp_io`)
 
 **Does not control:**
 - Per-click GCP state transitions (delegated to `GeoReferencerTaskDelegate`)
@@ -169,6 +183,7 @@ final warp.
 |--------|----------|--------------|
 | `gcp_pair_added` | `GroundControlPointPair` | A complete target+reference pair is finalized |
 | `gcp_add_attempt` | `GroundControlPoint` | A reference point is added via manual lat/lon entry |
+| `warp_completed` | `str` (output path) | A **Run Warp** finishes successfully on its worker thread |
 
 ---
 
@@ -248,11 +263,14 @@ the `COLUMN_ID` enum.
 
 ### The CRS model
 
-**File:** `src/wiser/gui/geo_reference_dialog.py`
+**File:** `src/wiser/raster/crs_model.py`
 
 All CRSs are represented through the `GeneralCRS` ABC, whose single contract is
 `get_osr_crs() -> osr.SpatialReference`. This lets the dialog treat every CRS source
-uniformly (and compare them by WKT via `__eq__`):
+uniformly (and compare them by WKT via `__eq__`). The hierarchy is Qt-free and now shared
+with the Seamless Mosaic's CRS chooser (`mosaic_crs_dialog.py`), so both features offer the
+same CRSs from a single source of truth (`geo_reference_dialog.py` re-exports the names for
+backwards compatibility):
 
 | Class | Built from |
 |-------|------------|
@@ -337,20 +355,23 @@ sequenceDiagram
     Pane->>Del: on_key_release()
     Del->>Dlg: gcp_pair_added.emit(pair)
     Dlg->>Table: _on_gcp_pair_added()<br/>add GeoRefTableEntry row
-    Dlg->>Dlg: _georeference() (recompute residuals)
-    Dlg->>Table: _update_residuals() per row
+    Dlg->>Dlg: _schedule_residual_recompute()<br/>(debounced, off-thread)
+    Dlg->>Table: _apply_residuals() per row (GUI thread)
 ```
 
 Editing a cell in the table (`_on_cell_changed`), toggling a row's *enabled* checkbox,
-or switching the output CRS / reference CRS / transform type all re-enter
-`_georeference()` so the residual columns stay live.
+or switching the output CRS / reference CRS / transform type all call
+`_schedule_residual_recompute()` so the residual columns stay live — see
+[Residual Computation](#residual-computation-schedule_residual_recompute) for how that runs
+off the GUI thread.
 
 ---
 
 ## Transformation Models
 
-The transform type is chosen from the `TRANSFORM_TYPES` enum. Each maps to a GDAL
-transformer method and has a minimum GCP count (`min_points_per_transform`):
+The transform type is chosen from the `TRANSFORM_TYPES` enum (defined in
+`wiser.raster.georef_warp`). Each maps to a GDAL transformer method and has a minimum GCP
+count (`min_points_per_transform`):
 
 | Transform | `TRANSFORM_TYPES` | Min GCPs | GDAL mapping | Use when |
 |-----------|-------------------|----------|--------------|----------|
@@ -359,27 +380,47 @@ transformer method and has a minimum GCP count (`min_points_per_transform`):
 | Polynomial 3 | `POLY_3` | 10 | `METHOD=GCP_POLYNOMIAL`, `MAX_GCP_ORDER=3` | Stronger distortion |
 | Thin Plate Spline | `TPS` | 10 | `tps=True`, `METHOD=GCP_TPS`, `MAX_GCP_ORDER=-1` | Local, non-uniform warping; passes through all GCPs |
 
-These selections are written into `_warp_kwargs` and `_transform_options` in
-`_georeference()`, and reused unchanged by `_create_warped_output()`.
+The mapping lives in one place — `georef_warp.build_warp_kwargs(resample_alg,
+transform_type, output_srs)` — which returns the `gdal.Warp` kwargs plus the matching
+`gdal.Transformer` options. Both the residual calc and the final warp call it, so they can
+never drift apart.
 
 ---
 
-## Residual Computation (`_georeference`)
+## Residual Computation (`_schedule_residual_recompute`)
 
-`_georeference()` runs after every change to give the user immediate feedback on how
-well each GCP fits the chosen transform. It does **not** warp the real image — it builds
-a 1×1 placeholder dataset purely to drive GDAL's transformer.
+Residuals are recomputed after every change to give the user immediate feedback on how
+well each GCP fits the chosen transform. The math itself
+(`georef_warp.compute_residuals`) does **not** warp the real image — it builds a 1×1
+placeholder dataset purely to drive GDAL's transformer — but because it runs a full
+`gdal.Warp` per call it must not block the GUI.
+
+The dialog therefore **debounces and single-flights** the recompute (mirroring
+`MosaicView`'s off-thread pixel reads):
+
+1. An edit calls `_schedule_residual_recompute()`, which (re)starts a ~150 ms single-shot
+   `QTimer`.
+2. When the timer fires, `_recompute_residuals_async()` snapshots the GCPs + SRSs on the
+   GUI thread (`_snapshot_residual_inputs()`), bumps an in-flight token
+   (`_residual_signature`), and submits `compute_residuals` to
+   `app_services.scheduler.submit_thread`.
+3. The worker's result is delivered back to the GUI thread via the queued `_residuals_ready`
+   signal; `_apply_residuals()` drops it if a newer recompute has superseded the token,
+   otherwise writes the residual columns.
+
+(When no scheduler is available — e.g. some unit contexts — it falls back to a synchronous
+`_georeference()`.)
 
 ```{mermaid}
 flowchart TD
     A["_get_entry_gcp_list()<br/>enabled rows → gdal.GCP"] --> B["build output_srs + ref_srs<br/>(OAMS_TRADITIONAL_GIS_ORDER)"]
-    B --> C["assemble _warp_kwargs +<br/>transformerOptions (per transform type)"]
+    B --> C["build_warp_kwargs()<br/>→ warp_kwargs + transformerOptions"]
     C --> D["gdal.Transformer(temp_ds, options)<br/>pixel → output SRS"]
     D --> E["per GCP: TransformPoint(pixel)<br/>→ output-SRS coord"]
     E --> F["CoordinateTransformation<br/>output SRS → reference SRS"]
     F --> G["spatial error = gcp.GCPX/Y − transformed X/Y"]
     G --> H["pixel error = spatial error ÷<br/>warped geotransform pixel size"]
-    H --> I["entry.set_residual_x/y()<br/>→ dX/dY columns"]
+    H --> I["return residuals →<br/>entry.set_residual_x/y() on GUI thread"]
 ```
 
 Key details:
@@ -396,26 +437,37 @@ Key details:
 
 ---
 
-## Warp / Output Pipeline (`_create_warped_output`)
+## Warp / Output Pipeline (`warp_dataset_to_path`)
 
-Accepting the dialog calls `accept()` → `_create_warped_output()`, which produces the
-georeferenced GeoTIFF. Because hyperspectral cubes can be very large, the band data is
-processed in RAM-bounded chunks.
+The **Run Warp** button (`_on_warp_button_clicked` → `_create_warped_output()`) produces
+the georeferenced GeoTIFF. `_create_warped_output()` only *validates and launches*: it
+gathers the GCPs, resolves the SRSs, builds the warp kwargs, and hands
+`georef_warp.warp_dataset_to_path` to `run_with_progress`, which runs it on the work
+scheduler with a progress dialog and cancellation. On success `_on_warp_done` emits
+`warp_completed(path)`; on failure/cancel `_on_warp_error` surfaces the message. The dialog's
+`accept()` no longer warps — the previous double-warp (both `accept()` **and** the button
+calling the warp) is gone, so the OK button is now a plain commit/close.
+
+Because hyperspectral cubes can be very large, `warp_dataset_to_path` processes the band
+data in RAM-bounded chunks, reporting `progress` and calling `raise_if_cancelled()` between
+chunks.
 
 ```{mermaid}
 flowchart TD
-    V["validate: save path, enough GCPs, target selected"] --> P["probe output size:<br/>warp band 0 to /vsimem"]
+    V["_create_warped_output: validate<br/>+ build_warp_kwargs"] --> R["run_with_progress →<br/>warp_dataset_to_path (worker thread)"]
+    R --> P["probe output size:<br/>warp band 0 to /vsimem"]
     P --> Branch{target impl & size}
     Branch -->|"GDALRasterDataImpl"| G["Translate → VRT,<br/>SetGCPs, gdal.Warp whole dataset"]
     Branch -->|"numpy & fits in RAM"| N["OpenNumPyArray,<br/>SetGCPs, gdal.Warp whole array"]
-    Branch -->|"too big for RAM"| C["chunk bands by MAX_RAM_BYTES:<br/>warp each chunk, write incrementally"]
+    Branch -->|"too big for RAM"| C["chunk bands by MAX_RAM_BYTES:<br/>warp each chunk, write incrementally<br/>(progress + raise_if_cancelled)"]
     C --> M["driver.Create GTiff,<br/>SetGeoTransform + SetSpatialRef"]
     G --> F["copy_metadata_to_gdal_dataset, FlushCache"]
     N --> F
     M --> F
+    F --> S["warp_completed.emit(path)"]
 ```
 
-`_warp_kwargs` carries everything GDAL needs:
+`warp_kwargs` carries everything GDAL needs:
 
 | Key | Value | Notes |
 |-----|-------|-------|
@@ -425,7 +477,8 @@ flowchart TD
 | `polynomialOrder` / `tps` | `1`/`2`/`3` or `True` | Set per transform type |
 | `transformerOptions` | `["METHOD=…", "MAX_GCP_ORDER=…"]` | Mirrors the transform type |
 
-The available resampling algorithms are discovered dynamically:
+The available resampling algorithms are discovered dynamically (in
+`wiser.raster.georef_warp`):
 `RESAMPLE_ALGORITHMS = {name: getattr(gdal, name) for name in dir(gdal) if name.startswith("GRA_")}`
 — i.e. all of GDAL's `GRA_NearestNeighbour`, `GRA_Bilinear`, `GRA_Cubic`,
 `GRA_CubicSpline`, `GRA_Lanczos`, etc.
@@ -438,18 +491,52 @@ transform from the GCPs rather than from any pre-existing geotransform on the so
 
 ## GCP Persistence
 
-GCPs can be saved and reloaded in two formats, chosen by file extension in
-`_on_save_gcps_clicked` / `_on_load_gcps_clicked`:
+GCPs can be saved and reloaded in two formats, chosen by file extension. The parsing /
+writing is Qt-free and lives in `wiser.raster.gcp_io`; the dialog's
+`_on_save_gcps_clicked` / `_on_load_gcps_clicked` are thin wrappers (the writers take the
+dialog's flattened `(map_x, map_y, pixel_x, pixel_y, enabled)` rows from `_get_gcp_rows()`):
 
-| Format | Extension | CRS header | Writer / reader |
+| Format | Extension | CRS header | Writer / reader (`gcp_io`) |
 |--------|-----------|------------|-----------------|
-| QGIS points | `.points` | `# CRS, EPSG:code` row (CSV) | `_write_qgis_points_file` / `_read_qgis_points_file` |
-| ENVI points | `.pts` | `; projection info = {auth, code, units=Degrees}` comment | `_write_envi_pts_file` / `_read_envi_pts_file` |
+| QGIS points | `.points` | `# CRS, EPSG:code` row (CSV) | `write_qgis_points` / `read_qgis_points_file` |
+| ENVI points | `.pts` | `; projection info = {auth, code, units=Degrees}` comment | `write_envi_pts` / `read_envi_pts_file` |
 
-On load, `_read_gcp_file` dispatches by extension; `load_gcps_and_srs` rebuilds the
-`GeoRefTableEntry` rows and the associated `GeneralCRS`. Both readers fall back to an
-embedded WKT line if the authority header is missing. `compare_srs_lenient` is used to
+On load, `gcp_io.read_gcp_file` dispatches by extension; the dialog's `load_gcps_and_srs`
+rebuilds the `GeoRefTableEntry` rows and the associated `GeneralCRS`. Both readers fall back
+to an embedded WKT line if the authority header is missing. `compare_srs_lenient` is used to
 reconcile a loaded file's CRS against the current reference CRS.
+
+---
+
+## Programmatic Configuration & Locking
+
+The dialog can be driven entirely through code — not just its own combo boxes — via a
+`GeoReferencerConfig` (`src/wiser/gui/geo_reference_config.py`). This is what lets another
+feature (e.g. re-georeferencing a scene from the Seamless Mosaic pane) reuse the dialog with
+a fixed target, a caller-owned save path, and a custom accept button, without touching the
+Tools-menu flow.
+
+`show(config=None)` / `exec_(config=None)` accept an optional config and delegate to
+`_apply_config`, which first resets the dialog to its classic baseline (repopulate choosers,
+clear any prior locks / accept-button label) and then, if a config is given, applies presets
+**before** locks:
+
+| Config field | Effect |
+|--------------|--------|
+| `target_dataset` | `set_target_dataset(ds)` — show it in the target pane |
+| `reference_dataset` | `set_reference_dataset(ds)` — show it in the reference pane |
+| `reference_crs` | `set_reference_crs(crs)` — manual reference CRS (used when there is no reference dataset) |
+| `save_path` | `set_save_path(path)` — preset the output path |
+| `allow_change_target` = False | `_set_target_locked(True)` — disable the target chooser |
+| `allow_change_reference` = False | `_set_reference_locked(True)` — disable the reference chooser + suppress the manual-ref toggle |
+| `allow_change_save_path` = False | `_set_save_path_locked(True)` — make the path read-only, disable the choose button, skip its validation |
+| `accept_button_text` | relabel the OK button (e.g. "Save to Mosaic") |
+
+The `set_*` setters are the single shared apply-path: the interactive chooser slots
+(`_on_switch_target_dataset` / `_on_switch_reference_dataset`) keep the user-facing
+confirm-discard-GCPs prompts, then funnel through the same setters, while a programmatic
+caller calls the setters directly (no prompts). `config=None` reproduces the Tools-menu
+behavior exactly, so the reused singleton is safe to reopen either way.
 
 ---
 
@@ -467,6 +554,11 @@ reconcile a loaded file's CRS against the current reference CRS.
 - **`RasterDataSet`** — GCP spatial coordinates come from
   `RasterDataSet.to_geographic_coords()` and `geo_to_pixel_coords_exact()`, and CRSs
   from `get_spatial_ref()` (`src/wiser/raster/dataset.py`).
+- **Work scheduler / progress** — the final warp and the interactive residual recompute
+  both run off the GUI thread through `app_services` (`run_with_progress` +
+  `scheduler.submit_thread`), the same stack the Seamless Mosaic uses; see
+  [Residual Computation](#residual-computation-schedule_residual_recompute) and
+  [Warp / Output Pipeline](#warp-output-pipeline-warp_dataset_to_path).
 - **Entry point** — `App.show_geo_reference_dialog` (`src/wiser/gui/app.py`) constructs
-  the dialog lazily with the shared `ApplicationState` and the main view, then
-  `exec_()`s it.
+  the dialog lazily with the shared `ApplicationState` and `app_services`, then
+  `exec_()`s it (optionally with a `GeoReferencerConfig`).

--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -1144,6 +1144,11 @@ class WiserTestModel:
     def open_geo_referencer(self):
         self.main_window.show_geo_reference_dialog(in_test_mode=True)
 
+    @run_in_wiser_decorator
+    def apply_geo_ref_config(self, config) -> None:
+        """Apply a ``GeoReferencerConfig`` to the (already open) georeferencer dialog."""
+        self.main_window._geo_ref_dialog._apply_config(config)
+
     def close_geo_referencer(self):
         def func():
             self.main_window._geo_ref_dialog.close()
@@ -1237,10 +1242,35 @@ class WiserTestModel:
         QTest.keyClicks(ledit, path)
         self.main_window._geo_ref_dialog._georeference()
 
-    @run_in_wiser_decorator
-    def click_run_warp(self) -> None:
-        btn = self.main_window._geo_ref_dialog._ui.btn_run_warp
-        QTest.mouseClick(btn, Qt.LeftButton)
+    def click_run_warp(self, timeout_ms: int = 60000) -> None:
+        """
+        Click "Run Warp" and pump the event loop until the (threaded) warp finishes.
+
+        The warp now runs off the GUI thread via ``run_with_progress`` and signals
+        completion through ``warp_completed``, so this helper waits for that signal (up to
+        ``timeout_ms``) before returning, keeping callers effectively synchronous.
+        """
+        dialog = self.main_window._geo_ref_dialog
+        completed = []
+
+        def _on_done(path):
+            completed.append(path)
+
+        dialog.warp_completed.connect(_on_done)
+        try:
+
+            def func():
+                QTest.mouseClick(dialog._ui.btn_run_warp, Qt.LeftButton)
+
+            self.app.postEvent(self.testing_widget, FunctionEvent(func))
+
+            waited = 0
+            step_ms = 50
+            while not completed and waited < timeout_ms:
+                QTest.qWait(step_ms)
+                waited += step_ms
+        finally:
+            dialog.warp_completed.disconnect(_on_done)
 
     # ---------- GCP creation helpers ----------
 

--- a/src/tests/test_crs_model.py
+++ b/src/tests/test_crs_model.py
@@ -1,0 +1,77 @@
+"""
+Unit tests for the shared, Qt-free CRS model (:mod:`wiser.raster.crs_model`, WISER#684).
+
+Covers: each :class:`GeneralCRS` subclass resolving to the expected
+``osr.SpatialReference``, WKT-based equality, and the ``COMMON_SRS`` presets.
+"""
+
+from __future__ import annotations
+
+import pytest
+from osgeo import osr
+
+import tests.context  # noqa: F401  (sets up sys.path for `wiser` imports)
+
+from wiser.raster.crs_model import (
+    AVAILABLE_AUTHORITIES,
+    COMMON_SRS,
+    AuthorityCodeCRS,
+    GeneralCRS,
+    UserGeneratedCRS,
+    WktGeneratedCRS,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _wgs84_srs() -> osr.SpatialReference:
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    return srs
+
+
+def test_authority_code_crs_resolves():
+    crs = AuthorityCodeCRS("EPSG", 4326)
+    srs = crs.get_osr_crs()
+    assert isinstance(srs, osr.SpatialReference)
+    assert srs.GetAuthorityCode(None) == "4326"
+
+
+def test_authority_code_crs_bad_code_raises():
+    with pytest.raises(Exception):
+        AuthorityCodeCRS("EPSG", 999999999).get_osr_crs()
+
+
+def test_user_generated_crs_returns_wrapped_srs():
+    srs = _wgs84_srs()
+    crs = UserGeneratedCRS("my crs", srs)
+    assert crs.get_osr_crs() is srs
+
+
+def test_wkt_generated_crs_roundtrips():
+    wkt = _wgs84_srs().ExportToWkt()
+    crs = WktGeneratedCRS("wgs84", wkt)
+    assert crs.get_osr_crs().GetAuthorityCode(None) == "4326"
+
+
+def test_equality_is_by_wkt():
+    a = AuthorityCodeCRS("EPSG", 4326)
+    b = WktGeneratedCRS("wgs84", _wgs84_srs().ExportToWkt())
+    c = AuthorityCodeCRS("EPSG", 3857)
+    assert a == b
+    assert a != c
+
+
+def test_common_srs_entries_resolve():
+    assert set(COMMON_SRS) == {
+        "WGS84 EPSG:4326",
+        "Web Mercator EPSG:3857",
+        "NAD83 / UTM zone 15N EPSG:26915",
+    }
+    for name, crs in COMMON_SRS.items():
+        assert isinstance(crs, GeneralCRS)
+        assert crs.get_osr_crs() is not None
+
+
+def test_available_authorities_includes_epsg():
+    assert "EPSG" in AVAILABLE_AUTHORITIES

--- a/src/tests/test_gcp_io.py
+++ b/src/tests/test_gcp_io.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for GCP file I/O (:mod:`wiser.raster.gcp_io`, WISER#684).
+
+Covers QGIS ``*.points`` and ENVI ``*.pts`` write->read round-tripping (points + CRS), the
+WKT-fallback path when the authority header is absent, and extension dispatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from osgeo import osr
+
+import tests.context  # noqa: F401  (sets up sys.path for `wiser` imports)
+
+from wiser.raster import gcp_io
+from wiser.raster.crs_model import AuthorityCodeCRS
+
+pytestmark = [pytest.mark.unit]
+
+# (map_x, map_y, pixel_x, pixel_y, enabled)
+ROWS = [
+    (-120.5, 35.25, 10.0, 20.0, True),
+    (-119.0, 36.0, 100.0, 200.0, False),
+    (-118.25, 34.75, 50.5, 60.5, True),
+]
+POINTS = [(map_x, map_y, px, py) for map_x, map_y, px, py, _ in ROWS]
+
+
+@pytest.mark.parametrize(
+    "ext,writer",
+    [(".points", gcp_io.write_qgis_points), (".pts", gcp_io.write_envi_pts)],
+)
+def test_roundtrip_with_authority(tmp_path, ext, writer):
+    path = str(tmp_path / f"gcps{ext}")
+    writer(path, ROWS, "EPSG", "4326", None)
+
+    points, srs = gcp_io.read_gcp_file(path)
+
+    assert points == pytest.approx(POINTS)
+    assert isinstance(srs, AuthorityCodeCRS)
+    assert srs.get_osr_crs().GetAuthorityCode(None) == "4326"
+
+
+@pytest.mark.parametrize(
+    "ext,writer",
+    [(".points", gcp_io.write_qgis_points), (".pts", gcp_io.write_envi_pts)],
+)
+def test_roundtrip_wkt_fallback(tmp_path, ext, writer):
+    wgs84 = osr.SpatialReference()
+    wgs84.ImportFromEPSG(4326)
+    wkt = wgs84.ExportToWkt()
+
+    path = str(tmp_path / f"gcps_wkt{ext}")
+    # No authority pair -> only the embedded WKT line carries the CRS.
+    writer(path, ROWS, None, None, wkt)
+
+    points, srs = gcp_io.read_gcp_file(path)
+
+    assert points == pytest.approx(POINTS)
+    # Recovered from the WKT fallback; still EPSG:4326 by identity.
+    assert srs.get_osr_crs().IsSame(wgs84)
+
+
+def test_read_unsupported_extension_raises(tmp_path):
+    path = str(tmp_path / "gcps.bogus")
+    with open(path, "w") as f:
+        f.write("nothing\n")
+    with pytest.raises(RuntimeError):
+        gcp_io.read_gcp_file(path)

--- a/src/tests/test_geo_ref_gui.py
+++ b/src/tests/test_geo_ref_gui.py
@@ -26,6 +26,7 @@ from wiser.gui.geo_reference_dialog import (
     UserGeneratedCRS,
     GeneralCRS,
 )
+from wiser.gui.geo_reference_config import GeoReferencerConfig
 
 import numpy as np
 
@@ -255,6 +256,70 @@ class TestGeoReferencerGUI(unittest.TestCase):
 
         warped_transform = ds_warp.get_geo_transform()
         self.assertTrue(np.allclose(warped_transform, ground_truth_geo_transform))
+
+    def test_config_driven_locking(self):
+        """A GeoReferencerConfig presets + locks the choosers; config=None restores them.
+
+        Verifies:
+        - presetting target dataset + save path populates the panes/fields,
+        - lock flags disable exactly the right widgets,
+        - a custom accept_button_text relabels the OK button,
+        - re-applying config=None (the Tools-menu path) re-enables everything.
+        """
+        rel_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "caltech_4_100_150_nm",
+        )
+        ds = self.test_model.load_dataset(rel_path)
+        self.test_model.open_geo_referencer()
+        dialog = self.test_model.main_window._geo_ref_dialog
+
+        save_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "test_utils",
+            "test_datasets",
+            "artifacts",
+            "config_locked_output.tif",
+        )
+        config = GeoReferencerConfig(
+            target_dataset=ds,
+            save_path=save_path,
+            allow_change_target=False,
+            allow_change_save_path=False,
+            accept_button_text="Save to Mosaic",
+        )
+        self.test_model.apply_geo_ref_config(config)
+
+        # Presets applied.
+        self.assertEqual(dialog._target_rasterpane.get_rasterview().get_raster_data().get_id(), ds.get_id())
+        self.assertEqual(dialog._ui.ledit_save_path.text(), save_path)
+
+        # Locks disable exactly the right widgets.
+        self.assertFalse(dialog._target_cbox.isEnabled())
+        self.assertTrue(dialog._ui.ledit_save_path.isReadOnly())
+        self.assertFalse(dialog._ui.btn_save_path.isEnabled())
+        # Reference was left unlocked.
+        self.assertTrue(dialog._reference_cbox.isEnabled())
+
+        # Accept button relabeled.
+        ok_btn = dialog._ui.buttonBox.button(QDialogButtonBox.Ok)
+        self.assertEqual(ok_btn.text(), "Save to Mosaic")
+
+        # config=None restores the classic Tools-menu state.
+        self.test_model.apply_geo_ref_config(None)
+        self.assertTrue(dialog._target_cbox.isEnabled())
+        self.assertFalse(dialog._ui.ledit_save_path.isReadOnly())
+        self.assertTrue(dialog._ui.btn_save_path.isEnabled())
+        self.assertEqual(ok_btn.text(), self._default_ok_text(dialog))
+
+    @staticmethod
+    def _default_ok_text(dialog):
+        # The remembered original label of the OK button.
+        return dialog._default_accept_button_text
 
 
 """

--- a/src/tests/test_georef_warp.py
+++ b/src/tests/test_georef_warp.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for the Qt-free georeferencer warp engine
+(:mod:`wiser.raster.georef_warp`, WISER#684).
+
+Covers: transform-type -> GDAL-option mapping, near-zero residuals for GCPs that fit the
+chosen transform exactly, the full multi-band output warp (size / band count / geotransform),
+and cooperative cancellation via a ProgressReporter.
+"""
+
+from __future__ import annotations
+
+import pytest
+from osgeo import gdal, osr
+
+import tests.context  # noqa: F401  (sets up sys.path for `wiser` imports)
+
+from tests.mosaic_fixtures import make_numpy_scene
+from wiser.raster import georef_warp
+from wiser.raster.georef_warp import (
+    TRANSFORM_TYPES,
+    build_warp_kwargs,
+    compute_residuals,
+    warp_dataset_to_path,
+)
+from wiser.utils.progress import ProgressCancelled, ProgressReporter
+
+pytestmark = [pytest.mark.unit]
+
+EPSG = 32611  # UTM 11N: a metric CRS, so ref SRS == output SRS and there is no reprojection.
+
+# An exact affine mapping from target pixel (col, row) -> map (x, y):
+#   map_x = X0 + col * RES ,  map_y = Y0 - row * RES
+X0, Y0, RES = 500000.0, 4000000.0, 10.0
+# Four target-pixel corners of a 100x100-pixel region.
+PIXEL_CORNERS = [(0.0, 0.0), (100.0, 0.0), (0.0, 100.0), (100.0, 100.0)]
+
+
+def _srs(epsg: int = EPSG) -> osr.SpatialReference:
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(epsg)
+    srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    return srs
+
+
+def _affine_gcps():
+    gcps = []
+    for col, row in PIXEL_CORNERS:
+        map_x = X0 + col * RES
+        map_y = Y0 - row * RES
+        gcps.append(gdal.GCP(map_x, map_y, 0, col, row))
+    return gcps
+
+
+@pytest.mark.parametrize(
+    "transform_type,expected_substr",
+    [
+        (TRANSFORM_TYPES.POLY_1, "MAX_GCP_ORDER=1"),
+        (TRANSFORM_TYPES.POLY_2, "MAX_GCP_ORDER=2"),
+        (TRANSFORM_TYPES.POLY_3, "MAX_GCP_ORDER=3"),
+        (TRANSFORM_TYPES.TPS, "METHOD=GCP_TPS"),
+    ],
+)
+def test_build_warp_kwargs_maps_transform(transform_type, expected_substr):
+    out_srs = _srs()
+    warp_kwargs, transformer_options = build_warp_kwargs(gdal.GRA_NearestNeighbour, transform_type, out_srs)
+    assert warp_kwargs["resampleAlg"] == gdal.GRA_NearestNeighbour
+    assert warp_kwargs["dstSRS"] is out_srs
+    assert warp_kwargs["transformerOptions"] is transformer_options
+    assert any(expected_substr in opt for opt in transformer_options)
+    if transform_type == TRANSFORM_TYPES.TPS:
+        assert warp_kwargs.get("tps") is True
+    else:
+        assert warp_kwargs["polynomialOrder"] == int(expected_substr[-1])
+
+
+def test_build_warp_kwargs_unknown_transform_raises():
+    with pytest.raises(RuntimeError):
+        build_warp_kwargs(gdal.GRA_NearestNeighbour, object(), _srs())
+
+
+def test_compute_residuals_near_zero_for_exact_affine():
+    ref_srs = _srs()
+    out_srs = _srs()
+    gcps = _affine_gcps()
+    warp_kwargs, transformer_options = build_warp_kwargs(
+        gdal.GRA_NearestNeighbour, TRANSFORM_TYPES.POLY_1, out_srs
+    )
+
+    residuals = compute_residuals(gcps, ref_srs, out_srs, warp_kwargs, transformer_options)
+
+    assert len(residuals) == len(gcps)
+    for rx, ry in residuals:
+        assert abs(rx) < 1e-3
+        assert abs(ry) < 1e-3
+
+
+def test_warp_dataset_to_path_writes_output(tmp_path):
+    dataset = make_numpy_scene(width=8, height=6, num_bands=3, epsg=EPSG)
+    out_srs = _srs()
+    ref_srs = _srs()
+    # Map the 8x6 target onto real coordinates via the same exact affine.
+    gcps = [
+        gdal.GCP(X0 + col * RES, Y0 - row * RES, 0, col, row)
+        for col, row in [(0.0, 0.0), (8.0, 0.0), (0.0, 6.0), (8.0, 6.0)]
+    ]
+    warp_kwargs, _ = build_warp_kwargs(gdal.GRA_NearestNeighbour, TRANSFORM_TYPES.POLY_1, out_srs)
+
+    save_path = str(tmp_path / "warped.tif")
+    result = warp_dataset_to_path(dataset, gcps, warp_kwargs, ref_srs, save_path)
+
+    assert result == save_path
+    written = gdal.Open(save_path)
+    assert written is not None
+    assert written.RasterCount == 3
+    assert written.GetGeoTransform() is not None
+    written = None
+
+
+def test_warp_dataset_to_path_honors_cancellation(tmp_path):
+    dataset = make_numpy_scene(width=8, height=6, num_bands=3, epsg=EPSG)
+    out_srs = _srs()
+    ref_srs = _srs()
+    gcps = [
+        gdal.GCP(X0 + col * RES, Y0 - row * RES, 0, col, row)
+        for col, row in [(0.0, 0.0), (8.0, 0.0), (0.0, 6.0), (8.0, 6.0)]
+    ]
+    warp_kwargs, _ = build_warp_kwargs(gdal.GRA_NearestNeighbour, TRANSFORM_TYPES.POLY_1, out_srs)
+
+    cancelled = ProgressReporter(is_cancelled=lambda: True)
+    save_path = str(tmp_path / "cancelled.tif")
+    with pytest.raises(ProgressCancelled):
+        warp_dataset_to_path(dataset, gcps, warp_kwargs, ref_srs, save_path, progress=cancelled)

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -1054,7 +1054,7 @@ class DataVisualizerApp(QMainWindow):
 
     def show_geo_reference_dialog(self, in_test_mode=False):
         if self._geo_ref_dialog is None:
-            self._geo_ref_dialog = GeoReferencerDialog(self._app_state, self._main_view, parent=self)
+            self._geo_ref_dialog = GeoReferencerDialog(self._app_state, self._app_services, parent=self)
         # Note the best solution to the inability to properly close QDialogs
         # in our tests, but for now it gets the job done
         if not in_test_mode:

--- a/src/wiser/gui/geo_reference_config.py
+++ b/src/wiser/gui/geo_reference_config.py
@@ -1,0 +1,40 @@
+"""
+Configuration object for driving :class:`~wiser.gui.geo_reference_dialog.GeoReferencerDialog`
+programmatically (WISER#684).
+
+A ``GeoReferencerConfig`` lets an external caller (e.g. the Seamless Mosaic pane) preset the
+target dataset, the reference dataset *or* a manual reference CRS, and the output save path,
+and independently lock any of those choosers so the user cannot change them. It also lets the
+caller relabel the accept button (e.g. "Save to Mosaic").
+
+Passing ``config=None`` to ``GeoReferencerDialog.show`` / ``exec_`` reproduces the classic
+Tools -> Geo Reference behavior exactly.
+
+This lives in its own module (rather than in ``geo_reference_dialog``) so callers that only
+need to build a config do not import the heavy dialog module, avoiding an import cycle.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from wiser.raster.dataset import RasterDataSet
+    from wiser.raster.crs_model import GeneralCRS
+
+
+@dataclass
+class GeoReferencerConfig:
+    """Presets + lock flags for :class:`GeoReferencerDialog`."""
+
+    target_dataset: Optional["RasterDataSet"] = None
+    reference_dataset: Optional["RasterDataSet"] = None
+    # Used when reference_dataset is None (manual reference CRS).
+    reference_crs: Optional["GeneralCRS"] = None
+    save_path: Optional[str] = None
+
+    allow_change_target: bool = True
+    allow_change_reference: bool = True
+    allow_change_save_path: bool = True
+
+    # e.g. "Save to Mosaic"; None keeps the dialog's default accept-button text.
+    accept_button_text: Optional[str] = None

--- a/src/wiser/gui/geo_reference_dialog.py
+++ b/src/wiser/gui/geo_reference_dialog.py
@@ -8,7 +8,6 @@ from PySide6.QtWidgets import *
 from .generated.geo_referencer_dialog_ui import Ui_GeoReferencerDialog
 
 from wiser.gui.app_state import ApplicationState
-from wiser.gui.rasterpane import RasterPane
 from wiser.gui.geo_reference_pane import GeoReferencerPane
 from wiser.gui.geo_reference_task_delegate import (
     GeoReferencerTaskDelegate,
@@ -26,32 +25,35 @@ from wiser.gui.util import (
 )
 
 from wiser.raster.dataset import RasterDataSet
-from wiser.raster.dataset_impl import GDALRasterDataImpl
-from wiser.raster.utils import (
-    copy_metadata_to_gdal_dataset,
-    numpy_dtype_to_gdal_export_types,
-    set_data_ignore_of_gdal_dataset,
+from wiser.raster.crs_model import (
+    AVAILABLE_AUTHORITIES,
+    GeneralCRS,
+    AuthorityCodeCRS,
+    UserGeneratedCRS,
+    WktGeneratedCRS,
+    COMMON_SRS,
+)
+from wiser.raster import gcp_io
+from wiser.raster.georef_warp import (
+    RESAMPLE_ALGORITHMS,
+    TRANSFORM_TYPES,
+    min_points_per_transform,
+    build_warp_kwargs,
+    compute_residuals,
+    warp_dataset_to_path,
 )
 
-from wiser.bandmath.utils import write_raster_to_dataset
+from wiser.gui.progress_task import run_with_progress
+from wiser.gui.geo_reference_config import GeoReferencerConfig
+from wiser.utils.primitives import PriorityClass
 
-from enum import IntEnum, Enum
+from enum import IntEnum
 
-from osgeo import gdal, osr, gdal_array
+from osgeo import gdal, osr
 
-import numpy as np
-
-from abc import ABC
-
-import csv
 from pathlib import Path
 
 from pyproj import CRS
-from pyproj.database import get_authorities
-
-from wiser.bandmath.builtins.constants import MAX_RAM_BYTES
-
-AVAILABLE_AUTHORITIES = get_authorities()
 
 
 class COLUMN_ID(IntEnum):
@@ -67,97 +69,15 @@ class COLUMN_ID(IntEnum):
     REMOVAL_COL = 9
 
 
-RESAMPLE_ALGORITHMS = {name: getattr(gdal, name) for name in dir(gdal) if name.startswith("GRA_")}
+# RESAMPLE_ALGORITHMS, TRANSFORM_TYPES, and min_points_per_transform now live in
+# wiser.raster.georef_warp alongside the Qt-free warp engine; they are imported at the top
+# of this module and re-exported here for backwards compatibility.
 
 
-class TRANSFORM_TYPES(Enum):
-    POLY_1 = "Affine (Polynomial 1)"
-    POLY_2 = "Polynomial 2"
-    POLY_3 = "Polynomial 3"
-    TPS = "Thin Plate Spline (TPS)"
-
-
-min_points_per_transform = {
-    TRANSFORM_TYPES.POLY_1: 3,
-    TRANSFORM_TYPES.POLY_2: 6,
-    TRANSFORM_TYPES.POLY_3: 10,
-    TRANSFORM_TYPES.TPS: 10,
-}
-
-
-class GeneralCRS(ABC):
-    """
-    The base class representing a generic coordinate reference system
-    """
-
-    def get_osr_crs(self) -> Optional[osr.SpatialReference]:
-        """
-        Gets a osr.SpatialReference object for this class
-        """
-        raise NotImplementedError("Function has not yet been implemented.")
-
-    def __eq__(self, other: "GeneralCRS"):
-        return self.get_osr_crs().ExportToWkt() == other.get_osr_crs().ExportToWkt()
-
-
-class AuthorityCodeCRS(GeneralCRS):
-    """
-    This class represents a coordinate reference system that is made
-    from just the autority name and the authority code.
-    """
-
-    def __init__(self, authority_name: str, authority_code: int):
-        self.authority_name = authority_name
-        self.authority_code = authority_code
-
-    def get_osr_crs(self) -> Optional[osr.SpatialReference]:
-        # Build the AUTH:CODE string
-        auth_code_str = f"{self.authority_name}:{self.authority_code}"
-
-        # Create and populate the SpatialReference
-        srs = osr.SpatialReference()
-        err = srs.SetFromUserInput(auth_code_str)
-        if err != 0:
-            raise RuntimeError(f"Failed to import CRS '{auth_code_str}' (GDAL error {err})")
-
-        return srs
-
-
-class UserGeneratedCRS(GeneralCRS):
-    """
-    This class represents a CRS that the user made in the
-    reference_creator_dialog
-    """
-
-    def __init__(self, name: str, crs: osr.SpatialReference):
-        self._name = name
-        self._crs = crs
-
-    def get_osr_crs(self) -> Optional[osr.SpatialReference]:
-        return self._crs
-
-
-class WktGeneratedCRS(GeneralCRS):
-    """
-    A coordinate reference system generated from a wkt string
-    """
-
-    def __init__(self, name: str, wkt: str):
-        self._name = name
-        self._wkt = wkt
-        crs = osr.SpatialReference()
-        crs.ImportFromWkt(wkt)
-        self._crs = crs
-
-    def get_osr_crs(self) -> Optional[osr.SpatialReference]:
-        return self._crs
-
-
-COMMON_SRS = {
-    "WGS84 EPSG:4326": AuthorityCodeCRS("EPSG", 4326),
-    "Web Mercator EPSG:3857": AuthorityCodeCRS("EPSG", 3857),
-    "NAD83 / UTM zone 15N EPSG:26915": AuthorityCodeCRS("EPSG", 26915),
-}
+# The CRS model (GeneralCRS and subclasses, COMMON_SRS, AVAILABLE_AUTHORITIES) now lives
+# in wiser.raster.crs_model so it can be shared Qt-free with the mosaic CRS chooser. It is
+# imported at the top of this module and re-exported here for backwards compatibility with
+# existing callers that import these names from geo_reference_dialog.
 
 
 class GeoRefTableEntry:
@@ -265,10 +185,21 @@ class GeoReferencerDialog(QDialog):
 
     gcp_add_attempt = Signal(GroundControlPoint)
 
-    def __init__(self, app_state: ApplicationState, main_view: RasterPane, parent=None):
+    # Emitted with the written output path once a "Run Warp" finishes on its worker thread.
+    warp_completed = Signal(str)
+
+    # Internal: carries a completed residual computation (payload includes an in-flight
+    # token) back to the GUI thread from the scheduler worker. Connected queued so the
+    # table update always runs on the GUI thread.
+    _residuals_ready = Signal(object)
+
+    # Debounce window (ms) for coalescing a burst of GCP edits into one residual recompute.
+    _RESIDUAL_DEBOUNCE_MS = 150
+
+    def __init__(self, app_state: ApplicationState, app_services, parent=None):
         super().__init__(parent=parent)
         self._app_state = app_state
-        self._main_view = main_view
+        self._app_services = app_services
 
         # Set up the UI state
         self._ui = Ui_GeoReferencerDialog()
@@ -305,11 +236,33 @@ class GeoReferencerDialog(QDialog):
         self._manual_entry_spacer = None
         self._manual_entry_shown = False
 
-        self._first_init()
+        # Chooser lock flags (set from a GeoReferencerConfig). When locked, the matching
+        # chooser is caller-owned and the interactive prompts/validation are suppressed.
+        self._target_locked = False
+        self._reference_locked = False
+        self._save_path_locked = False
+
+        # Remembers the accept button's original label so a config-supplied
+        # accept_button_text can be reverted on the next (config-less) open.
+        self._default_accept_button_text: Optional[str] = None
 
         self._warp_kwargs: Dict = None
         self._transform_options: List[str] = None
         self._suppress_cell_changed: bool = False
+
+        # Off-thread + debounced residual recompute. A burst of GCP edits coalesces into a
+        # single background compute_residuals() once edits settle for _RESIDUAL_DEBOUNCE_MS.
+        # _residual_signature is the token of the in-flight compute; a superseded result is
+        # dropped so a stale computation can never clobber newer residuals. Created before
+        # _first_init() because chooser wiring can trigger a residual recompute immediately.
+        self._residual_signature: int = 0
+        self._residual_debounce_timer = QTimer(self)
+        self._residual_debounce_timer.setSingleShot(True)
+        self._residual_debounce_timer.setInterval(self._RESIDUAL_DEBOUNCE_MS)
+        self._residual_debounce_timer.timeout.connect(self._recompute_residuals_async)
+        self._residuals_ready.connect(self._apply_residuals)
+
+        self._first_init()
 
         self._prev_chosen_ref_crs_index: int = 0
 
@@ -319,12 +272,12 @@ class GeoReferencerDialog(QDialog):
         self._prev_ref_dataset_index: int = None
         self._prev_target_dataset_index: int = None
 
-    def exec_(self):
-        self._refresh_init()
+    def exec_(self, config: Optional[GeoReferencerConfig] = None):
+        self._apply_config(config)
         super().exec_()
 
-    def show(self):
-        self._refresh_init()
+    def show(self, config: Optional[GeoReferencerConfig] = None):
+        self._apply_config(config)
         super().show()
 
     # region Initialization
@@ -346,10 +299,63 @@ class GeoReferencerDialog(QDialog):
         self._init_help_button()
         self._init_gcp_io_buttons()
 
-    def _refresh_init(self):
+    def _apply_config(self, config: Optional[GeoReferencerConfig] = None):
+        """
+        Reset the dialog to its baseline, then apply a :class:`GeoReferencerConfig`.
+
+        ``config=None`` reproduces the classic Tools-menu behavior exactly: repopulate the
+        choosers and clear any locks / custom accept-button text left over from a prior
+        (config-driven) open of this reused dialog.
+        """
+        # Baseline: repopulate choosers and clear prior locks / accept-button label.
         self._update_dataset_choosers()
         self._update_ref_crs_cbox_items()
         self._update_output_srs_cbox_items()
+        self._set_target_locked(False)
+        self._set_reference_locked(False)
+        self._set_save_path_locked(False)
+        self._restore_default_accept_button_text()
+
+        if config is None:
+            return
+
+        # Presets are applied before locks so the setters (and the manual-ref chooser) can
+        # still act while the reference is momentarily unlocked.
+        if config.target_dataset is not None:
+            self.set_target_dataset(config.target_dataset)
+        if config.reference_dataset is not None:
+            self.set_reference_dataset(config.reference_dataset)
+        elif config.reference_crs is not None:
+            self.set_reference_crs(config.reference_crs)
+        if config.save_path is not None:
+            self.set_save_path(config.save_path)
+
+        if config.accept_button_text is not None:
+            self._set_accept_button_text(config.accept_button_text)
+
+        self._set_target_locked(not config.allow_change_target)
+        self._set_reference_locked(not config.allow_change_reference)
+        self._set_save_path_locked(not config.allow_change_save_path)
+
+        # Now that presets are in place, refresh the residual columns.
+        self._schedule_residual_recompute()
+
+    def _set_accept_button_text(self, text: str):
+        """Relabel the accept (OK) button, remembering the original text for restore."""
+        btn = self._ui.buttonBox.button(QDialogButtonBox.Ok)
+        if btn is None:
+            return
+        if self._default_accept_button_text is None:
+            self._default_accept_button_text = btn.text()
+        btn.setText(text)
+
+    def _restore_default_accept_button_text(self):
+        """Revert the accept button to its original label (if it was changed)."""
+        if self._default_accept_button_text is None:
+            return
+        btn = self._ui.buttonBox.button(QDialogButtonBox.Ok)
+        if btn is not None:
+            btn.setText(self._default_accept_button_text)
 
     def _init_gcp_io_buttons(self):
         self._ui.btn_save_gcps.clicked.connect(self._on_save_gcps_clicked)
@@ -427,6 +433,10 @@ class GeoReferencerDialog(QDialog):
         Shows the manual reference chooser UI if there is no dataset passed in. Shows
         the reference dataset if there is a dataset passed in.
         """
+        # When the reference is locked (caller-owned), suppress toggling the manual chooser
+        # so the reference display cannot be changed out from under the caller.
+        if self._reference_locked:
+            return
         if self._manual_entry_spacer is None:
             self._manual_entry_spacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
         self._manual_entry_shown = show_manual_chooser
@@ -696,18 +706,32 @@ class GeoReferencerDialog(QDialog):
             if wkt_auth is not None:
                 auth_name, auth_code = wkt_auth
 
+        rows = self._get_gcp_rows()
         ext = Path(filename).suffix.lower()
         try:
             if ext == ".points":
-                self._write_qgis_points_file(filename, auth_name, auth_code, wkt_str)
+                gcp_io.write_qgis_points(filename, rows, auth_name, auth_code, wkt_str)
             elif ext == ".pts":
-                self._write_envi_pts_file(filename, auth_name, auth_code, wkt_str)
+                gcp_io.write_envi_pts(filename, rows, auth_name, auth_code, wkt_str)
             else:
                 QMessageBox.warning(self, "Extension error", "Please use either *.points or *.pts")
                 return
             self.set_message_text(f"GCPs saved to {filename}")
         except Exception as e:
             QMessageBox.critical(self, "Save failed", str(e))
+
+    def _get_gcp_rows(self) -> List[Tuple[float, float, float, float, bool]]:
+        """
+        Flatten the current table entries into ``(map_x, map_y, pixel_x, pixel_y,
+        enabled)`` rows for the Qt-free GCP writers in :mod:`wiser.raster.gcp_io`.
+        """
+        rows = []
+        for entry in self._table_entry_list:
+            pair = entry.get_gcp_pair()
+            map_x, map_y = pair.get_reference_gcp_spatial_coord()
+            pix_x, pix_y = pair.get_target_gcp().get_point()
+            rows.append((map_x, map_y, pix_x, pix_y, entry.is_enabled()))
+        return rows
 
     def _on_load_gcps_clicked(self, checked: bool):
         filename, _ = QFileDialog.getOpenFileName(
@@ -719,7 +743,7 @@ class GeoReferencerDialog(QDialog):
             return
 
         try:
-            points, gcp_srs = self._read_gcp_file(filename)
+            points, gcp_srs = gcp_io.read_gcp_file(filename)
             if points is None or gcp_srs is None:
                 raise RuntimeError(
                     "Passed-in reference system can't be parsed. Reference system WKT:\n"
@@ -813,7 +837,7 @@ class GeoReferencerDialog(QDialog):
             target_gcp = list_entry.get_gcp_pair().get_target_gcp()
             curr_point = target_gcp.get_point()
             target_gcp.set_point([new_target_x, curr_point[1]])
-            self._georeference()
+            self._schedule_residual_recompute()
         elif col == COLUMN_ID.TARGET_Y_COL:
             item = table_widget.item(row, col)
             new_val = item.text()
@@ -822,7 +846,7 @@ class GeoReferencerDialog(QDialog):
             target_gcp = list_entry.get_gcp_pair().get_target_gcp()
             curr_point = target_gcp.get_point()
             target_gcp.set_point([curr_point[0], new_target_y])
-            self._georeference()
+            self._schedule_residual_recompute()
         elif col == COLUMN_ID.REF_X_COL:
             item = table_widget.item(row, col)
             new_val = item.text()
@@ -831,7 +855,7 @@ class GeoReferencerDialog(QDialog):
             gcp_pair = list_entry.get_gcp_pair()
             ref_gcp = gcp_pair.get_reference_gcp()
             ref_gcp.set_spatial_point((new_ref_spatial_x, gcp_pair.get_reference_gcp_spatial_coord()[1]))
-            self._georeference()
+            self._schedule_residual_recompute()
         elif col == COLUMN_ID.REF_Y_COL:
             item = table_widget.item(row, col)
             new_val = item.text()
@@ -840,7 +864,7 @@ class GeoReferencerDialog(QDialog):
             gcp_pair = list_entry.get_gcp_pair()
             ref_gcp = gcp_pair.get_reference_gcp()
             ref_gcp.set_spatial_point((gcp_pair.get_reference_gcp_spatial_coord()[0], new_ref_spatial_y))
-            self._georeference()
+            self._schedule_residual_recompute()
         else:
             return
         self._update_panes()
@@ -849,6 +873,10 @@ class GeoReferencerDialog(QDialog):
         """
         A handler for when the file-chooser for the "save-filename" is shown.
         """
+        # A locked save path is caller-owned: do not let the user re-choose it, and skip the
+        # save-path-vs-dataset-path validation below (which assumes a user-chosen path).
+        if self._save_path_locked:
+            return
         file_dialog = QFileDialog(parent=self, caption=self.tr("Save raster dataset"))
 
         # Restrict selection to only .tif files.
@@ -888,12 +916,12 @@ class GeoReferencerDialog(QDialog):
                 )
                 return
             self._ui.ledit_save_path.setText(filename)
-            self._georeference()
+            self._schedule_residual_recompute()
 
     def _on_switch_output_srs(self, index: int):
         # We don't record the output srs because we get this
         # directly from the combo box.
-        self._georeference()
+        self._schedule_residual_recompute()
 
     def _on_switch_chosen_ref_srs(self, index: int):
         if self._prev_chosen_ref_crs_index != index:
@@ -915,7 +943,7 @@ class GeoReferencerDialog(QDialog):
     def _on_switch_transform_type(self, index: int):
         transform_type = self._ui.cbox_poly_order.itemData(index)
         self._curr_transform_type = transform_type
-        self._georeference()
+        self._schedule_residual_recompute()
 
     def _on_choose_default_color(self):
         """
@@ -961,7 +989,7 @@ class GeoReferencerDialog(QDialog):
         row_to_add = table_entry.get_id()
         self._set_row_enabled_state(row_to_add, checked)
         self._update_panes()
-        self._georeference()
+        self._schedule_residual_recompute()
 
     def _on_gcp_pair_added(self, gcp_pair: GroundControlPointPair):
         # Create new table entry
@@ -976,99 +1004,176 @@ class GeoReferencerDialog(QDialog):
         # geo referencer task delegate point list
         self._add_entry_to_table(table_entry)
         self._clear_manual_ref_ledits()
-        self._georeference()
+        self._schedule_residual_recompute()
 
     def _on_removal_button_clicked(self, table_entry: GeoRefTableEntry):
         """
         Removes an row from the table
         """
         self._remove_table_entry(table_entry)
-        self._georeference()
+        self._schedule_residual_recompute()
 
     def _on_switch_target_dataset(self, index: int):
+        """
+        User-initiated target chooser slot: run the guard + confirm-discard prompts, then
+        funnel through :meth:`set_target_dataset` (the shared, prompt-free apply path).
+        """
         ds_id = self._target_cbox.itemData(index)
-        dataset = None
         try:
-            # Check if the file save path already there matches this
-            current_save_path = self._get_current_save_path()
             dataset = self._app_state.get_dataset(ds_id)
-            if dataset is not None:
-                if current_save_path in dataset.get_filepaths():
-                    QMessageBox.information(
-                        self,
-                        self.tr("Target Dataset Path Equals Save Path"),
-                        self.tr(
-                            "The target dataset path equals the save path.\n"
-                            "Change the save path before selecting this target dataset."
-                        ),
-                    )
-                    self._target_cbox.setCurrentIndex(self._prev_target_dataset_index)
-                    return
-            # Check if there are already GCPs
-            if len(self._table_entry_list) > 0 and self._prev_target_dataset_index != index:
-                confirm = QMessageBox.question(
-                    self,
-                    self.tr("Change Target Dataset?"),
-                    self.tr("Are you sure you want to change the target dataset?")
-                    + "\n\nThis will discard all selected GCPs. Do you want\n"
-                    "to continue?",
-                )
-                if confirm == QMessageBox.Yes:
-                    self._reset_gcps()
-                else:
-                    self._target_cbox.setCurrentIndex(self._prev_target_dataset_index)
-                    return
-        except:
-            pass
+        except Exception as e:
+            self.set_message_text(f"Could not load target dataset: {e}")
+            self._target_cbox.setCurrentIndex(self._prev_target_dataset_index)
+            return
+
+        # The target's file must not equal the save path.
+        current_save_path = self._get_current_save_path()
+        if dataset is not None and current_save_path in dataset.get_filepaths():
+            QMessageBox.information(
+                self,
+                self.tr("Target Dataset Path Equals Save Path"),
+                self.tr(
+                    "The target dataset path equals the save path.\n"
+                    "Change the save path before selecting this target dataset."
+                ),
+            )
+            self._target_cbox.setCurrentIndex(self._prev_target_dataset_index)
+            return
+
+        # Changing the target discards existing GCPs; confirm first.
+        if len(self._table_entry_list) > 0 and self._prev_target_dataset_index != index:
+            confirm = QMessageBox.question(
+                self,
+                self.tr("Change Target Dataset?"),
+                self.tr("Are you sure you want to change the target dataset?")
+                + "\n\nThis will discard all selected GCPs. Do you want\n"
+                "to continue?",
+            )
+            if confirm == QMessageBox.Yes:
+                self._reset_gcps()
+            else:
+                self._target_cbox.setCurrentIndex(self._prev_target_dataset_index)
+                return
+
+        self.set_target_dataset(dataset)
+
+    def set_target_dataset(self, dataset: Optional[RasterDataSet]):
+        """
+        Show ``dataset`` in the target pane without any user prompts (programmatic path,
+        shared by the chooser slot). Syncs the chooser to match.
+        """
+        self._select_dataset_in_combo(self._target_cbox, dataset)
         self._target_rasterpane.show_dataset(dataset)
         self._prev_target_dataset_index = self._target_cbox.currentIndex()
 
+    def _select_dataset_in_combo(self, combo: QComboBox, dataset: Optional[RasterDataSet]):
+        """Point ``combo`` at ``dataset`` (or the "(no data)" -1 entry when None)."""
+        ds_id = dataset.get_id() if dataset is not None else -1
+        idx = combo.findData(ds_id)
+        if idx >= 0:
+            combo.setCurrentIndex(idx)
+
     def _on_switch_reference_dataset(self, index: int):
+        """
+        User-initiated reference chooser slot: run the guard + confirm-discard prompts, then
+        funnel through :meth:`set_reference_dataset` (the shared, prompt-free apply path).
+        """
         ds_id = self._reference_cbox.itemData(index)
-        dataset = None
         try:
-            # Check if the file save path already there matches this
-            current_save_path = self._get_current_save_path()
             dataset = self._app_state.get_dataset(ds_id)
-            if dataset is not None:
-                if current_save_path in dataset.get_filepaths():
-                    QMessageBox.information(
-                        self,
-                        self.tr("Reference Dataset Path Equals Save Path"),
-                        self.tr(
-                            "The reference dataset path equals the save path.\n"
-                            "Change the save path before selecting this reference dataset."
-                        ),
-                    )
-                    self._reference_cbox.setCurrentIndex(self._prev_ref_dataset_index)
-                    return
-            if len(self._table_entry_list) > 0 and self._prev_ref_dataset_index != index:
-                confirm = QMessageBox.question(
-                    self,
-                    self.tr("Change Reference Dataset?"),
-                    self.tr("Are you sure you want to change the reference dataset?")
-                    + "\n\nThis will discard all selected GCPs. Do you want\n"
-                    "to continue?",
-                )
-                if confirm == QMessageBox.Yes:
-                    self._reset_gcps()
-                else:
-                    self._reference_cbox.setCurrentIndex(self._prev_ref_dataset_index)
-                    return
-            if not dataset.has_geographic_info():
-                QMessageBox.warning(
-                    self,
-                    self.tr("Unreferenced Dataset"),
-                    self.tr("You must choose a dataset with a spatial reference system"),
-                )
+        except Exception as e:
+            self.set_message_text(f"Could not load reference dataset: {e}")
+            self._reference_cbox.setCurrentIndex(self._prev_ref_dataset_index)
+            return
+
+        # The reference's file must not equal the save path.
+        current_save_path = self._get_current_save_path()
+        if dataset is not None and current_save_path in dataset.get_filepaths():
+            QMessageBox.information(
+                self,
+                self.tr("Reference Dataset Path Equals Save Path"),
+                self.tr(
+                    "The reference dataset path equals the save path.\n"
+                    "Change the save path before selecting this reference dataset."
+                ),
+            )
+            self._reference_cbox.setCurrentIndex(self._prev_ref_dataset_index)
+            return
+
+        # Changing the reference discards existing GCPs; confirm first.
+        if len(self._table_entry_list) > 0 and self._prev_ref_dataset_index != index:
+            confirm = QMessageBox.question(
+                self,
+                self.tr("Change Reference Dataset?"),
+                self.tr("Are you sure you want to change the reference dataset?")
+                + "\n\nThis will discard all selected GCPs. Do you want\n"
+                "to continue?",
+            )
+            if confirm == QMessageBox.Yes:
+                self._reset_gcps()
+            else:
                 self._reference_cbox.setCurrentIndex(self._prev_ref_dataset_index)
                 return
-        except:
-            pass
+
+        # A real reference dataset must carry a spatial reference; guard against None so we
+        # do not call has_geographic_info() on the "(no data)" selection.
+        if dataset is not None and not dataset.has_geographic_info():
+            QMessageBox.warning(
+                self,
+                self.tr("Unreferenced Dataset"),
+                self.tr("You must choose a dataset with a spatial reference system"),
+            )
+            self._reference_cbox.setCurrentIndex(self._prev_ref_dataset_index)
+            return
+
+        self.set_reference_dataset(dataset)
+
+    def set_reference_dataset(self, dataset: Optional[RasterDataSet]):
+        """
+        Show ``dataset`` in the reference pane without any user prompts (programmatic path,
+        shared by the chooser slot). Syncs the chooser to match.
+        """
+        self._select_dataset_in_combo(self._reference_cbox, dataset)
         self._reference_rasterpane.show_dataset(dataset)
         self._update_output_srs_cbox_items()
         self._show_manual_ref_chooser_display(False)
         self._prev_ref_dataset_index = self._reference_cbox.currentIndex()
+
+    def set_reference_crs(self, crs: Optional[GeneralCRS]):
+        """
+        Use a manual reference CRS (no reference dataset): show the manual chooser and
+        select ``crs`` in it. Used to preset the reference when a config supplies a CRS
+        instead of a reference dataset.
+        """
+        if crs is None:
+            return
+        self._select_dataset_in_combo(self._reference_cbox, None)
+        self._show_manual_ref_chooser_display(True)
+        srs = crs.get_osr_crs()
+        name = srs.GetName() if srs is not None else "Reference CRS"
+        self._add_srs_to_ref_choose_cbox(name, crs)
+
+    def set_save_path(self, path: Optional[str]):
+        """Preset the output save path (programmatic path)."""
+        if path is None:
+            return
+        self._ui.ledit_save_path.setText(path)
+
+    def _set_target_locked(self, locked: bool):
+        """Lock the target chooser (caller owns the target dataset)."""
+        self._target_locked = locked
+        self._target_cbox.setEnabled(not locked)
+
+    def _set_reference_locked(self, locked: bool):
+        """Lock the reference chooser (caller owns the reference dataset/CRS)."""
+        self._reference_locked = locked
+        self._reference_cbox.setEnabled(not locked)
+
+    def _set_save_path_locked(self, locked: bool):
+        """Lock the save path (caller owns the output path)."""
+        self._save_path_locked = locked
+        self._ui.ledit_save_path.setReadOnly(locked)
+        self._ui.btn_save_path.setEnabled(not locked)
 
     # region Helpers
 
@@ -1199,194 +1304,6 @@ class GeoReferencerDialog(QDialog):
                 info_lines.append("")  # blank line between entries
 
             QMessageBox.information(self, "Skipped GCPs", "\n".join(info_lines).rstrip())
-
-    def _read_gcp_file(self, path: str):
-        ext = Path(path).suffix.lower()
-        if ext == ".points":
-            return self._read_qgis_points_file(path)
-        elif ext == ".pts":
-            return self._read_envi_pts_file(path)
-        raise RuntimeError("Unsupported GCP file extension")
-
-    def _read_qgis_points_file(self, path: str) -> Tuple[List, GeneralCRS]:
-        """Read a QGIS ``*.points`` file.
-
-        If the header contains ``# CRS`` the routine returns an
-        :class:`AuthorityCodeCRS`; otherwise it looks for ``# WKT`` and
-        returns a :class:`WktGeneratedCRS`.
-
-        Returns
-        -------
-        points : list[tuple[float, float, float, float]]
-            ``(map_x, map_y, pixel_x, pixel_y)`` tuples.
-        gcp_srs : GeneralCRS
-            Extracted from the header
-        """
-        points = []
-        gcp_srs = None
-        pending_wkt = None
-
-        with open(path, newline="") as f:
-            rdr = csv.reader(f)
-            for row in rdr:
-                if not row:
-                    continue
-                if row[0].startswith("# CRS"):
-                    _, authcode = row[:2]
-                    auth, code = authcode.split(":")
-                    gcp_srs = AuthorityCodeCRS(auth, int(code))
-                    continue
-                if row[0].startswith("# WKT"):
-                    # WKT may contain commas, so rebuild the original line
-                    pending_wkt = ",".join(row[1:]).strip()
-                    continue
-                if row[0].startswith("mapX"):
-                    continue
-                map_x, map_y, pix_x, pix_y, *_ = map(float, row[:5])
-                points.append((map_x, map_y, pix_x, pix_y))
-
-        if gcp_srs is None and pending_wkt:
-            gcp_srs = WktGeneratedCRS("WKT", pending_wkt)
-        if gcp_srs is None:
-            raise RuntimeError("No CRS or WKT line found in .points file")
-        return points, gcp_srs
-
-    def _read_envi_pts_file(self, path: str) -> Tuple[List, GeneralCRS]:
-        """Read an ENVI ``*.pts`` file with optional embedded WKT.
-
-        The routine first tries the traditional ``; projection info`` comment
-        to extract *(authority, code)*.  If that is missing it looks for a
-        line beginning ``; wkt =`` and constructs a
-        :class:`WktGeneratedCRS`.
-
-        Returns
-        -------
-        points : list[tuple[float, float, float, float]]
-            ``(map_x, map_y, pixel_x, pixel_y)`` tuples.
-        gcp_srs : GeneralCRS
-            Extracted from the header
-        """
-        points = []
-        gcp_srs = None
-        pending_wkt = None
-        with open(path) as f:
-            for ln in f:
-                ln = ln.strip()
-                if ln.lower().startswith("; projection info"):
-                    inside = ln.split("{", 1)[-1].split("}", 1)[0]
-                    auth, code, *_ = [x.strip().split(",")[0] for x in inside.split()]
-                    gcp_srs = AuthorityCodeCRS(auth, int(code))
-                elif ln.lower().startswith("; wkt ="):
-                    pending_wkt = ln.split("=", 1)[1].strip()
-                elif ln.startswith(";") or not ln:
-                    continue
-                else:
-                    parts = list(map(float, ln.split()))
-                    if len(parts) >= 5:
-                        map_x, map_y, _elev, pix_x, pix_y = parts[:5]
-                        points.append((map_x, map_y, pix_x, pix_y))
-        if gcp_srs is None and pending_wkt:
-            gcp_srs = WktGeneratedCRS("WKT", pending_wkt)
-        if gcp_srs is None:
-            raise RuntimeError("No projection info or WKT found in .pts file")
-        return points, gcp_srs
-
-    def _write_qgis_points_file(
-        self,
-        path: str,
-        auth: Optional[str] = None,
-        code: Optional[str] = None,
-        wkt: Optional[str] = None,
-    ) -> None:
-        """Write ground-control points to a QGIS ``*.points`` file.
-
-        Parameters
-        ----------
-        path : str
-            Destination filepath (should end with ``.points``).
-        auth : str or None, optional
-            Authority name (e.g. ``"EPSG"``).  If *None*, the ``# CRS``
-            header line is **omitted**.
-        code : str or None, optional
-            Authority code (e.g. ``"4326"``).  Ignored when *auth* is
-            *None*.
-        wkt : str or None, optional
-            Well-Known Text definition of the CRS.  When provided it is
-            written on a dedicated line starting with ``# WKT``.  QGIS
-            will ignore this line, but *WISER* can parse it on load.
-
-        Notes
-        -----
-        The file layout becomes::
-
-            # CRS, EPSG:4326  ← optional
-            # WKT,<LONG_WKT> ← optional
-            mapX,mapY,pixelX,pixelY,enable
-            123.4, 45.6, 100.0, 200.0, 1
-            ...
-
-        Only ASCII commas are used as delimiters so the routine is
-        locale-independent.
-        """
-        header_rows = []
-        if auth and code:
-            header_rows.append(["# CRS", f"{auth}:{code}"])
-        if wkt:
-            header_rows.append(["# WKT", wkt])
-
-        with open(path, "w", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerows(header_rows)
-            writer.writerow(["mapX", "mapY", "pixelX", "pixelY", "enable"])
-
-            for entry in self._table_entry_list:
-                pair = entry.get_gcp_pair()
-                map_x, map_y = pair.get_reference_gcp_spatial_coord()
-                pix_x, pix_y = pair.get_target_gcp().get_point()
-                writer.writerow(
-                    [
-                        map_x,
-                        map_y,
-                        pix_x,
-                        pix_y,
-                        1 if entry.is_enabled() else 0,
-                    ]
-                )
-
-    def _write_envi_pts_file(
-        self,
-        path: str,
-        auth: Optional[str] = None,
-        code: Optional[str] = None,
-        wkt: Optional[str] = None,
-    ) -> None:
-        """Write ground-control points to an ENVI ``*.pts`` file. auth and code
-        must be non-None or wkt must be non-None
-
-        Parameters
-        ----------
-        path : str
-            Destination filepath (should end with ``.pts``).
-        auth, code : str or None, optional
-            Authority name and code.  When either is *None*, the traditional
-            ``; projection info`` comment is skipped.
-        wkt : str or None, optional
-            Well-Known Text to embed after a ``; wkt = `` comment.  ENVI will
-            ignore this line; *WISER* uses it when the authority pair is
-            missing.
-        """
-        with open(path, "w") as f:
-            f.write("; ENVI Ground Control Points File\n")
-            if auth and code:
-                f.write(f"; projection info = {{{auth}, {code}, units=Degrees}}\n")
-            if wkt:
-                f.write(f"; wkt = {wkt}\n")
-            f.write("; Map (x,y,elev), Image (x,y)\n;\n")
-            for entry in self._table_entry_list:
-                pair = entry.get_gcp_pair()
-                map_x, map_y = pair.get_reference_gcp_spatial_coord()
-                pix_x, pix_y = pair.get_target_gcp().get_point()
-                f.write(f"{map_x:.10f} {map_y:.10f} 0.0 {pix_x:.3f} {pix_y:.3f}\n")
 
     def _get_current_save_path(self):
         return self._ui.ledit_save_path.text()
@@ -1830,75 +1747,77 @@ class GeoReferencerDialog(QDialog):
         else:
             raise RuntimeError("Both the dataset shown is none and the manual entry widget is None")
 
-    def _georeference(self):
+    def _snapshot_residual_inputs(self) -> Optional[dict]:
+        """
+        Gather everything :func:`compute_residuals` needs, on the GUI thread.
+
+        Returns a dict of the snapshotted inputs, or ``None`` if residuals cannot be
+        computed yet (no save path, no target, or too few points). The GDAL/OSR objects
+        captured here are plain data that can be safely handed to a worker thread.
+        """
         save_path = self._get_save_file_path()
         if save_path is None:
             self.set_message_text("Must enter a save path for geo referencing to occur!")
-            return
+            return None
 
         if self._target_rasterpane.get_rasterview().get_raster_data() is None:
-            self.set_message_text("Must select a targetr dataset for geo referencing to occur!")
-            return
+            self.set_message_text("Must select a target dataset for geo referencing to occur!")
+            return None
 
         if not self._enough_points_for_transform():
             self._set_all_residuals_NA()
-            return
+            return None
 
-        gdal.UseExceptions()
+        entries_and_gcps = self._get_entry_gcp_list()
+        entries = [entry for entry, _ in entries_and_gcps]
+        gcps = [gcp for _, gcp in entries_and_gcps]
 
-        gcps: List[GeoRefTableEntry, gdal.GCP] = self._get_entry_gcp_list()
-
-        output_srs = osr.SpatialReference()
         output_srs = self._import_current_output_srs()
         output_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 
         ref_srs = self._get_reference_srs()
         ref_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
-        ref_projection = ref_srs.ExportToWkt()
-        # If it doesn't have a gdal dataset, instead we create one from a smaller
-        # array just to do geo referencing
-        assert (
-            ref_projection is not None and ref_srs is not None
-        ), f"ref_srs ({ref_srs}) or ref_project ({ref_projection}) is None!"
 
-        # We need a temporary gdal dataset so we can calculate the residuals
-        # without making a massive data object
-        temp_gdal_ds = None
-        place_holder_arr = np.zeros((1, 1), np.uint8)
-        temp_gdal_ds: gdal.Dataset = gdal_array.OpenNumPyArray(place_holder_arr, True)
-        temp_gdal_ds.SetSpatialRef(ref_srs)
-        temp_gdal_ds.SetGCPs([pair[1] for pair in gcps], ref_projection)
+        warp_kwargs, transformer_options = build_warp_kwargs(
+            self._curr_resample_alg, self._curr_transform_type, output_srs
+        )
+        # Retain the last-built kwargs/options for any callers that still read them.
+        self._warp_kwargs = warp_kwargs
+        self._transform_options = transformer_options
 
-        # Set all of the metadata we need to
-        self._warp_kwargs = {
-            "copyMetadata": True,
-            "resampleAlg": self._curr_resample_alg,
-            "dstSRS": output_srs,
+        return {
+            "entries": entries,
+            "gcps": gcps,
+            "ref_srs": ref_srs,
+            "output_srs": output_srs,
+            "warp_kwargs": warp_kwargs,
+            "transformer_options": transformer_options,
         }
 
-        self._transform_options = [f"DST_SRS={output_srs.ExportToWkt()}"]
+    def _apply_residuals_to_entries(self, entries, residuals):
+        """Write computed residuals back onto the table entries (GUI thread)."""
+        for entry, (residual_x, residual_y) in zip(entries, residuals):
+            entry.set_residual_x(round(residual_x, 6))
+            entry.set_residual_y(round(residual_y, 6))
+            self._update_residuals(entry)
 
-        if self._curr_transform_type == TRANSFORM_TYPES.TPS:
-            self._warp_kwargs["tps"] = True
-            self._transform_options += ["METHOD=GCP_TPS", "MAX_GCP_ORDER=-1"]
-        elif self._curr_transform_type == TRANSFORM_TYPES.POLY_1:
-            self._warp_kwargs["polynomialOrder"] = 1
-            self._transform_options += ["METHOD=GCP_POLYNOMIAL", "MAX_GCP_ORDER=1"]
-        elif self._curr_transform_type == TRANSFORM_TYPES.POLY_2:
-            self._warp_kwargs["polynomialOrder"] = 2
-            self._transform_options += ["METHOD=GCP_POLYNOMIAL", "MAX_GCP_ORDER=2"]
-        elif self._curr_transform_type == TRANSFORM_TYPES.POLY_3:
-            self._warp_kwargs["polynomialOrder"] = 3
-            self._transform_options += ["METHOD=GCP_POLYNOMIAL", "MAX_GCP_ORDER=3"]
-        else:
-            raise RuntimeError(f"Unknown self._curr_transform_type: {self._curr_transform_type}")
-        self._warp_kwargs["transformerOptions"] = self._transform_options
+    def _georeference(self):
+        """
+        Synchronously recompute residuals and update the table.
 
+        Kept for tests and as the no-scheduler fallback; interactive edits go through
+        :meth:`_schedule_residual_recompute` so the GUI never blocks on a warp.
+        """
+        snapshot = self._snapshot_residual_inputs()
+        if snapshot is None:
+            return
         try:
-            # This will be used to transform the pixel coordinate to the
-            # output srs coordinate that has undergone the spatial warping
-            tr_pixel_to_output_srs: gdal.Transformer = gdal.Transformer(
-                temp_gdal_ds, None, self._transform_options
+            residuals = compute_residuals(
+                snapshot["gcps"],
+                snapshot["ref_srs"],
+                snapshot["output_srs"],
+                snapshot["warp_kwargs"],
+                snapshot["transformer_options"],
             )
         except BaseException as e:
             msg = str(e)
@@ -1906,76 +1825,79 @@ class GeoReferencerDialog(QDialog):
                 msg = msg[:197] + "..."
             QMessageBox.critical(self, self.tr("Error!"), self.tr(f"Error:\n{msg}"), QMessageBox.Ok)
             return
+        self._apply_residuals_to_entries(snapshot["entries"], residuals)
 
-        try:
-            # Sneak peek into the transformed dataset's geo transform so we can use them later
-            # when calculating residuals. We don't just use the geotransform here to calculate
-            # residuals because transformed_gt goes from the warped datasets pixel coordinates
-            # to the warped dataset's spatial coordinates. Our GCPs are just in the target
-            # dataset's pixel coordinates and reference srs's spatial coordinates.
-            warp_options = gdal.WarpOptions(**self._warp_kwargs)
-            warp_save_path = f"/vsimem/temp_band_{0}"
-            place_holder_arr = np.zeros((1, 1), np.uint8)
-            temp_gdal_ds: gdal.Dataset = gdal_array.OpenNumPyArray(place_holder_arr, True)
-            temp_gdal_ds.SetGCPs([pair[1] for pair in gcps], ref_projection)
-            transformed_ds: gdal.Dataset = gdal.Warp(warp_save_path, temp_gdal_ds, options=warp_options)
-            transformed_gt = transformed_ds.GetGeoTransform()
+    def _schedule_residual_recompute(self):
+        """
+        Request a residual recompute after edits settle.
 
-            # The output_srs here is the target spatial reference system (srs). In case
-            # the target srs is different from the reference srs, then we need a way to
-            # go between them.
-            tr_output_srs_to_ref_srs = osr.CoordinateTransformation(output_srs, ref_srs)
+        Coalesces a burst of GCP edits into a single background compute. When no scheduler
+        is available (e.g. some unit contexts), falls back to a synchronous recompute.
+        """
+        scheduler = getattr(self._app_services, "scheduler", None) if self._app_services else None
+        if scheduler is None:
+            self._georeference()
+            return
+        self._residual_debounce_timer.start()
 
-            residuals = []
-            # The general flow of calculating the residuals is to go from our target
-            # dataset's pixel coordinate (gcp.GCPPixel, gcp.GCPLine) to our output
-            # srs coordinates. Then we go from the output srs coordinate to the
-            # reference srs coordinate. We then get the difference in reference srs
-            # coordinates from the original GCP to get the spatial error. Then to make
-            # it a pixel error we divide by the width/height per pixel of the warped
-            # dataset's geo transform.
-            for entry, gcp in gcps:
-                # These coordinates could get back to us in either lat/lon, lon/lat,
-                # or north/easting, easting/north
-                (
-                    ok,
-                    (output_spatial_x, output_spatial_y, z),
-                ) = tr_pixel_to_output_srs.TransformPoint(False, gcp.GCPPixel, gcp.GCPLine)
+    def _recompute_residuals_async(self):
+        """
+        Fired by the debounce timer: snapshot inputs on the GUI thread and run
+        :func:`compute_residuals` on the work scheduler, tracking an in-flight token so a
+        superseded result is dropped.
+        """
+        snapshot = self._snapshot_residual_inputs()
+        if snapshot is None:
+            return
 
-                # Since we use OAMS_TRADITIONAL_GIS_ORDER on both reference and output CRS, we don't need
-                # to swap the spatial coordinates
-                ref_spatial_coord = tr_output_srs_to_ref_srs.TransformPoint(
-                    output_spatial_x, output_spatial_y, 0
+        scheduler = getattr(self._app_services, "scheduler", None) if self._app_services else None
+        if scheduler is None:
+            try:
+                residuals = compute_residuals(
+                    snapshot["gcps"],
+                    snapshot["ref_srs"],
+                    snapshot["output_srs"],
+                    snapshot["warp_kwargs"],
+                    snapshot["transformer_options"],
                 )
+            except BaseException as e:
+                self.set_message_text(f"Error computing residuals: {e}")
+                return
+            self._apply_residuals_to_entries(snapshot["entries"], residuals)
+            return
 
-                ref_spatial_x, ref_spatial_y = (
-                    ref_spatial_coord[0],
-                    ref_spatial_coord[1],
-                )
+        self._residual_signature += 1
+        token = self._residual_signature
+        entries = snapshot["entries"]
 
-                error_spatial_x = gcp.GCPX - ref_spatial_x
-                error_spatial_y = gcp.GCPY - ref_spatial_y
+        def _done(future):
+            try:
+                residuals = future.result()
+            except BaseException:
+                residuals = None
+            # Deliver back to the GUI thread; a stale token is dropped in _apply_residuals.
+            self._residuals_ready.emit((token, entries, residuals))
 
-                error_raster_x = error_spatial_x / transformed_gt[1]
-                error_raster_y = error_spatial_y / transformed_gt[5]
+        future = scheduler.submit_thread(
+            PriorityClass.INTERACTIVE,
+            compute_residuals,
+            snapshot["gcps"],
+            snapshot["ref_srs"],
+            snapshot["output_srs"],
+            snapshot["warp_kwargs"],
+            snapshot["transformer_options"],
+        )
+        future.add_done_callback(_done)
 
-                entry.set_residual_x(round(error_raster_x, 6))
-                entry.set_residual_y(round(error_raster_y, 6))
-
-                self._update_residuals(entry)
-
-                residuals.append((error_raster_x, error_raster_y))
-
-            tr_pixel_to_output_srs = None
-            tr_output_srs_to_ref_srs = None
-            temp_gdal_ds = None
-        except BaseException as e:
-            QMessageBox.warning(self, self.tr("Error"), self.tr(f"Error:\n{e}"), QMessageBox.Ok)
-            print(f"Error:\n{e}")
-        finally:
-            tr_pixel_to_output_srs = None
-            tr_output_srs_to_ref_srs = None
-            temp_gdal_ds = None
+    def _apply_residuals(self, payload):
+        """Install a completed residual computation on the GUI thread (unless superseded)."""
+        token, entries, residuals = payload
+        if token != self._residual_signature:
+            return  # superseded by a newer recompute; discard
+        if residuals is None:
+            self.set_message_text("Error computing residuals.")
+            return
+        self._apply_residuals_to_entries(entries, residuals)
 
     # ========================
     # region Accepting
@@ -1983,182 +1905,83 @@ class GeoReferencerDialog(QDialog):
 
     def _create_warped_output(self) -> bool:
         """
-        Returns a bool on whether this function created the warped dataset correctly.
+        Validate inputs and launch the multi-band warp on a background thread.
+
+        Returns ``True`` if the warp was successfully *started* (inputs valid), ``False``
+        otherwise. The GDAL work runs off the GUI thread via
+        :func:`~wiser.gui.progress_task.run_with_progress`; on completion
+        :meth:`_on_warp_done` emits :attr:`warp_completed` and updates the status label.
         """
-        try:
-            save_path = self._get_save_file_path()
-            if save_path is None:
-                QMessageBox.information(
-                    self,
-                    self.tr("No Save Path Selected"),
-                    self.tr(
-                        "In order to georeference, a save path "
-                        "must be selected. There is no save path "
-                        "selected, so georeferencing will not occur.\n\n"
-                        "Please select a save path."
-                    ),
-                )
-                return False
-
-            if not self._enough_points_for_transform() or self._warp_kwargs is None:
-                QMessageBox.information(
-                    self,
-                    self.tr("Can't Run Georeferencer"),
-                    self.tr("Not enough points to run georeferencer"),
-                )
-                return False
-
-            if self._target_rasterpane.get_rasterview().get_raster_data() is None:
-                QMessageBox.information(
-                    self,
-                    self.tr("No Target Dataset Selected"),
-                    self.tr("A target dataset is not selected. Please select a target dataset."),
-                )
-                return False
-
-            gcps: List[GeoRefTableEntry, gdal.GCP] = self._get_entry_gcp_list()
-
-            target_dataset = self._target_rasterpane.get_rasterview().get_raster_data()
-            target_dataset_impl = target_dataset.get_impl()
-
-            ref_srs = self._get_reference_srs()
-            ref_projection = ref_srs.ExportToWkt()
-            temp_gdal_ds = None
-            output_dataset = None
-
-            self.set_message_text(self.tr("Starting warp..."))
-
-            # We warp one band of the input dataset to a virtual memory file,
-            # so we can create the correct output data size.
-            # Then we create the output dataset with width and height equal to the warp,
-            # but correct number of bands.
-            # Then we override each band in the created array and flush cache.
-            output_size: Tuple[int, int] = None
-            output_dataset: gdal.Dataset = None
-            driver: gdal.Driver = gdal.GetDriverByName("GTiff")
-            gdal_dtype, _ = numpy_dtype_to_gdal_export_types(target_dataset.get_elem_type())
-
-            # Get the output size
-            warp_options = gdal.WarpOptions(**self._warp_kwargs)
-            warp_save_path = f"/vsimem/temp_band_{0}"
-            band_arr = target_dataset.get_band_data(0)
-            temp_gdal_ds: gdal.Dataset = gdal_array.OpenNumPyArray(band_arr, True)
-            # Make sure dataset has no spatial information that could mess with warping
-            temp_gdal_ds.SetGCPs([pair[1] for pair in gcps], ref_projection)
-            transformed_ds: gdal.Dataset = gdal.Warp(warp_save_path, temp_gdal_ds, options=warp_options)
-
-            width = transformed_ds.RasterXSize
-            height = transformed_ds.RasterYSize
-            output_size = (width, height)
-            output_bytes = (
-                width * height * target_dataset.num_bands() * target_dataset.get_elem_type().itemsize
+        save_path = self._get_save_file_path()
+        if save_path is None:
+            QMessageBox.information(
+                self,
+                self.tr("No Save Path Selected"),
+                self.tr(
+                    "In order to georeference, a save path "
+                    "must be selected. There is no save path "
+                    "selected, so georeferencing will not occur.\n\n"
+                    "Please select a save path."
+                ),
             )
-
-            gdal.Unlink(warp_save_path)
-            output_gt = None
-
-            ratio = MAX_RAM_BYTES / output_bytes
-            if isinstance(target_dataset_impl, GDALRasterDataImpl):
-                # Saving the full gdal dataste
-                target_gdal_dataset = target_dataset_impl.gdal_dataset
-                temp_vrt_path = "/vsimem/ref.vrt"
-                translate_opts = None
-                if target_dataset.get_data_ignore_value() is not None:
-                    translate_opts = gdal.TranslateOptions(
-                        format="VRT",
-                        noData=target_dataset.get_data_ignore_value(),
-                    )
-                else:
-                    translate_opts = gdal.TranslateOptions(
-                        format="VRT",
-                    )
-                temp_gdal_ds = gdal.Translate(temp_vrt_path, target_gdal_dataset, options=translate_opts)
-                # Make sure dataset has no spatial information that could mess with warping
-                temp_gdal_ds.SetGCPs([pair[1] for pair in gcps], ref_projection)
-                warp_options = gdal.WarpOptions(**self._warp_kwargs)
-                output_dataset = gdal.Warp(save_path, temp_gdal_ds, options=warp_options)
-            elif not isinstance(target_dataset_impl, GDALRasterDataImpl) and ratio > 1.0:
-                # Saving the full object array
-                warp_options = gdal.WarpOptions(**self._warp_kwargs)
-                dataset_arr = target_dataset.get_image_data()
-                temp_gdal_ds: gdal.Dataset = gdal_array.OpenNumPyArray(dataset_arr, True)
-                # Make sure dataset has no spatial information that could mess with warping
-                temp_gdal_ds.SetGCPs([pair[1] for pair in gcps], ref_projection)
-                set_data_ignore_of_gdal_dataset(temp_gdal_ds, target_dataset)
-                output_dataset: gdal.Dataset = gdal.Warp(save_path, temp_gdal_ds, options=warp_options)
-                output_dataset.FlushCache()
-            else:
-                # Saving incrementally using the numpy dataset
-                num_bands_per = int(ratio * target_dataset.num_bands())
-                for band_index in range(0, target_dataset.num_bands(), num_bands_per):
-                    band_list_index = [
-                        band
-                        for band in range(band_index, band_index + num_bands_per)
-                        if band < target_dataset.num_bands()
-                    ]
-                    warp_options = gdal.WarpOptions(**self._warp_kwargs)
-                    warp_save_path = f"/vsimem/temp_band_{min(band_list_index)}_to_{max(band_list_index)}"
-                    # print(f"saving chunk: {min(band_list_index)}_to_{max(band_list_index)}")
-
-                    band_arr = target_dataset.get_multiple_band_data(band_list_index)
-                    temp_gdal_ds: gdal.Dataset = gdal_array.OpenNumPyArray(band_arr, True)
-                    # Make sure dataset has no spatial information that could mess with warping
-                    temp_gdal_ds.SetGCPs([pair[1] for pair in gcps], ref_projection)
-                    set_data_ignore_of_gdal_dataset(temp_gdal_ds, target_dataset)
-                    transformed_ds: gdal.Dataset = gdal.Warp(
-                        warp_save_path, temp_gdal_ds, options=warp_options
-                    )
-
-                    width = transformed_ds.RasterXSize
-                    height = transformed_ds.RasterYSize
-                    assert (
-                        width == output_size[0] and height == output_size[1]
-                    ), "Width and/or height of warped band does not equal a previous warped band"
-
-                    if output_dataset is None:
-                        output_dataset = driver.Create(
-                            save_path,
-                            width,
-                            height,
-                            target_dataset.num_bands(),
-                            gdal_dtype,
-                        )
-                        output_gt = transformed_ds.GetGeoTransform()
-
-                    write_raster_to_dataset(
-                        output_dataset,
-                        band_list_index,
-                        transformed_ds.ReadAsArray(),
-                        gdal_dtype,
-                    )
-
-                    gdal.Unlink(warp_save_path)
-                    transformed_ds = None
-                output_dataset.SetGeoTransform(output_gt)
-                output_dataset.SetSpatialRef(ref_srs)
-
-            if output_dataset is None:
-                raise RuntimeError("gdal.Warp failed to produce a transformed dataset.")
-
-            copy_metadata_to_gdal_dataset(output_dataset, target_dataset)
-            gt = output_dataset.GetGeoTransform()
-            if gt is None:
-                raise RuntimeError("Failed to retrieve geotransform from the transformed dataset.")
-
-            output_dataset.FlushCache()
-            output_dataset = None
-
-            self.set_message_text(self.tr("Done warping!"))
-        except BaseException as e:
-            QMessageBox.critical(self, self.tr("Error While Creating Output"), self.tr(f"Error:\n{e}"))
             return False
+
+        if not self._enough_points_for_transform():
+            QMessageBox.information(
+                self,
+                self.tr("Can't Run Georeferencer"),
+                self.tr("Not enough points to run georeferencer"),
+            )
+            return False
+
+        if self._target_rasterpane.get_rasterview().get_raster_data() is None:
+            QMessageBox.information(
+                self,
+                self.tr("No Target Dataset Selected"),
+                self.tr("A target dataset is not selected. Please select a target dataset."),
+            )
+            return False
+
+        target_dataset = self._target_rasterpane.get_rasterview().get_raster_data()
+        gcps = [gcp for _, gcp in self._get_entry_gcp_list()]
+
+        output_srs = self._import_current_output_srs()
+        output_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        warp_kwargs, _ = build_warp_kwargs(self._curr_resample_alg, self._curr_transform_type, output_srs)
+
+        # The reference SRS supplies the projection attached to the GCPs. Left in its
+        # native axis mapping to match the original in-dialog warp exactly.
+        ref_srs = self._get_reference_srs()
+
+        self.set_message_text(self.tr("Starting warp..."))
+        run_with_progress(
+            self._app_services,
+            self,
+            self.tr("Warping…"),
+            warp_dataset_to_path,
+            target_dataset,
+            gcps,
+            warp_kwargs,
+            ref_srs,
+            save_path,
+            on_success=self._on_warp_done,
+            on_error=self._on_warp_error,
+        )
         return True
 
-    def accept(self):
-        should_continue = self._create_warped_output()
+    def _on_warp_done(self, written_path: str):
+        """GUI-thread callback when a warp finishes: announce it and update status."""
+        self.set_message_text(self.tr("Done warping!"))
+        self.warp_completed.emit(written_path)
 
-        if should_continue:
-            super().accept()
+    def _on_warp_error(self, message: str):
+        """GUI-thread callback when a warp fails (or is cancelled)."""
+        QMessageBox.critical(self, self.tr("Error While Creating Output"), self.tr(f"Error:\n{message}"))
+
+    def accept(self):
+        # The warp is produced by the dedicated "Run Warp" button (threaded); accept() is a
+        # plain commit/close so the OK button no longer double-warps.
+        super().accept()
 
     # region Event overrides
 

--- a/src/wiser/gui/mosaic_crs_dialog.py
+++ b/src/wiser/gui/mosaic_crs_dialog.py
@@ -35,9 +35,9 @@ from PySide6.QtWidgets import (
 
 from wiser.gui.app_state import ApplicationState
 
-# Reuse the CRS building blocks from the georeferencer so the target chooser behaves
-# identically to the one users already know (same common CRSs, same authority lookup).
-from wiser.gui.geo_reference_dialog import (
+# Reuse the CRS building blocks from the shared, Qt-free CRS model so the target chooser
+# behaves identically to the georeferencer's
+from wiser.raster.crs_model import (
     AVAILABLE_AUTHORITIES,
     COMMON_SRS,
     AuthorityCodeCRS,

--- a/src/wiser/raster/crs_model.py
+++ b/src/wiser/raster/crs_model.py
@@ -1,0 +1,99 @@
+"""
+A small, Qt-free hierarchy of coordinate reference systems (CRS) that the UI can offer.
+
+This is the single source of truth for "a CRS the UI can offer" and is shared by both the
+georeferencer (:mod:`wiser.gui.geo_reference_dialog`) and the Seamless Mosaic CRS chooser
+(:mod:`wiser.gui.mosaic_crs_dialog`). Keeping it Qt-free means neither feature has to
+import the other's heavy dialog module just to reuse the CRS building blocks, and it makes
+the CRS logic unit-testable without a running app.
+
+Every CRS is represented through the :class:`GeneralCRS` ABC, whose single contract is
+``get_osr_crs() -> osr.SpatialReference``. This lets callers treat every CRS source
+uniformly (and compare them by WKT via ``__eq__``).
+"""
+
+from abc import ABC
+from typing import Optional
+
+from osgeo import osr
+
+from pyproj.database import get_authorities
+
+# The list of authorities pyproj knows about (e.g. "EPSG", "ESRI", ...). Computed once at
+# import time; consumed by the manual-reference authority chooser.
+AVAILABLE_AUTHORITIES = get_authorities()
+
+
+class GeneralCRS(ABC):
+    """
+    The base class representing a generic coordinate reference system
+    """
+
+    def get_osr_crs(self) -> Optional[osr.SpatialReference]:
+        """
+        Gets a osr.SpatialReference object for this class
+        """
+        raise NotImplementedError("Function has not yet been implemented.")
+
+    def __eq__(self, other: "GeneralCRS"):
+        return self.get_osr_crs().ExportToWkt() == other.get_osr_crs().ExportToWkt()
+
+
+class AuthorityCodeCRS(GeneralCRS):
+    """
+    This class represents a coordinate reference system that is made
+    from just the autority name and the authority code.
+    """
+
+    def __init__(self, authority_name: str, authority_code: int):
+        self.authority_name = authority_name
+        self.authority_code = authority_code
+
+    def get_osr_crs(self) -> Optional[osr.SpatialReference]:
+        # Build the AUTH:CODE string
+        auth_code_str = f"{self.authority_name}:{self.authority_code}"
+
+        # Create and populate the SpatialReference
+        srs = osr.SpatialReference()
+        err = srs.SetFromUserInput(auth_code_str)
+        if err != 0:
+            raise RuntimeError(f"Failed to import CRS '{auth_code_str}' (GDAL error {err})")
+
+        return srs
+
+
+class UserGeneratedCRS(GeneralCRS):
+    """
+    This class represents a CRS that the user made in the
+    reference_creator_dialog
+    """
+
+    def __init__(self, name: str, crs: osr.SpatialReference):
+        self._name = name
+        self._crs = crs
+
+    def get_osr_crs(self) -> Optional[osr.SpatialReference]:
+        return self._crs
+
+
+class WktGeneratedCRS(GeneralCRS):
+    """
+    A coordinate reference system generated from a wkt string
+    """
+
+    def __init__(self, name: str, wkt: str):
+        self._name = name
+        self._wkt = wkt
+        crs = osr.SpatialReference()
+        crs.ImportFromWkt(wkt)
+        self._crs = crs
+
+    def get_osr_crs(self) -> Optional[osr.SpatialReference]:
+        return self._crs
+
+
+COMMON_SRS = {
+    "WGS84 EPSG:4326": AuthorityCodeCRS("EPSG", 4326),
+    "Web Mercator EPSG:3857": AuthorityCodeCRS("EPSG", 3857),
+    "NAD83 / UTM zone 15N EPSG:26915": AuthorityCodeCRS("EPSG", 26915),
+}

--- a/src/wiser/raster/gcp_io.py
+++ b/src/wiser/raster/gcp_io.py
@@ -1,0 +1,219 @@
+"""
+Ground-control-point (GCP) file I/O for the georeferencer, in QGIS ``*.points`` and ENVI
+``*.pts`` formats.
+
+These are pure, Qt-free file parsers/writers so GCP round-tripping can be unit-tested
+without a running app. The georeferencer dialog's save/load handlers are thin wrappers
+around :func:`read_gcp_file`, :func:`write_qgis_points`, and :func:`write_envi_pts`.
+
+A GCP *point* is a ``(map_x, map_y, pixel_x, pixel_y)`` tuple: the map (reference-SRS)
+coordinate paired with the target dataset's pixel coordinate. A GCP *row* additionally
+carries the enabled flag: ``(map_x, map_y, pixel_x, pixel_y, enabled)``.
+"""
+
+import csv
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from wiser.raster.crs_model import GeneralCRS, AuthorityCodeCRS, WktGeneratedCRS
+
+# (map_x, map_y, pixel_x, pixel_y)
+GcpPoint = Tuple[float, float, float, float]
+# (map_x, map_y, pixel_x, pixel_y, enabled)
+GcpRow = Tuple[float, float, float, float, bool]
+
+
+def read_gcp_file(path: str) -> Tuple[List[GcpPoint], GeneralCRS]:
+    """Dispatch on file extension and read a GCP file.
+
+    Returns ``(points, gcp_srs)``. Raises ``RuntimeError`` for unsupported extensions.
+    """
+    ext = Path(path).suffix.lower()
+    if ext == ".points":
+        return read_qgis_points_file(path)
+    elif ext == ".pts":
+        return read_envi_pts_file(path)
+    raise RuntimeError("Unsupported GCP file extension")
+
+
+def read_qgis_points_file(path: str) -> Tuple[List[GcpPoint], GeneralCRS]:
+    """Read a QGIS ``*.points`` file.
+
+    If the header contains ``# CRS`` the routine returns an
+    :class:`AuthorityCodeCRS`; otherwise it looks for ``# WKT`` and
+    returns a :class:`WktGeneratedCRS`.
+
+    Returns
+    -------
+    points : list[tuple[float, float, float, float]]
+        ``(map_x, map_y, pixel_x, pixel_y)`` tuples.
+    gcp_srs : GeneralCRS
+        Extracted from the header
+    """
+    points = []
+    gcp_srs = None
+    pending_wkt = None
+
+    with open(path, newline="") as f:
+        rdr = csv.reader(f)
+        for row in rdr:
+            if not row:
+                continue
+            if row[0].startswith("# CRS"):
+                _, authcode = row[:2]
+                auth, code = authcode.split(":")
+                gcp_srs = AuthorityCodeCRS(auth, int(code))
+                continue
+            if row[0].startswith("# WKT"):
+                # WKT may contain commas, so rebuild the original line
+                pending_wkt = ",".join(row[1:]).strip()
+                continue
+            if row[0].startswith("mapX"):
+                continue
+            map_x, map_y, pix_x, pix_y, *_ = map(float, row[:5])
+            points.append((map_x, map_y, pix_x, pix_y))
+
+    if gcp_srs is None and pending_wkt:
+        gcp_srs = WktGeneratedCRS("WKT", pending_wkt)
+    if gcp_srs is None:
+        raise RuntimeError("No CRS or WKT line found in .points file")
+    return points, gcp_srs
+
+
+def read_envi_pts_file(path: str) -> Tuple[List[GcpPoint], GeneralCRS]:
+    """Read an ENVI ``*.pts`` file with optional embedded WKT.
+
+    The routine first tries the traditional ``; projection info`` comment
+    to extract *(authority, code)*.  If that is missing it looks for a
+    line beginning ``; wkt =`` and constructs a
+    :class:`WktGeneratedCRS`.
+
+    Returns
+    -------
+    points : list[tuple[float, float, float, float]]
+        ``(map_x, map_y, pixel_x, pixel_y)`` tuples.
+    gcp_srs : GeneralCRS
+        Extracted from the header
+    """
+    points = []
+    gcp_srs = None
+    pending_wkt = None
+    with open(path) as f:
+        for ln in f:
+            ln = ln.strip()
+            if ln.lower().startswith("; projection info"):
+                inside = ln.split("{", 1)[-1].split("}", 1)[0]
+                auth, code, *_ = [x.strip().split(",")[0] for x in inside.split()]
+                gcp_srs = AuthorityCodeCRS(auth, int(code))
+            elif ln.lower().startswith("; wkt ="):
+                pending_wkt = ln.split("=", 1)[1].strip()
+            elif ln.startswith(";") or not ln:
+                continue
+            else:
+                parts = list(map(float, ln.split()))
+                if len(parts) >= 5:
+                    map_x, map_y, _elev, pix_x, pix_y = parts[:5]
+                    points.append((map_x, map_y, pix_x, pix_y))
+    if gcp_srs is None and pending_wkt:
+        gcp_srs = WktGeneratedCRS("WKT", pending_wkt)
+    if gcp_srs is None:
+        raise RuntimeError("No projection info or WKT found in .pts file")
+    return points, gcp_srs
+
+
+def write_qgis_points(
+    path: str,
+    rows: List[GcpRow],
+    auth: Optional[str] = None,
+    code: Optional[str] = None,
+    wkt: Optional[str] = None,
+) -> None:
+    """Write ground-control points to a QGIS ``*.points`` file.
+
+    Parameters
+    ----------
+    path : str
+        Destination filepath (should end with ``.points``).
+    rows : list[tuple[float, float, float, float, bool]]
+        ``(map_x, map_y, pixel_x, pixel_y, enabled)`` rows to write.
+    auth : str or None, optional
+        Authority name (e.g. ``"EPSG"``).  If *None*, the ``# CRS``
+        header line is **omitted**.
+    code : str or None, optional
+        Authority code (e.g. ``"4326"``).  Ignored when *auth* is
+        *None*.
+    wkt : str or None, optional
+        Well-Known Text definition of the CRS.  When provided it is
+        written on a dedicated line starting with ``# WKT``.  QGIS
+        will ignore this line, but *WISER* can parse it on load.
+
+    Notes
+    -----
+    The file layout becomes::
+
+        # CRS, EPSG:4326  ← optional
+        # WKT,<LONG_WKT> ← optional
+        mapX,mapY,pixelX,pixelY,enable
+        123.4, 45.6, 100.0, 200.0, 1
+        ...
+
+    Only ASCII commas are used as delimiters so the routine is
+    locale-independent.
+    """
+    header_rows = []
+    if auth and code:
+        header_rows.append(["# CRS", f"{auth}:{code}"])
+    if wkt:
+        header_rows.append(["# WKT", wkt])
+
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerows(header_rows)
+        writer.writerow(["mapX", "mapY", "pixelX", "pixelY", "enable"])
+
+        for map_x, map_y, pix_x, pix_y, enabled in rows:
+            writer.writerow(
+                [
+                    map_x,
+                    map_y,
+                    pix_x,
+                    pix_y,
+                    1 if enabled else 0,
+                ]
+            )
+
+
+def write_envi_pts(
+    path: str,
+    rows: List[GcpRow],
+    auth: Optional[str] = None,
+    code: Optional[str] = None,
+    wkt: Optional[str] = None,
+) -> None:
+    """Write ground-control points to an ENVI ``*.pts`` file. auth and code
+    must be non-None or wkt must be non-None
+
+    Parameters
+    ----------
+    path : str
+        Destination filepath (should end with ``.pts``).
+    rows : list[tuple[float, float, float, float, bool]]
+        ``(map_x, map_y, pixel_x, pixel_y, enabled)`` rows to write. ENVI's format has no
+        per-point enable flag, so the flag is ignored on write.
+    auth, code : str or None, optional
+        Authority name and code.  When either is *None*, the traditional
+        ``; projection info`` comment is skipped.
+    wkt : str or None, optional
+        Well-Known Text to embed after a ``; wkt = `` comment.  ENVI will
+        ignore this line; *WISER* uses it when the authority pair is
+        missing.
+    """
+    with open(path, "w") as f:
+        f.write("; ENVI Ground Control Points File\n")
+        if auth and code:
+            f.write(f"; projection info = {{{auth}, {code}, units=Degrees}}\n")
+        if wkt:
+            f.write(f"; wkt = {wkt}\n")
+        f.write("; Map (x,y,elev), Image (x,y)\n;\n")
+        for map_x, map_y, pix_x, pix_y, _enabled in rows:
+            f.write(f"{map_x:.10f} {map_y:.10f} 0.0 {pix_x:.3f} {pix_y:.3f}\n")

--- a/src/wiser/raster/georef_warp.py
+++ b/src/wiser/raster/georef_warp.py
@@ -1,0 +1,356 @@
+"""
+Qt-free GDAL warp engine for the georeferencer (WISER#684).
+
+This module holds all the GDAL/OSR logic that used to live inside
+``GeoReferencerDialog``: building the warp/transformer options from the chosen transform
+type, computing per-GCP residuals for the interactive preview, and producing the final
+warped GeoTIFF. Keeping it Qt-free (GDAL + WISER raster helpers only, mirroring
+:mod:`wiser.raster.mosaic_export`) means the warp math is unit-testable without a running
+app and can run on a background thread.
+
+The three entry points are:
+
+- :func:`build_warp_kwargs` -- turn a resample algorithm + transform type + output SRS into
+  the ``gdal.Warp`` kwargs and the matching ``gdal.Transformer`` options.
+- :func:`compute_residuals` -- the fast interactive residual calc: warp a 1x1 placeholder
+  purely to drive GDAL's transformer, and return per-GCP pixel residuals.
+- :func:`warp_dataset_to_path` -- the full multi-band output warp, streamed in RAM-bounded
+  band chunks with progress reporting and cooperative cancellation.
+
+Callers pass plain data (``gdal.GCP`` lists, ``osr.SpatialReference`` objects) and a
+:class:`~wiser.utils.progress.ProgressReporter`; these functions never touch Qt, show
+dialogs, or log. Errors are raised; progress and exceptions are the only channels out.
+"""
+
+from enum import Enum
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from osgeo import gdal, osr, gdal_array
+
+from wiser.raster.dataset import RasterDataSet
+from wiser.raster.dataset_impl import GDALRasterDataImpl
+from wiser.raster.utils import (
+    copy_metadata_to_gdal_dataset,
+    numpy_dtype_to_gdal_export_types,
+    set_data_ignore_of_gdal_dataset,
+)
+from wiser.bandmath.utils import write_raster_to_dataset
+from wiser.bandmath.builtins.constants import MAX_RAM_BYTES
+from wiser.utils.progress import ProgressReporter
+
+
+# All of GDAL's GRA_* resampling algorithms, e.g. GRA_NearestNeighbour, GRA_Bilinear,
+# GRA_Cubic, GRA_CubicSpline, GRA_Lanczos, ...
+RESAMPLE_ALGORITHMS = {name: getattr(gdal, name) for name in dir(gdal) if name.startswith("GRA_")}
+
+
+class TRANSFORM_TYPES(Enum):
+    POLY_1 = "Affine (Polynomial 1)"
+    POLY_2 = "Polynomial 2"
+    POLY_3 = "Polynomial 3"
+    TPS = "Thin Plate Spline (TPS)"
+
+
+min_points_per_transform = {
+    TRANSFORM_TYPES.POLY_1: 3,
+    TRANSFORM_TYPES.POLY_2: 6,
+    TRANSFORM_TYPES.POLY_3: 10,
+    TRANSFORM_TYPES.TPS: 10,
+}
+
+
+def build_warp_kwargs(
+    resample_alg,
+    transform_type: TRANSFORM_TYPES,
+    output_srs: osr.SpatialReference,
+) -> Tuple[dict, List[str]]:
+    """
+    Build the ``gdal.Warp`` kwargs and the matching ``gdal.Transformer`` options for the
+    chosen transform.
+
+    ``output_srs`` is expected to already have its axis-mapping strategy set (typically
+    ``OAMS_TRADITIONAL_GIS_ORDER``) by the caller. Returns ``(warp_kwargs,
+    transformer_options)``.
+    """
+    warp_kwargs = {
+        "copyMetadata": True,
+        "resampleAlg": resample_alg,
+        "dstSRS": output_srs,
+    }
+
+    transformer_options = [f"DST_SRS={output_srs.ExportToWkt()}"]
+
+    if transform_type == TRANSFORM_TYPES.TPS:
+        warp_kwargs["tps"] = True
+        transformer_options += ["METHOD=GCP_TPS", "MAX_GCP_ORDER=-1"]
+    elif transform_type == TRANSFORM_TYPES.POLY_1:
+        warp_kwargs["polynomialOrder"] = 1
+        transformer_options += ["METHOD=GCP_POLYNOMIAL", "MAX_GCP_ORDER=1"]
+    elif transform_type == TRANSFORM_TYPES.POLY_2:
+        warp_kwargs["polynomialOrder"] = 2
+        transformer_options += ["METHOD=GCP_POLYNOMIAL", "MAX_GCP_ORDER=2"]
+    elif transform_type == TRANSFORM_TYPES.POLY_3:
+        warp_kwargs["polynomialOrder"] = 3
+        transformer_options += ["METHOD=GCP_POLYNOMIAL", "MAX_GCP_ORDER=3"]
+    else:
+        raise RuntimeError(f"Unknown transform type: {transform_type}")
+
+    warp_kwargs["transformerOptions"] = transformer_options
+    return warp_kwargs, transformer_options
+
+
+def compute_residuals(
+    gcps: List[gdal.GCP],
+    ref_srs: osr.SpatialReference,
+    output_srs: osr.SpatialReference,
+    warp_kwargs: dict,
+    transformer_options: List[str],
+) -> List[Tuple[float, float]]:
+    """
+    Compute per-GCP residuals (in target-pixel units) for the chosen transform.
+
+    Does **not** warp the real image: it builds a 1x1 placeholder dataset purely to drive
+    GDAL's transformer, then measures how far each GCP's transformed position lands from
+    its reference coordinate.
+
+    ``ref_srs`` and ``output_srs`` must already have their axis-mapping strategy set
+    (``OAMS_TRADITIONAL_GIS_ORDER``). Returns a list of ``(residual_x, residual_y)`` in the
+    same order as ``gcps``. Raises on GDAL failure (e.g. a degenerate GCP configuration).
+    """
+    gdal.UseExceptions()
+
+    ref_projection = ref_srs.ExportToWkt()
+    assert (
+        ref_projection is not None and ref_srs is not None
+    ), f"ref_srs ({ref_srs}) or ref_project ({ref_projection}) is None!"
+
+    # We need a temporary gdal dataset so we can calculate the residuals
+    # without making a massive data object
+    place_holder_arr = np.zeros((1, 1), np.uint8)
+    temp_gdal_ds: gdal.Dataset = gdal_array.OpenNumPyArray(place_holder_arr, True)
+    temp_gdal_ds.SetSpatialRef(ref_srs)
+    temp_gdal_ds.SetGCPs(gcps, ref_projection)
+
+    # This will be used to transform the pixel coordinate to the
+    # output srs coordinate that has undergone the spatial warping
+    tr_pixel_to_output_srs: gdal.Transformer = gdal.Transformer(temp_gdal_ds, None, transformer_options)
+
+    # Sneak peek into the transformed dataset's geo transform so we can use them later
+    # when calculating residuals. We don't just use the geotransform here to calculate
+    # residuals because transformed_gt goes from the warped datasets pixel coordinates
+    # to the warped dataset's spatial coordinates. Our GCPs are just in the target
+    # dataset's pixel coordinates and reference srs's spatial coordinates.
+    warp_options = gdal.WarpOptions(**warp_kwargs)
+    warp_save_path = f"/vsimem/temp_band_{0}"
+    place_holder_arr = np.zeros((1, 1), np.uint8)
+    temp_gdal_ds = gdal_array.OpenNumPyArray(place_holder_arr, True)
+    temp_gdal_ds.SetGCPs(gcps, ref_projection)
+    transformed_ds: gdal.Dataset = gdal.Warp(warp_save_path, temp_gdal_ds, options=warp_options)
+    transformed_gt = transformed_ds.GetGeoTransform()
+
+    # The output_srs here is the target spatial reference system (srs). In case
+    # the target srs is different from the reference srs, then we need a way to
+    # go between them.
+    tr_output_srs_to_ref_srs = osr.CoordinateTransformation(output_srs, ref_srs)
+
+    residuals: List[Tuple[float, float]] = []
+    # The general flow of calculating the residuals is to go from our target
+    # dataset's pixel coordinate (gcp.GCPPixel, gcp.GCPLine) to our output
+    # srs coordinates. Then we go from the output srs coordinate to the
+    # reference srs coordinate. We then get the difference in reference srs
+    # coordinates from the original GCP to get the spatial error. Then to make
+    # it a pixel error we divide by the width/height per pixel of the warped
+    # dataset's geo transform.
+    for gcp in gcps:
+        # These coordinates could get back to us in either lat/lon, lon/lat,
+        # or north/easting, easting/north
+        (
+            ok,
+            (output_spatial_x, output_spatial_y, z),
+        ) = tr_pixel_to_output_srs.TransformPoint(False, gcp.GCPPixel, gcp.GCPLine)
+
+        # Since we use OAMS_TRADITIONAL_GIS_ORDER on both reference and output CRS, we don't need
+        # to swap the spatial coordinates
+        ref_spatial_coord = tr_output_srs_to_ref_srs.TransformPoint(output_spatial_x, output_spatial_y, 0)
+
+        ref_spatial_x, ref_spatial_y = (
+            ref_spatial_coord[0],
+            ref_spatial_coord[1],
+        )
+
+        error_spatial_x = gcp.GCPX - ref_spatial_x
+        error_spatial_y = gcp.GCPY - ref_spatial_y
+
+        error_raster_x = error_spatial_x / transformed_gt[1]
+        error_raster_y = error_spatial_y / transformed_gt[5]
+
+        residuals.append((error_raster_x, error_raster_y))
+
+    tr_pixel_to_output_srs = None
+    tr_output_srs_to_ref_srs = None
+    temp_gdal_ds = None
+    gdal.Unlink(warp_save_path)
+
+    return residuals
+
+
+def warp_dataset_to_path(
+    target_dataset: RasterDataSet,
+    gcps: List[gdal.GCP],
+    warp_kwargs: dict,
+    ref_srs: osr.SpatialReference,
+    save_path: str,
+    *,
+    progress: Optional[ProgressReporter] = None,
+) -> str:
+    """
+    Warp ``target_dataset`` onto real-world coordinates using ``gcps`` and write the result
+    as a GeoTIFF at ``save_path``. Returns ``save_path``.
+
+    Because hyperspectral cubes can be very large, the band data is processed in RAM-bounded
+    chunks. Three cases (matching the original in-dialog implementation):
+
+    - target backed by a GDAL dataset -> Translate to a VRT and warp the whole thing;
+    - a numpy-backed target that fits in RAM -> warp the whole array;
+    - otherwise -> warp band chunks and write incrementally, reporting ``progress`` and
+      calling :meth:`ProgressReporter.raise_if_cancelled` between chunks.
+
+    ``ref_srs`` supplies the destination projection attached to the GCPs. The caller is
+    responsible for validating inputs (save path, GCP count, target selected) before
+    calling.
+    """
+    if progress is None:
+        progress = ProgressReporter()
+
+    gdal.UseExceptions()
+
+    target_dataset_impl = target_dataset.get_impl()
+    ref_projection = ref_srs.ExportToWkt()
+
+    driver: gdal.Driver = gdal.GetDriverByName("GTiff")
+    gdal_dtype, _ = numpy_dtype_to_gdal_export_types(target_dataset.get_elem_type())
+
+    output_dataset: gdal.Dataset = None
+    output_gt = None
+
+    # We warp one band of the input dataset to a virtual memory file, so we can create the
+    # correct output data size. Then we create the output dataset with width and height
+    # equal to the warp, but correct number of bands. Then we override each band in the
+    # created array and flush cache.
+    warp_options = gdal.WarpOptions(**warp_kwargs)
+    warp_save_path = f"/vsimem/temp_band_{0}"
+    band_arr = target_dataset.get_band_data(0)
+    temp_gdal_ds: gdal.Dataset = gdal_array.OpenNumPyArray(band_arr, True)
+    # Make sure dataset has no spatial information that could mess with warping
+    temp_gdal_ds.SetGCPs(gcps, ref_projection)
+    transformed_ds: gdal.Dataset = gdal.Warp(warp_save_path, temp_gdal_ds, options=warp_options)
+
+    width = transformed_ds.RasterXSize
+    height = transformed_ds.RasterYSize
+    output_size = (width, height)
+    output_bytes = width * height * target_dataset.num_bands() * target_dataset.get_elem_type().itemsize
+
+    gdal.Unlink(warp_save_path)
+
+    progress.raise_if_cancelled()
+    progress.report(0, target_dataset.num_bands(), "Warping...")
+
+    ratio = MAX_RAM_BYTES / output_bytes
+    if isinstance(target_dataset_impl, GDALRasterDataImpl):
+        # Saving the full gdal dataset
+        target_gdal_dataset = target_dataset_impl.gdal_dataset
+        temp_vrt_path = "/vsimem/ref.vrt"
+        if target_dataset.get_data_ignore_value() is not None:
+            translate_opts = gdal.TranslateOptions(
+                format="VRT",
+                noData=target_dataset.get_data_ignore_value(),
+            )
+        else:
+            translate_opts = gdal.TranslateOptions(
+                format="VRT",
+            )
+        temp_gdal_ds = gdal.Translate(temp_vrt_path, target_gdal_dataset, options=translate_opts)
+        # Make sure dataset has no spatial information that could mess with warping
+        temp_gdal_ds.SetGCPs(gcps, ref_projection)
+        warp_options = gdal.WarpOptions(**warp_kwargs)
+        output_dataset = gdal.Warp(save_path, temp_gdal_ds, options=warp_options)
+        progress.report(target_dataset.num_bands(), target_dataset.num_bands(), "Warping...")
+    elif not isinstance(target_dataset_impl, GDALRasterDataImpl) and ratio > 1.0:
+        # Saving the full object array
+        warp_options = gdal.WarpOptions(**warp_kwargs)
+        dataset_arr = target_dataset.get_image_data()
+        temp_gdal_ds = gdal_array.OpenNumPyArray(dataset_arr, True)
+        # Make sure dataset has no spatial information that could mess with warping
+        temp_gdal_ds.SetGCPs(gcps, ref_projection)
+        set_data_ignore_of_gdal_dataset(temp_gdal_ds, target_dataset)
+        output_dataset = gdal.Warp(save_path, temp_gdal_ds, options=warp_options)
+        output_dataset.FlushCache()
+        progress.report(target_dataset.num_bands(), target_dataset.num_bands(), "Warping...")
+    else:
+        # Saving incrementally using the numpy dataset
+        num_bands_per = int(ratio * target_dataset.num_bands())
+        for band_index in range(0, target_dataset.num_bands(), num_bands_per):
+            progress.raise_if_cancelled()
+            band_list_index = [
+                band
+                for band in range(band_index, band_index + num_bands_per)
+                if band < target_dataset.num_bands()
+            ]
+            warp_options = gdal.WarpOptions(**warp_kwargs)
+            warp_save_path = f"/vsimem/temp_band_{min(band_list_index)}_to_{max(band_list_index)}"
+
+            band_arr = target_dataset.get_multiple_band_data(band_list_index)
+            temp_gdal_ds = gdal_array.OpenNumPyArray(band_arr, True)
+            # Make sure dataset has no spatial information that could mess with warping
+            temp_gdal_ds.SetGCPs(gcps, ref_projection)
+            set_data_ignore_of_gdal_dataset(temp_gdal_ds, target_dataset)
+            transformed_ds = gdal.Warp(warp_save_path, temp_gdal_ds, options=warp_options)
+
+            width = transformed_ds.RasterXSize
+            height = transformed_ds.RasterYSize
+            assert (
+                width == output_size[0] and height == output_size[1]
+            ), "Width and/or height of warped band does not equal a previous warped band"
+
+            if output_dataset is None:
+                output_dataset = driver.Create(
+                    save_path,
+                    width,
+                    height,
+                    target_dataset.num_bands(),
+                    gdal_dtype,
+                )
+                output_gt = transformed_ds.GetGeoTransform()
+
+            write_raster_to_dataset(
+                output_dataset,
+                band_list_index,
+                transformed_ds.ReadAsArray(),
+                gdal_dtype,
+            )
+
+            gdal.Unlink(warp_save_path)
+            transformed_ds = None
+            progress.report(
+                min(band_index + num_bands_per, target_dataset.num_bands()),
+                target_dataset.num_bands(),
+                "Warping...",
+            )
+        output_dataset.SetGeoTransform(output_gt)
+        output_dataset.SetSpatialRef(ref_srs)
+
+    if output_dataset is None:
+        raise RuntimeError("gdal.Warp failed to produce a transformed dataset.")
+
+    copy_metadata_to_gdal_dataset(output_dataset, target_dataset)
+    gt = output_dataset.GetGeoTransform()
+    if gt is None:
+        raise RuntimeError("Failed to retrieve geotransform from the transformed dataset.")
+
+    output_dataset.FlushCache()
+    output_dataset = None
+
+    progress.report(target_dataset.num_bands(), target_dataset.num_bands(), "Done warping!")
+    return save_path


### PR DESCRIPTION
## What does this change do?
Refactors the Georeferencer so it can be driven programmatically (preset + independently
lockable target dataset, reference dataset/CRS, and save path) and moves all GDAL warping
off the GUI thread. The 2170-line `GeoReferencerDialog` massive file is split: the warp engine,
GCP file I/O, and CRS model are extracted into Qt-free modules under `src/wiser/raster/`, the
dead `main_view` dependency is deleted, the accept-time double-warp is removed, and the two
silent `except: pass` blocks are fixed. The Tools → Georeferencer flow is behaviorally
unchanged.

Closes #684
Closes #647

## What type of PR is this? (check all applicable)
- [ ] Feature
- [x] Bug Fix <!-- silent except: pass blocks; double-warp -->
- [x] Documentation Update
- [ ] Style
- [x] Code Refactor
- [x] Performance Improvements <!-- warp + residuals now off the GUI thread -->
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
Issue: https://github.com/Ehlmann-research-group/WISER/issues/684

The dialog could only be driven through its own combo boxes, with no way for another feature
to hand it a dataset, lock a chooser, or preset/lock the save path — this blocked
re-georeferencing a scene from the Seamless Mosaic pane (PR 2). All GDAL warping ran
synchronously on the GUI thread: the final multi-band warp (in `accept()`) and a full
`gdal.Warp` residual recompute on *every* GCP add and *every* cell edit, freezing the UI.
The GDAL/CRS/file-I/O logic was entangled with Qt (untestable), the CRS model was imported
wholesale by the mosaic's `mosaic_crs_dialog.py` (dragging in the whole dialog module), and
there were a dead `main_view` param, a double-warp (`accept()` **and** the Run-Warp button),
and two `except: pass` blocks swallowing real errors.

## How did you implement the change?
- **Extracted Qt-free modules** (mirroring the mosaic's `mosaic_export.py` split):
  `wiser/raster/georef_warp.py` (`build_warp_kwargs`, `compute_residuals`,
  `warp_dataset_to_path` + `TRANSFORM_TYPES`/`RESAMPLE_ALGORITHMS`),
  `wiser/raster/gcp_io.py` (QGIS/ENVI read/write), and `wiser/raster/crs_model.py`
  (the `GeneralCRS` hierarchy + `COMMON_SRS`), now shared with `mosaic_crs_dialog.py`.
- **Threaded the final warp** via `run_with_progress` (progress + cancellation), emitting a
  new `warp_completed` signal; `accept()` no longer warps (double-warp removed).
- **Debounced + single-flighted** the interactive residual recompute onto
  `scheduler.submit_thread` with a supersede token (mirrors `MosaicView`).
- **Added `GeoReferencerConfig`** + `show/exec_(config=None)` → `_apply_config`, with
  `set_target_dataset` / `set_reference_dataset` / `set_reference_crs` / `set_save_path`
  setters and target/reference/save-path lock flags; the chooser slots funnel through the
  same setters. `config=None` reproduces today's behavior exactly.
- **Deleted the dead `main_view`** param (injected `app_services` instead) and **fixed the
  two `except: pass`** blocks (guard `dataset is None`, surface errors via `set_message_text`).

## Added tests?
- [x] yes

New Qt-free unit tests: `test_georef_warp.py` (transform→GDAL-option mapping, near-zero
residuals for exact-fit GCPs, output warp size/bands/geotransform, progress cancellation),
`test_gcp_io.py` (QGIS/ENVI round-trip + WKT fallback), `test_crs_model.py`. Plus a
config-driven-locking GUI test in `test_geo_ref_gui.py`. The existing georeferencer e2e,
mosaic-CRS, and CRS-creator suites still pass (28 in the combined run).

## Added to documentation?
- [x] yes

Updated `doc/sphinx-general-wiser-docs/source/developer-content/georeferencer-internals.md`:
core-files table, CRS/GCP/warp sections, threaded residual + warp diagrams, and a new
"Programmatic Configuration & Locking" section.

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## [optional] Are there any post-merge tasks we need to perform?
Follow-up PR 2 (separate issue): wire mosaic per-scene re-georeferencing to the new
`GeoReferencerConfig` surface (locked target + caller-owned save path, "Save to Mosaic"
accept button, reingest on Run Warp).
