### PR TITLE
feat(mosaic): Add georeferencing to mosaic

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/georeferencer-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/georeferencer-internals.md
@@ -512,9 +512,11 @@ reconcile a loaded file's CRS against the current reference CRS.
 
 The dialog can be driven entirely through code — not just its own combo boxes — via a
 `GeoReferencerConfig` (`src/wiser/gui/geo_reference_config.py`). This is what lets another
-feature (e.g. re-georeferencing a scene from the Seamless Mosaic pane) reuse the dialog with
-a fixed target, a caller-owned save path, and a custom accept button, without touching the
-Tools-menu flow.
+feature reuse the dialog with a fixed target, a caller-owned save path, and a custom accept
+button, without touching the Tools-menu flow. The Seamless Mosaic's
+[**Re-georeferencing a Scene In Place**](mosaic-internals.md#re-georeferencing-a-scene-in-place)
+is the production consumer: it opens a task-scoped dialog locked onto a mosaic scene, then
+reingests the `warp_completed` output and swaps the corrected scene back into the mosaic.
 
 `show(config=None)` / `exec_(config=None)` accept an optional config and delegate to
 `_apply_config`, which first resets the dialog to its classic baseline (repopulate choosers,

--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -10,9 +10,10 @@ materialization, common-grid/CRS resolution, the **vector overlay** (footprints,
 bounding box, overlap highlight), the **static-scene pixel compositor** (the composited
 preview, with an off-thread debounced per-scene cache), the **control panel**
 (drag-to-reorder z-order, resolution mode, resampling method, and the band-metadata
-chooser), and the **full-resolution export path** (streaming ENVI compositor on the
-common grid — see [The Export Path](#the-export-path)) are implemented and wired into
-the GUI.
+chooser), the **full-resolution export path** (streaming ENVI compositor on the
+common grid — see [The Export Path](#the-export-path)), and **in-place scene
+re-georeferencing** (right-click → warp → swap; see [Re-georeferencing a Scene In
+Place](#re-georeferencing-a-scene-in-place)) are implemented and wired into the GUI.
 ```
 
 For the design rationale and full child-issue breakdown, see `EPIC_seamless_mosaic.md`
@@ -702,6 +703,138 @@ in `src/tests/test_mosaic_controller.py`.
 
 ---
 
+## Re-georeferencing a Scene In Place
+
+**File:** `src/wiser/gui/mosaic_pane.py` (issue #685)
+
+A scene may be **mis-registered** — its spatial information places it wrong relative to
+the other scenes. Rather than sending the user out to Tools → Georeferencer and back
+through a file round-trip, `MosaicPane` lets them fix it **in place**: right-click a
+scene → **"Georeference…"**, warp it, and the corrected result is swapped into the
+mosaic live, with a clean revert on cancel. This reuses the configurable
+`GeoReferencerDialog` (see [Programmatic Configuration &
+Locking](georeferencer-internals.md#programmatic-configuration-locking)) — no new warp,
+GCP, or CRS logic is added here.
+
+### Entry point: the scene-list context menu
+
+`_build_scene_list_group` gives `self._scene_list` a `Qt.CustomContextMenu` policy;
+`_on_scene_context_menu(pos)` resolves the clicked row to a **controller** index via
+`item.data(Qt.UserRole)` (the list is shown top-first but each item carries its real
+bottom-to-top index) and pops a one-action `QMenu` → `_on_georeference_scene(index)`. The
+menu is suppressed when the scheduler or the session materializer is absent, since the
+swap reingests (the same requirement Add Scene guards on).
+
+### Opening the dialog (locked target + locked save path)
+
+`_on_georeference_scene(index)` builds a `GeoReferencerConfig` that locks the two things
+the mosaic owns and leaves the reference user-chosen:
+
+- `target_dataset = scene.dataset` (the **original** dataset, not a copy) with
+  `allow_change_target=False`,
+- `save_path` = a fresh temp path with `allow_change_save_path=False`,
+- `reference_dataset=None` (unlocked — the user picks a reference or a manual CRS),
+- `accept_button_text="Save to Mosaic"`.
+
+It constructs a **fresh, task-scoped** `GeoReferencerDialog` (not the Tools-menu
+singleton, so the lock state can never leak back into that flow), connects
+`warp_completed` → `_on_scene_rewarped` and `finished` → `_on_geodialog_finished`,
+stashes the in-flight state in a `_RegeorefContext` (`orig_scene`, `orig_index`,
+`dialog`, `warped_scene`), and `show(config)`s it **non-modally** (the mosaic dialog is
+non-modal, so the georeferencer must not block it).
+
+> **The save path is a *fresh* name per warp** (`regeoref_{id(scene)}_{uuid4}.tif` under
+> `wiser.utils.primitives.temp_dir()`), not one reused path. The previous warped
+> `RasterDataSet` keeps its GeoTIFF open, and on Windows an open file cannot be
+> overwritten — so a repeated "Run Warp" onto one fixed path would fail. The file is a
+> throwaway regardless: reingestion re-materializes it into the mosaic's own copy.
+
+### Two threaded phases: warp, then reingest-and-swap
+
+```{mermaid}
+sequenceDiagram
+    participant User
+    participant Pane as MosaicPane
+    participant Dlg as GeoReferencerDialog
+    participant Sched as WorkScheduler
+    participant Ctrl as MosaicController
+    participant View as MosaicView
+
+    User->>Pane: right-click scene → "Georeference…"
+    Pane->>Dlg: show(GeoReferencerConfig, locked target+save)
+    User->>Dlg: place GCPs, click "Run Warp"
+    Dlg->>Sched: warp_dataset_to_path (bg thread, own progress modal)
+    Sched-->>Dlg: written path
+    Dlg-->>Pane: warp_completed(path)
+    Pane->>Pane: load path → RasterDataSet (NOT registered)
+    Pane->>Sched: _ingest_scene(dataset, materializer) [blocks the dialog]
+    Sched-->>Pane: MosaicScene (materialized + overviews + footprint)
+    Pane->>Ctrl: remove current occupant, add_scene, move_scene(→ orig slot)
+    Pane->>Pane: _ensure_common_grid + _refresh_scene_list
+    Pane->>View: invalidate_overlay + invalidate_pixels
+    User->>Dlg: "Save to Mosaic" (accept) or Cancel (revert)
+    Dlg-->>Pane: finished(result) → finalize or _revert_regeoref
+```
+
+**Run Warp** is phase one: the dialog threads the full-resolution GDAL warp (PR 1) and
+emits `warp_completed(path)`. `_on_scene_rewarped(path)` then wraps that output into a
+`RasterDataSet` via the shared loader
+(`app_state.get_loader().load_from_file(path, data_cache=app_state.get_cache())[0]`) but
+**does not register it** in `ApplicationState` — it is a mosaic-owned throwaway, so it
+must never pollute the global dataset list or the Add-Scene combo. Phase two runs
+`_ingest_scene` on the scheduler (the **same** materialize → overviews → footprint
+pipeline as Add Scene) with its own progress modal, **blocking the georeferencer dialog**
+(not the mosaic window) so the user cannot re-run the warp mid-reingest.
+
+`_on_rewarp_ingested(scene)` does the swap on the GUI thread. It replaces the slot's
+**current occupant** — the original on the first warp, or the previous warped scene on a
+repeat, so warps never stack — located by **object identity** (robust to a user reorder
+while the non-modal dialog is open), falling back to the recorded `orig_index`:
+`remove_scene(slot)` → `add_scene(scene)` (appends to the top) → `move_scene(scene_count-1,
+slot)` to restore the z-order slot. It then runs the normal ingest epilogue
+(`_ensure_common_grid`, `_refresh_scene_list`, `invalidate_overlay`, `invalidate_pixels`),
+because the warp changed the geotransform, footprint, and extent/resolution, so the whole
+derived state must rebuild. The original `MosaicScene` is held aside in the context and
+**never mutated**.
+
+### Save vs. revert
+
+`_on_geodialog_finished(result)` centralizes the outcome. On **accept** ("Save to
+Mosaic") the warped scene is already live, so it just drops the revert handle. On
+**reject / close** it calls `_revert_regeoref`, which removes the swapped-in warped scene
+(by identity) and re-adds the original at its slot, rebuilding **quietly**
+(`_rebuild_grid_quietly` — a revert restores a previously-valid state, so a reproject
+prompt would be a surprising interruption); it is a no-op if no warp ever ran. Either way
+the task-scoped dialog is `deleteLater()`d.
+
+### Why reingest, and how the fix reaches the export
+
+This is the part most likely to confuse a new reader, so it is called out explicitly:
+
+> **The georeferencer's "Run Warp" produces a real, full-resolution, all-bands raster
+> whose pixels are physically resampled onto the new georeferencing — not merely a
+> re-tagged preview.** The mosaic then makes *that file* the scene's backing data: after
+> the swap, `scene.dataset` is the warped dataset and `scene.gdal_path` is its
+> materialized tiled copy; the original (unwarped) dataset is removed from the mosaic
+> entirely. So there is no "unwarped full dataset" left behind to reconcile.
+
+Both the preview compositor
+([`render_scene_argb`](mosaic-internals.md#the-per-scene-renderer-render_scene_argb-qt-free))
+and the export compositor
+([`_warp_scene_to_grid_vrt`](#the-compositor-export_mosaic-qt-free)) read pixels **and**
+the geotransform from `scene.gdal_path`. They differ only in output resolution (screen
+vs. full), so they are always consistent. The re-georeferenced scene therefore reaches
+export the same way any scene does — **twice-warped in sequence**: warp #1 (the
+georeferencer) baked the correction into `scene.gdal_path`, and export's per-scene warp #2
+reprojects that corrected file onto the shared common grid. The common grid itself
+rebuilds off the corrected `footprint_wkt`, so extent and overlap follow too. This is
+exactly why the design reingests rather than patching caches in place — one coherent
+rebuild, and the export path picks it up for free. (The correction lives only for the
+session; the mosaic export re-warps from the temp at full resolution, so the on-disk
+product is correct without persisting the single corrected scene separately.)
+
+---
+
 ## The Export Path
 
 **Files:** `src/wiser/raster/mosaic_export.py` (Qt-free) and the
@@ -842,6 +975,13 @@ worker never logs — progress and raised exceptions are its only channels out.
   `wiser.gui.mosaic_pane.ReprojectPromptDialog` so nothing blocks the test.
 - `src/tests/test_mosaic_dialog_gui.py` — dialog shell, Add Scene ingestion flow,
   progress modal.
+- `src/tests/test_mosaic_georeference_gui.py` — re-georeferencing a scene in place
+  (#685) end to end via `WiserTestModel`: the context menu opens a `GeoReferencerDialog`
+  locked onto the scene (target + save path); a simulated `warp_completed` reingests and
+  swaps the corrected scene in at its original z-order slot (blocking the georeferencer
+  dialog, not the mosaic window); a repeated warp **replaces** rather than stacks; the
+  warp output is **not** registered as a global dataset; Cancel restores the original at
+  its slot while "Save to Mosaic" keeps the warped one.
 
 GUI tests use `@pytest.mark.functional`/`@pytest.mark.smoke` with the
 `WiserTestModel` harness (`src/test_utils/test_model.py`), not pytest-qt/qtbot. Run

--- a/src/tests/test_mosaic_georeference_gui.py
+++ b/src/tests/test_mosaic_georeference_gui.py
@@ -301,6 +301,64 @@ class TestMosaicRegeoreferenceEntryPoint(unittest.TestCase):
         ctx.dialog.reject()
         self.test_model.close_seamless_mosaic_dialog()
 
+    # -- save vs. revert (Chunk 3) --------------------------------------------
+
+    def test_cancel_after_warp_restores_original(self):
+        _dlg, pane, controller = self._open_with_two_scenes()
+        scenes_before = controller.get_scenes()  # [A, B]
+        index = 0
+        orig = scenes_before[index]
+        ctx = self._open_georef(pane, index)
+
+        warped = self._rewarp_and_wait(pane, ctx, "warp_cancel.tif")
+        self.assertIs(controller.get_scenes()[index], warped)  # swapped in
+
+        # Cancel the dialog -> finished(Rejected) -> revert (synchronous).
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            ctx.dialog.reject()
+
+        scenes_after = controller.get_scenes()
+        self.assertEqual(controller.scene_count(), 2)
+        # The original scene is back at its z-order slot; the warped one is gone.
+        self.assertIs(scenes_after[index], orig)
+        self.assertIs(scenes_after[1], scenes_before[1])
+        self.assertFalse(any(s is warped for s in scenes_after))
+        self.assertIsNone(pane._regeoref_ctx)
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_accept_keeps_warped_scene(self):
+        _dlg, pane, controller = self._open_with_two_scenes()
+        index = 0
+        ctx = self._open_georef(pane, index)
+        orig = ctx.orig_scene
+
+        warped = self._rewarp_and_wait(pane, ctx, "warp_accept.tif")
+
+        # "Save to Mosaic" -> finished(Accepted) -> finalize (keep the warped scene).
+        ctx.dialog.accept()
+
+        scenes_after = controller.get_scenes()
+        self.assertEqual(controller.scene_count(), 2)
+        self.assertIs(scenes_after[index], warped)
+        self.assertFalse(any(s is orig for s in scenes_after))
+        self.assertIsNone(pane._regeoref_ctx)
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_cancel_without_warp_is_noop(self):
+        _dlg, pane, controller = self._open_with_two_scenes()
+        scenes_before = controller.get_scenes()
+        ctx = self._open_georef(pane, 0)
+
+        # No warp was run; cancelling must leave the mosaic exactly as it was.
+        ctx.dialog.reject()
+
+        scenes_after = controller.get_scenes()
+        self.assertEqual(controller.scene_count(), 2)
+        self.assertIs(scenes_after[0], scenes_before[0])
+        self.assertIs(scenes_after[1], scenes_before[1])
+        self.assertIsNone(pane._regeoref_ctx)
+        self.test_model.close_seamless_mosaic_dialog()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/tests/test_mosaic_georeference_gui.py
+++ b/src/tests/test_mosaic_georeference_gui.py
@@ -1,0 +1,214 @@
+"""GUI tests for re-georeferencing a mosaic scene in place (EPIC #629, issue #685).
+
+Drive the real :class:`MosaicPane` right-click "Georeference…" entry point end to end
+through the real ingestion path (as the #634/#638 GUI tests do). Chunk 1 covers the
+entry point: the context menu offers the action, and it opens a task-scoped
+:class:`GeoReferencerDialog` locked onto the chosen scene (target + save path locked)
+without disturbing the controller. The live reingest/swap and save/revert semantics are
+exercised in later chunks.
+"""
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import numpy as np
+from osgeo import gdal, osr
+from PySide6.QtCore import Qt, QPoint
+from PySide6.QtTest import QTest
+
+import tests.context  # noqa: F401  (adds src/ to sys.path)
+from test_utils.test_model import WiserTestModel
+from wiser.gui.geo_reference_config import GeoReferencerConfig
+from wiser.utils.primitives import temp_dir
+
+import pytest
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.integration,
+]
+
+
+def _write_tiff(path, origin, epsg=32611, pixel=30.0, size=20, collar=2, bands=3):
+    """Write a small georeferenced GeoTIFF at ``origin`` with a nodata collar."""
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(epsg)
+    ds = gdal.GetDriverByName("GTiff").Create(
+        path,
+        size,
+        size,
+        bands,
+        gdal.GDT_Float32,
+        options=["TILED=YES", "BLOCKXSIZE=16", "BLOCKYSIZE=16"],
+    )
+    ox, oy = origin
+    ds.SetGeoTransform([ox, pixel, 0.0, oy, 0.0, -pixel])
+    ds.SetProjection(srs.ExportToWkt())
+    for b in range(1, bands + 1):
+        arr = np.full((size, size), 7, dtype=np.float32)
+        arr[:collar, :] = -9999
+        arr[-collar:, :] = -9999
+        arr[:, :collar] = -9999
+        arr[:, -collar:] = -9999
+        band = ds.GetRasterBand(b)
+        band.WriteArray(arr)
+        band.SetNoDataValue(-9999.0)
+    ds.FlushCache()
+    ds = None
+
+
+class TestMosaicRegeoreferenceEntryPoint(unittest.TestCase):
+    def setUp(self):
+        self.test_model = WiserTestModel()
+        # ignore_cleanup_errors: a loaded RasterDataSet keeps its GeoTIFF open (a GDAL
+        # handle), and Windows refuses to unlink an open file.
+        self._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(self._tmp.cleanup)
+
+    def tearDown(self):
+        self.test_model.close_app()
+        del self.test_model
+
+    def _wait_for(self, predicate, timeout_ms=15000, step_ms=50):
+        waited = 0
+        while waited < timeout_ms:
+            if predicate():
+                return True
+            QTest.qWait(step_ms)
+            waited += step_ms
+        return predicate()
+
+    def _load(self, name, origin):
+        path = os.path.join(self._tmp.name, name)
+        _write_tiff(path, origin)
+        return self.test_model.load_dataset(path)
+
+    def _ingest(self, pane, controller, dataset, expected_count):
+        index = pane._dataset_combo.findData(dataset.get_id())
+        self.assertGreaterEqual(index, 0)
+        pane._dataset_combo.setCurrentIndex(index)
+        pane._add_scene_button.click()
+        self.assertTrue(
+            self._wait_for(lambda: controller.scene_count() == expected_count),
+            "scene was not ingested within the timeout",
+        )
+
+    def _open_with_two_scenes(self):
+        """Open the dialog and ingest two same-CRS scenes: bottom-to-top [a, b]."""
+        ds_a = self._load("a.tif", origin=(400000.0, 3800000.0))
+        ds_b = self._load("b.tif", origin=(400300.0, 3799700.0))
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_a, 1)
+            self._ingest(pane, controller, ds_b, 2)
+        return dlg, pane, controller
+
+    def test_scene_list_has_context_menu_policy(self):
+        _dlg, pane, _controller = self._open_with_two_scenes()
+        self.assertEqual(pane._scene_list.contextMenuPolicy(), Qt.CustomContextMenu)
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_context_menu_offers_georeference(self):
+        _dlg, pane, controller = self._open_with_two_scenes()
+        # Row 0 is the top scene; it carries its real controller index in UserRole.
+        item = pane._scene_list.item(0)
+        index = item.data(Qt.UserRole)
+
+        # Patch QMenu so exec_ does not block, and _on_georeference_scene so we can
+        # confirm the action targets the right controller index.
+        with mock.patch("wiser.gui.mosaic_pane.QMenu") as MenuCls, mock.patch.object(
+            pane._scene_list, "itemAt", return_value=item
+        ), mock.patch.object(pane, "_on_georeference_scene") as geo:
+            menu = MenuCls.return_value
+            action = menu.addAction.return_value
+            pane._on_scene_context_menu(QPoint(0, 0))
+
+            menu.addAction.assert_called_once()
+            (label,), _ = menu.addAction.call_args
+            self.assertIn("Georeference", label)
+            menu.exec_.assert_called_once()
+
+            # Firing the action re-georeferences the clicked row's scene.
+            (slot,), _ = action.triggered.connect.call_args
+            slot()
+            geo.assert_called_once_with(index)
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_context_menu_no_op_without_item(self):
+        _dlg, pane, _controller = self._open_with_two_scenes()
+        with mock.patch("wiser.gui.mosaic_pane.QMenu") as MenuCls, mock.patch.object(
+            pane._scene_list, "itemAt", return_value=None
+        ):
+            pane._on_scene_context_menu(QPoint(0, 0))
+            MenuCls.assert_not_called()
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_georeference_opens_locked_dialog(self):
+        _dlg, pane, controller = self._open_with_two_scenes()
+        scenes_before = controller.get_scenes()
+        index = 0  # georeference the bottom scene
+        scene = scenes_before[index]
+
+        with mock.patch("wiser.gui.mosaic_pane.GeoReferencerDialog") as DlgCls:
+            pane._on_georeference_scene(index)
+
+        # A fresh dialog was constructed with the shared app state / services.
+        DlgCls.assert_called_once()
+        args, kwargs = DlgCls.call_args
+        self.assertIs(args[0], pane._app_state)
+        self.assertIs(args[1], pane._app_services)
+        self.assertIn("parent", kwargs)
+
+        inst = DlgCls.return_value
+        inst.show.assert_called_once()
+        (config,), _ = inst.show.call_args
+        self.assertIsInstance(config, GeoReferencerConfig)
+
+        # The target is locked to this exact (original) dataset; save path is locked to
+        # a mosaic-owned temp GeoTIFF; the reference stays user-chosen.
+        self.assertIs(config.target_dataset, scene.dataset)
+        self.assertFalse(config.allow_change_target)
+        self.assertFalse(config.allow_change_save_path)
+        self.assertIsNone(config.reference_dataset)
+        self.assertEqual(config.accept_button_text, "Save to Mosaic")
+        self.assertTrue(config.save_path.endswith(".tif"))
+        self.assertTrue(
+            os.path.abspath(config.save_path).startswith(os.path.abspath(str(temp_dir()))),
+            "warp output should live under the session temp dir",
+        )
+
+        # The live result/teardown are wired to the pane's handlers.
+        inst.warp_completed.connect.assert_called_once_with(pane._on_scene_rewarped)
+        inst.finished.connect.assert_called_once_with(pane._on_geodialog_finished)
+
+        # The in-flight context holds the original scene aside at its z-order slot.
+        ctx = pane._regeoref_ctx
+        self.assertIsNotNone(ctx)
+        self.assertIs(ctx.orig_scene, scene)
+        self.assertEqual(ctx.orig_index, index)
+        self.assertIsNone(ctx.warped_scene)
+
+        # Nothing about the mosaic changed just by opening the dialog.
+        self.assertEqual(controller.scene_count(), 2)
+        scenes_after = controller.get_scenes()
+        self.assertIs(scenes_after[0], scenes_before[0])
+        self.assertIs(scenes_after[1], scenes_before[1])
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_finished_clears_context_and_deletes_dialog(self):
+        _dlg, pane, _controller = self._open_with_two_scenes()
+        with mock.patch("wiser.gui.mosaic_pane.GeoReferencerDialog") as DlgCls:
+            pane._on_georeference_scene(0)
+            inst = DlgCls.return_value
+
+        pane._on_geodialog_finished(0)
+        self.assertIsNone(pane._regeoref_ctx)
+        inst.deleteLater.assert_called_once()
+        self.test_model.close_seamless_mosaic_dialog()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_mosaic_georeference_gui.py
+++ b/src/tests/test_mosaic_georeference_gui.py
@@ -209,6 +209,98 @@ class TestMosaicRegeoreferenceEntryPoint(unittest.TestCase):
         inst.deleteLater.assert_called_once()
         self.test_model.close_seamless_mosaic_dialog()
 
+    # -- reingest + swap on Run Warp (Chunk 2) --------------------------------
+
+    def _open_georef(self, pane, index):
+        """Open the real (locked) georeference dialog on the scene at ``index``."""
+        pane._on_georeference_scene(index)
+        ctx = pane._regeoref_ctx
+        self.assertIsNotNone(ctx)
+        return ctx
+
+    def _rewarp_and_wait(self, pane, ctx, name, origin=(400000.0, 3800000.0)):
+        """Feed a real georeferenced GeoTIFF as a completed warp and wait for the swap."""
+        warp_path = os.path.join(self._tmp.name, name)
+        _write_tiff(warp_path, origin=origin)
+        prev = ctx.warped_scene
+        # _ensure_common_grid runs in the swap; same-CRS scenes never prompt, but patch
+        # the reproject dialog defensively so a stray prompt can't block the test.
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            pane._on_scene_rewarped(warp_path)
+            self.assertTrue(
+                self._wait_for(lambda: ctx.warped_scene is not None and ctx.warped_scene is not prev),
+                "warped scene was not swapped in within the timeout",
+            )
+        return ctx.warped_scene
+
+    def test_warp_completed_swaps_scene_in_place(self):
+        _dlg, pane, controller = self._open_with_two_scenes()
+        scenes_before = controller.get_scenes()  # bottom-to-top [A, B]
+        index = 0  # georeference the bottom scene, A
+        orig = scenes_before[index]
+
+        ctx = self._open_georef(pane, index)
+
+        warp_path = os.path.join(self._tmp.name, "warp1.tif")
+        _write_tiff(warp_path, origin=(400000.0, 3800000.0))
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            pane._on_scene_rewarped(warp_path)
+            # Reingest blocks the georeference dialog, not the mosaic window.
+            self.assertFalse(ctx.dialog.isEnabled())
+            self.assertTrue(_dlg.isEnabled())
+            self.assertTrue(
+                self._wait_for(lambda: ctx.warped_scene is not None),
+                "warped scene was not swapped in within the timeout",
+            )
+
+        scenes_after = controller.get_scenes()
+        self.assertEqual(controller.scene_count(), 2)  # swapped in place, not added
+        # The warped scene occupies the original z-order slot; the other is unchanged.
+        self.assertIs(scenes_after[index], ctx.warped_scene)
+        self.assertIsNot(scenes_after[index], orig)
+        self.assertIs(scenes_after[1], scenes_before[1])
+        # The reingest produced fully-derived state (overviews + footprint).
+        self.assertTrue(ctx.warped_scene.has_overviews)
+        self.assertIsNotNone(ctx.warped_scene.footprint_wkt)
+        # The original scene / dataset is held aside untouched.
+        self.assertIs(ctx.orig_scene, orig)
+        self.assertIs(ctx.orig_scene.dataset, orig.dataset)
+        self.assertFalse(any(s is orig for s in scenes_after))
+
+        ctx.dialog.reject()
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_repeated_warp_replaces_not_stacks(self):
+        _dlg, pane, controller = self._open_with_two_scenes()
+        index = 0
+        ctx = self._open_georef(pane, index)
+
+        first = self._rewarp_and_wait(pane, ctx, "warp_a.tif")
+        self.assertEqual(controller.scene_count(), 2)
+
+        second = self._rewarp_and_wait(pane, ctx, "warp_b.tif")
+        self.assertIsNot(second, first)
+        # Replaced, not stacked: still two scenes, and the first warped one is gone.
+        self.assertEqual(controller.scene_count(), 2)
+        scenes_after = controller.get_scenes()
+        self.assertFalse(any(s is first for s in scenes_after))
+        self.assertIs(scenes_after[index], second)
+
+        ctx.dialog.reject()
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_rewarp_does_not_register_output_dataset(self):
+        _dlg, pane, controller = self._open_with_two_scenes()
+        before = len(pane._app_state.get_datasets())
+        ctx = self._open_georef(pane, 0)
+        self._rewarp_and_wait(pane, ctx, "warp_noreg.tif")
+        # The warped output is mosaic-internal: it must not enter the global dataset
+        # list (and thus never appears in the Add-Scene combo).
+        self.assertEqual(len(pane._app_state.get_datasets()), before)
+
+        ctx.dialog.reject()
+        self.test_model.close_seamless_mosaic_dialog()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -648,14 +648,65 @@ class MosaicPane(QWidget):
 
     def _on_scene_rewarped(self, path: str) -> None:
         """
-        Warp finished: reingest the output at ``path`` and swap it into the mosaic in
-        place.
+        A "Run Warp" finished: reingest the warped output at ``path`` and swap the
+        corrected scene into the mosaic in place (see :meth:`_on_rewarp_ingested`).
 
-        Implemented in the reingest step (#685); for now the warp writes its temp
-        GeoTIFF but the mosaic is left unchanged.
+        The output is wrapped into a ``RasterDataSet`` with the shared loader but is
+        deliberately **not** registered in ``ApplicationState`` -- it is a
+        mosaic-owned throwaway that reingestion re-materializes, so it must never
+        pollute the global dataset list or the Add-Scene combo.
         """
-        # TODO(#685): load `path` as a RasterDataSet, reingest via _ingest_scene, and
-        # swap the corrected scene in at its original z-order slot.
+        ctx = self._regeoref_ctx
+        if ctx is None or self._app_services is None or self._materializer is None:
+            return
+        new_dataset = self._app_state.get_loader().load_from_file(
+            path=path, data_cache=self._app_state.get_cache()
+        )[0]
+        # Reingest on the scheduler (materialize -> overviews -> footprint) with its own
+        # progress modal. Block the georeference dialog (not the mosaic window) so the
+        # user cannot re-run the warp mid-reingest; the mosaic view updates when done.
+        self._active_progress_task = run_with_progress(
+            self._app_services,
+            ctx.dialog,
+            self.tr("Updating scene…"),
+            _ingest_scene,
+            new_dataset,
+            self._materializer,
+            on_success=self._on_rewarp_ingested,
+            on_error=self._on_scene_failed,
+            description=self.tr("Re-materializing warped scene…"),
+        )
+
+    def _on_rewarp_ingested(self, scene: MosaicScene) -> None:
+        """
+        Swap the freshly-reingested warped ``scene`` into the mosaic at the original
+        scene's z-order slot.
+
+        Replaces whatever currently occupies that slot -- the original on the first
+        warp, or the previous warped scene on a repeat -- so repeated warps never
+        stack. The occupant is located by object identity (robust to a user reorder
+        while the non-modal dialog is open), falling back to the recorded slot index.
+        """
+        ctx = self._regeoref_ctx
+        if ctx is None:
+            return
+        scenes = self._controller.get_scenes()
+        current = ctx.warped_scene if ctx.warped_scene is not None else ctx.orig_scene
+        slot = next((i for i, s in enumerate(scenes) if s is current), None)
+        if slot is None:
+            slot = ctx.orig_index
+        else:
+            self._controller.remove_scene(slot)
+        # add_scene appends to the top of the z-order, so move it back down to the slot.
+        self._controller.add_scene(scene)
+        self._controller.move_scene(self._controller.scene_count() - 1, slot)
+        ctx.warped_scene = scene
+        # The warp changed geotransform/footprint/extent, so the whole derived state
+        # must rebuild -- exactly the normal-ingest epilogue.
+        self._ensure_common_grid()
+        self._refresh_scene_list()
+        self._mosaic_view.invalidate_overlay()
+        self._mosaic_view.invalidate_pixels()
 
     def _on_geodialog_finished(self, result: int) -> None:
         """

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -15,8 +15,10 @@ z-order/visibility, a re-read (``invalidate_pixels``) when the pixels change, an
 rebuild when the output geometry changes.
 """
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Sequence, TYPE_CHECKING
+from uuid import uuid4
 
 from osgeo import gdal, osr
 
@@ -26,6 +28,8 @@ from PySide6.QtWidgets import *
 
 from .app_state import ApplicationState
 from .app_services import AppServices
+from .geo_reference_config import GeoReferencerConfig
+from .geo_reference_dialog import GeoReferencerDialog
 from .mosaic_crs_dialog import ReprojectPromptDialog
 from .mosaic_view import MosaicView
 from .progress_task import run_with_progress
@@ -45,6 +49,7 @@ from wiser.raster.mosaic_ingestion import (
     compute_footprint_wkt,
     validate_scene,
 )
+from wiser.utils.primitives import temp_dir
 from wiser.utils.progress import ProgressReporter
 
 if TYPE_CHECKING:
@@ -118,6 +123,24 @@ def _export_mosaic_task(
     return str(result)
 
 
+@dataclass
+class _RegeorefContext:
+    """
+    In-flight state for a right-click "Georeference…" session on one mosaic scene
+    (#685).
+
+    Holds the original scene aside (it is never mutated) so a cancel can restore it,
+    remembers the z-order slot to swap results back into, owns the task-scoped
+    :class:`GeoReferencerDialog`, and tracks the currently swapped-in warped scene (if
+    any) so a repeated warp *replaces* rather than stacks.
+    """
+
+    orig_scene: MosaicScene
+    orig_index: int
+    dialog: GeoReferencerDialog
+    warped_scene: Optional[MosaicScene] = None
+
+
 class MosaicPane(QWidget):
     """
     Hosts a :class:`MosaicView` plus a controls area with the Add-Scene action.
@@ -142,6 +165,8 @@ class MosaicPane(QWidget):
         # Holds the in-flight ingestion task (progress modal + background work) so it
         # is not garbage-collected mid-run; overwritten on the next add.
         self._active_progress_task = None
+        # In-flight right-click "Georeference…" session (#685), or None when idle.
+        self._regeoref_ctx: Optional[_RegeorefContext] = None
 
         self._init_ui()
 
@@ -245,6 +270,9 @@ class MosaicPane(QWidget):
         self._scene_list.itemSelectionChanged.connect(self._on_scene_selection_changed)
         self._scene_list.itemChanged.connect(self._on_scene_item_changed)
         self._scene_list.model().rowsMoved.connect(self._on_scene_rows_moved)
+        # Right-click a row to re-georeference that scene in place (#685).
+        self._scene_list.setContextMenuPolicy(Qt.CustomContextMenu)
+        self._scene_list.customContextMenuRequested.connect(self._on_scene_context_menu)
         layout.addWidget(self._scene_list)
 
         self._remove_scene_button = QPushButton(self.tr("Remove Selected"), group)
@@ -540,6 +568,106 @@ class MosaicPane(QWidget):
         self._rebuild_grid_quietly()
         self._mosaic_view.invalidate_overlay()
         self._mosaic_view.invalidate_pixels()
+
+    # -- re-georeference a scene in place (#685) -------------------------------
+
+    def _on_scene_context_menu(self, pos) -> None:
+        """
+        Right-click on a scene row: offer "Georeference…" for that scene.
+
+        Re-georeferencing reingests the warped result, which needs the scheduler and
+        the session materializer -- the same requirement Add Scene guards on -- so the
+        menu is suppressed when either is absent (e.g. a display-only pane).
+        """
+        if self._app_services is None or self._materializer is None:
+            return
+        item = self._scene_list.itemAt(pos)
+        if item is None:
+            return
+        index = item.data(Qt.UserRole)
+        if index is None:
+            return
+        menu = QMenu(self._scene_list)
+        action = menu.addAction(self.tr("Georeference…"))
+        action.triggered.connect(lambda *_a, i=index: self._on_georeference_scene(i))
+        menu.exec_(self._scene_list.mapToGlobal(pos))
+
+    def _regeoref_save_path(self, scene: MosaicScene) -> str:
+        """
+        Allocate a fresh, unique temp path for a re-georeference warp under the session
+        temp dir.
+
+        A new name per warp is deliberate: the previous warped ``RasterDataSet`` may
+        still hold its GeoTIFF open (a real hazard on Windows), so reusing one path
+        would risk overwriting a locked file. The file is a throwaway -- reingestion
+        re-materializes it into the mosaic's own copy.
+        """
+        out_dir = temp_dir()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return str(out_dir / f"regeoref_{id(scene)}_{uuid4().hex}.tif")
+
+    def _on_georeference_scene(self, index: int) -> None:
+        """
+        Open a task-scoped :class:`GeoReferencerDialog` locked onto the scene at
+        controller ``index``.
+
+        The target dataset and the save path are locked (the mosaic owns both); only
+        the reference is user-chosen. The warped result is swapped into the mosaic in
+        place when the user runs a warp (see :meth:`_on_scene_rewarped`), and reverted
+        on cancel (see :meth:`_on_geodialog_finished`).
+        """
+        scenes = self._controller.get_scenes()
+        if index < 0 or index >= len(scenes):
+            return
+        scene = scenes[index]
+
+        config = GeoReferencerConfig(
+            target_dataset=scene.dataset,  # the ORIGINAL dataset -- never a copy
+            allow_change_target=False,  # locked: this is the scene being fixed
+            reference_dataset=None,  # user picks (unlocked)
+            save_path=self._regeoref_save_path(scene),
+            allow_change_save_path=False,  # locked: the mosaic owns the output path
+            accept_button_text=self.tr("Save to Mosaic"),
+        )
+
+        # A fresh, task-scoped instance (not the Tools-menu singleton) so the locked
+        # config cannot leak back into that flow; it is destroyed when the dialog
+        # finishes. The context holds the reference so it is not GC'd while shown.
+        dialog = GeoReferencerDialog(self._app_state, self._app_services, parent=self.window())
+        dialog.warp_completed.connect(self._on_scene_rewarped)
+        dialog.finished.connect(self._on_geodialog_finished)
+
+        self._regeoref_ctx = _RegeorefContext(
+            orig_scene=scene,
+            orig_index=index,
+            dialog=dialog,
+            warped_scene=None,
+        )
+        # Non-modal, matching the (non-modal) mosaic dialog so it never blocks it.
+        dialog.show(config)
+
+    def _on_scene_rewarped(self, path: str) -> None:
+        """
+        Warp finished: reingest the output at ``path`` and swap it into the mosaic in
+        place.
+
+        Implemented in the reingest step (#685); for now the warp writes its temp
+        GeoTIFF but the mosaic is left unchanged.
+        """
+        # TODO(#685): load `path` as a RasterDataSet, reingest via _ingest_scene, and
+        # swap the corrected scene in at its original z-order slot.
+
+    def _on_geodialog_finished(self, result: int) -> None:
+        """
+        Tear down the task-scoped georeference dialog.
+
+        Save/revert semantics land in a later step (#685); for now this just drops the
+        in-flight context and schedules the dialog for deletion.
+        """
+        ctx = self._regeoref_ctx
+        self._regeoref_ctx = None
+        if ctx is not None:
+            ctx.dialog.deleteLater()
 
     # -- resolution -----------------------------------------------------------
 

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -710,15 +710,46 @@ class MosaicPane(QWidget):
 
     def _on_geodialog_finished(self, result: int) -> None:
         """
-        Tear down the task-scoped georeference dialog.
+        Finalize or revert the re-georeference session, then destroy the task-scoped
+        dialog.
 
-        Save/revert semantics land in a later step (#685); for now this just drops the
-        in-flight context and schedules the dialog for deletion.
+        "Save to Mosaic" (accept): the warped scene is already live, so this just drops
+        the revert handle. Cancel / close (reject): restore the original scene at its
+        slot via :meth:`_revert_regeoref` (a no-op if no warp ever ran). Either way the
+        task-scoped dialog is scheduled for deletion.
         """
         ctx = self._regeoref_ctx
+        if ctx is None:
+            return
+        if result != QDialog.Accepted:
+            self._revert_regeoref(ctx)
         self._regeoref_ctx = None
-        if ctx is not None:
-            ctx.dialog.deleteLater()
+        ctx.dialog.deleteLater()
+
+    def _revert_regeoref(self, ctx: "_RegeorefContext") -> None:
+        """
+        Undo an in-place re-georeference: remove the swapped-in warped scene (if any)
+        and restore the original scene at its z-order slot.
+
+        A no-op when the user never ran a warp (nothing was swapped in). The warped
+        scene is located by identity (robust to a user reorder), falling back to the
+        recorded slot. Rebuilds the grid *quietly* -- a revert restores a previously
+        valid state, so a reproject prompt here would be a surprising interruption.
+        """
+        if ctx.warped_scene is None:
+            return
+        scenes = self._controller.get_scenes()
+        slot = next((i for i, s in enumerate(scenes) if s is ctx.warped_scene), None)
+        if slot is None:
+            slot = ctx.orig_index
+        else:
+            self._controller.remove_scene(slot)
+        self._controller.add_scene(ctx.orig_scene)
+        self._controller.move_scene(self._controller.scene_count() - 1, slot)
+        self._rebuild_grid_quietly()
+        self._refresh_scene_list()
+        self._mosaic_view.invalidate_overlay()
+        self._mosaic_view.invalidate_pixels()
 
     # -- resolution -----------------------------------------------------------
 


### PR DESCRIPTION
## What does this change do?
Adds the ability to georeference a scene from the mosaic pane. You right click the scene and press geo reference.

Closes #685 

## What type of PR is this? (check all applicable) 
- [x] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
We need the user to be able to geo reference their scene and have the output show up in the preview. 

## How did you implement the change?
The georeference output is loaded into the mosaic pane and the previous output is replaced. But if the user cancels the operation the original dataset is still used.

## Added tests?
- [X] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [X] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed
