### PR TITLE
fix: Fixing inability to zoom in due to pyside6 change

### DIFF
--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -749,6 +749,12 @@ class WiserTestModel:
     def is_main_view_linked(self):
         return self.main_view._link_view_scrolling
 
+    def get_main_view_scale(self):
+        """
+        Returns the current zoom scale of the main view's raster panes.
+        """
+        return self.main_view.get_scale()
+
     # region State setting
 
     def click_link_button(self) -> bool:
@@ -834,6 +840,39 @@ class WiserTestModel:
             QPoint(dx, dy),  # angleDelta: values such as 120 typically indicate one notch
             Qt.NoButton,  # buttons (wheel events usually have no button pressed)
             Qt.NoModifier,  # keyboard modifiers
+            Qt.ScrollUpdate,  # scroll phase: ScrollUpdate indicates the wheel is in motion
+            False,  # inverted scrolling: False means normal behavior
+        )
+
+        # Post the event to the viewport so that it is handled as if a user scrolled.
+        self.app.postEvent(viewport, wheel_event)
+        self.run()
+
+    def ctrl_scroll_main_view_rv(self, rv_pos: Tuple[int, int], notches: int):
+        """
+        Simulates holding Ctrl and scrolling the mouse wheel over the specified main
+        view rasterview, which should zoom in (positive notches) or out (negative
+        notches) centered on the middle of the viewport.
+
+        One notch corresponds to the standard Qt wheel delta of 120 units.
+        """
+        rv = self.get_main_view_rv(rv_pos)
+        scroll_area = rv._scroll_area
+
+        # The viewport is the widget that actually receives the wheel events.
+        viewport = scroll_area.viewport()
+
+        # Scroll from the center of the viewport.
+        pos = QPointF(viewport.width() / 2, viewport.height() / 2)
+        global_pos = viewport.mapToGlobal(pos.toPoint())
+
+        wheel_event = QWheelEvent(
+            pos,  # local position (QPointF)
+            global_pos,  # global position (QPointF)
+            QPoint(0, 0),  # pixelDelta (unused here)
+            QPoint(0, notches * 120),  # angleDelta: 120 units is a single notch
+            Qt.NoButton,  # buttons (wheel events usually have no button pressed)
+            Qt.ControlModifier,  # keyboard modifiers: Ctrl triggers zoom instead of scroll
             Qt.ScrollUpdate,  # scroll phase: ScrollUpdate indicates the wheel is in motion
             False,  # inverted scrolling: False means normal behavior
         )

--- a/src/tests/test_main_view_wheel_zoom.py
+++ b/src/tests/test_main_view_wheel_zoom.py
@@ -1,0 +1,84 @@
+"""Regression tests for mouse-wheel zoom and pan behavior in the main view raster panes.
+
+Covers WISER issue #686: Ctrl+scroll wheel zoom-in crashed under PySide6 because
+QWheelEvent.pos() was removed in favor of position(). Zoom-out and plain-scroll
+panning are also covered here so a future change to the wheel-event handling
+can't silently regress the paths that already worked.
+"""
+import unittest
+
+import tests.context
+
+from test_utils.test_model import WiserTestModel
+
+import numpy as np
+
+import pytest
+
+pytestmark = [
+    pytest.mark.smoke,
+]
+
+
+def _make_dataset():
+    # Large enough that, even at 100% zoom, the image doesn't fit in the
+    # viewport -- otherwise there's nothing to scroll/pan.
+    rows, cols, channels = 400, 400, 3
+    row_values = np.linspace(0, 1, rows).reshape(rows, 1)
+    impl = np.tile(row_values, (1, cols))
+    return np.repeat(impl[np.newaxis, :, :], channels, axis=0)
+
+
+class TestMainViewWheelZoom(unittest.TestCase):
+    """
+    Test suite validating that Ctrl+scroll zooms the main view and that plain
+    scrolling still pans it, both before and after the PySide6 wheelEvent fix.
+    """
+
+    def setUp(self):
+        self.test_model = WiserTestModel()
+        self.test_model.load_dataset(_make_dataset())
+
+    def tearDown(self):
+        self.test_model.close_app()
+        del self.test_model
+
+    def test_ctrl_scroll_zooms_in(self):
+        """Ctrl+scroll wheel up should zoom in (WISER issue #686 regression)."""
+        initial_scale = self.test_model.get_main_view_scale()
+
+        self.test_model.ctrl_scroll_main_view_rv((0, 0), notches=1)
+
+        new_scale = self.test_model.get_main_view_scale()
+        self.assertGreater(new_scale, initial_scale)
+
+    def test_ctrl_scroll_zooms_out(self):
+        """Ctrl+scroll wheel down should zoom out."""
+        initial_scale = self.test_model.get_main_view_scale()
+
+        self.test_model.ctrl_scroll_main_view_rv((0, 0), notches=-1)
+
+        new_scale = self.test_model.get_main_view_scale()
+        self.assertLess(new_scale, initial_scale)
+
+    def test_plain_scroll_pans_without_zooming(self):
+        """Scrolling without Ctrl should pan the view instead of changing zoom."""
+        initial_scale = self.test_model.get_main_view_scale()
+        initial_region = self.test_model.get_main_view_rv_visible_region((0, 0))
+
+        self.test_model.scroll_main_view_rv((0, 0), dx=0, dy=5)
+
+        new_region = self.test_model.get_main_view_rv_visible_region((0, 0))
+        new_scale = self.test_model.get_main_view_scale()
+
+        # Panning should not change the zoom scale...
+        self.assertAlmostEqual(new_scale, initial_scale)
+        # ...but should move the visible region.
+        self.assertNotEqual(
+            (initial_region.x(), initial_region.y()),
+            (new_region.x(), new_region.y()),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/wiser/gui/rasterview.py
+++ b/src/wiser/gui/rasterview.py
@@ -549,7 +549,7 @@ class ImageScrollArea(QScrollArea):
         if event.modifiers() & Qt.ControlModifier:
             delta = event.angleDelta().y()
             if delta > 0:
-                viewport_pos = event.pos()  # pos() is in viewport coords
+                viewport_pos = event.position().toPoint()  # position() is in viewport coords
                 widget_pos = self.widget().mapFrom(self.viewport(), viewport_pos)
                 # Position as a ratio of the full image ­– stays constant after resize
                 rx = widget_pos.x() / max(1, self.widget().width())


### PR DESCRIPTION
## What does this change do?
Fixes a crash when Ctrl+scrolling to zoom in on a raster view. The wheel event handler was calling `QWheelEvent.pos()`, which no longer exists in PySide6, so every Ctrl+scroll-up zoom raised an `AttributeError` and did nothing.

Closes #686

## What type of PR is this? (check all applicable)
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
Reported in [#686](https://github.com/Ehlmann-research-group/WISER/issues/686): after the PySide6 migration, Ctrl+scroll wheel zoom-in stopped working on Windows. `QWheelEvent.pos()` was removed in PySide6 in favor of `position()` (a `QPointF`), and `ImageScrollArea.wheelEvent` in `rasterview.py` still called `event.pos()` inside the zoom-in branch, throwing an `AttributeError` that Qt swallowed and printed to stderr. Zoom-out and plain scroll/pan were unaffected since they don't touch that code path.

## How did you implement the change?
Replaced `event.pos()` with `event.position().toPoint()` in `ImageScrollArea.wheelEvent` (`src/wiser/gui/rasterview.py`), matching the PySide6 convention already used elsewhere in the codebase (e.g. `mosaic_view.py`).

Confirmed the new zoom-in test fails with the exact `AttributeError` from the issue before the fix, and that all three tests pass afterward.

## Added tests?
- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?
- [ ] yes
- [x] no documentation needed

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed
