### PR TITLE
fix(mosaic): Fix mosaic linear stretch using min and max of window and not dataset

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -8,7 +8,9 @@ intended for developers reading, debugging, or extending the tool.
 This is an in-progress feature (EPIC #629). As of this writing, scene ingestion,
 materialization, common-grid/CRS resolution, the **vector overlay** (footprints,
 bounding box, overlap highlight), the **static-scene pixel compositor** (the composited
-preview, with an off-thread debounced per-scene cache), the **control panel**
+preview, with an off-thread debounced per-scene cache and a stable, zoom-independent
+per-scene contrast stretch cached at ingest — see [Stretch
+bounds](#stretch-bounds-compute_stretch_bounds-mosaic_ingestionpy)), the **control panel**
 (drag-to-reorder z-order, resolution mode, resampling method, and the band-metadata
 chooser), the **full-resolution export path** (streaming ENVI compositor on the
 common grid — see [The Export Path](#the-export-path)), and **in-place scene
@@ -57,7 +59,7 @@ SRS/geotransform/nodata/band metadata from the dataset object, not from its `_im
 | `src/wiser/gui/mosaic_view.py` | `MosaicView` — the two-layer paint surface (pixel + vector), currently a stub |
 | `src/wiser/gui/mosaic_crs_dialog.py` | `ReprojectPromptDialog` — modal target-CRS chooser |
 | `src/wiser/raster/mosaic_controller.py` | `MosaicController`, `MosaicScene`, `CommonGrid`, `ResolutionMode` — the non-GUI model |
-| `src/wiser/raster/mosaic_ingestion.py` | `validate_scene`, `build_overviews`, `compute_footprint_wkt` — Qt-free ingestion gates |
+| `src/wiser/raster/mosaic_ingestion.py` | `validate_scene`, `build_overviews`, `compute_stretch_bounds`, `compute_footprint_wkt` — Qt-free ingestion gates |
 | `src/wiser/raster/mosaic_compositor.py` | `render_scene_argb` — Qt-free per-scene warp→RGBA renderer (alpha = validity) for the pixel layer |
 | `src/wiser/raster/mosaic_export.py` | `export_mosaic` — warps each scene onto the common grid and streams the mosaic to ENVI |
 | `src/wiser/raster/mosaic_materialize.py` | `SceneMaterializer`, `materialize_to_tiled_geotiff` — the object-model adapter |
@@ -214,7 +216,7 @@ with `TemporaryDirectory`'s own finalizer as a backstop on GC/interpreter exit.
 
 ## Scene Ingestion Pipeline
 
-Adding a scene runs three gated phases on a background thread, orchestrated by
+Adding a scene runs four gated phases on a background thread, orchestrated by
 `_ingest_scene()` (`mosaic_pane.py`):
 
 ```{mermaid}
@@ -236,8 +238,9 @@ sequenceDiagram
         Sched->>Ingest: run on scheduler thread
         Ingest->>Mat: gdal_source(dataset) → materialize/warp-ready GeoTIFF
         Ingest->>Ingest: build_overviews(gdal_path)
+        Ingest->>Ingest: compute_stretch_bounds(gdal_path, dataset)
         Ingest->>Ingest: compute_footprint_wkt(gdal_path)
-        Ingest-->>Sched: MosaicScene(dataset, gdal_path, footprint_wkt, has_overviews=True)
+        Ingest-->>Sched: MosaicScene(dataset, gdal_path, footprint_wkt,<br/>has_overviews=True, stretch_bounds)
         Sched-->>Pane: on_success(scene) [GUI thread]
         Pane->>Ctrl: add_scene(scene)
         Pane->>Pane: _refresh_scene_list()
@@ -283,6 +286,24 @@ has no first-paint stutter. Because materialization already produces a WISER-own
 temp copy, overviews can be written internally rather than as external `.ovr`
 sidecars.
 
+### Stretch bounds (`compute_stretch_bounds`, `mosaic_ingestion.py`)
+
+Computes stable, extent-independent 2-98 percentile contrast-stretch bounds per
+display band (issue #675), stored on `MosaicScene.stretch_bounds` (source band index
+→ `(lo, hi)`). Runs right after overviews, since it samples one: reads the
+level-4 internal overview (falling back to the coarsest available, or the full band
+if no overviews exist) rather than the full-resolution data, so a whole-scene
+percentile pass stays cheap regardless of the source's size — level 4 rather than the
+coarsest level trades a little ingest time for a larger, more representative sample
+(the coarsest overview's sparser `NEAREST`-resampled pixels risk missing a small
+bright/dark feature). A band with no valid (non-nodata) pixels in the sample is simply
+omitted from the result.
+
+This is what fixes the bug the pixel layer's per-scene renderer used to have: see
+[The per-scene renderer](#the-per-scene-renderer-render_scene_argb-qt-free) below for
+how the compositor consumes these bounds instead of recomputing a stretch from
+whatever happens to be in the current viewport.
+
 ### Footprint (`compute_footprint_wkt`, `mosaic_ingestion.py`)
 
 Derives the valid-pixel outline via `gdal.Footprint(..., format="WKT")`, in the
@@ -292,10 +313,10 @@ falls back to the full raster rectangle.
 
 ### Progress reporting
 
-All three phases share one `ProgressReporter` (`wiser/utils/progress.py`), split by
-weight — materialize 0.5, overviews 0.35, footprint 0.15 — so the overall bar advances
-smoothly across phases that report in very different native units (per-band count vs.
-GDAL's own `0..1` callbacks). The reporter is Qt-free; `run_with_progress`
+All four phases share one `ProgressReporter` (`wiser/utils/progress.py`), split by
+weight — materialize 0.45, overviews 0.30, stretch bounds 0.10, footprint 0.15 — so the
+overall bar advances smoothly across phases that report in very different native units
+(per-band count vs. GDAL's own `0..1` callbacks). The reporter is Qt-free; `run_with_progress`
 (`wiser/gui/progress_task.py`) is the reusable GUI bridge that:
 
 - shows a non-blocking-to-the-rest-of-WISER `ProgressDialog` (disables only the mosaic
@@ -457,11 +478,35 @@ an `(h, w, 4)` uint8 RGBA array. A single `gdal.Warp` does four jobs at once:
   mask-band read). This mirrors the warp seam already used by `_warped_resolution`.
 
 RGB comes from the dataset's `get_default_display_bands()` (1 band → grayscale, 3 →
-RGB), contrast-stretched per band over the valid pixels (2–98 percentile). Invalid
-pixels are forced fully clear `(0,0,0,0)` so nothing bleeds under a transparent alpha.
-It is Qt-free (produces a NumPy array) so it is unit-testable without a running app and
-can run on a background thread; the view wraps the array into a `QImage` on the GUI
-thread.
+RGB), contrast-stretched per band (2–98 percentile). Invalid pixels are forced fully
+clear `(0,0,0,0)` so nothing bleeds under a transparent alpha. It is Qt-free (produces
+a NumPy array) so it is unit-testable without a running app and can run on a
+background thread; the view wraps the array into a `QImage` on the GUI thread.
+
+> **The stretch is against `scene.stretch_bounds`, not the viewport's pixels** (issue
+> #675). Originally the 2-98 percentile was computed from whatever pixels happened to
+> land in the current warp output — so zooming in fed a smaller, different pixel
+> population into the percentile on every paint, and a scene's on-screen contrast
+> visibly drifted as the user zoomed, even though nothing about the data changed.
+> `render_scene_argb` now looks up `scene.stretch_bounds[band_idx]` — precomputed once
+> at ingest by
+> [`compute_stretch_bounds`](#stretch-bounds-compute_stretch_bounds-mosaic_ingestionpy)
+> from a whole-scene overview sample — and stretches every render against those fixed
+> bounds, so contrast is identical whether the viewport shows the full scene or a
+> single zoomed-in pixel. `_stretch_band` still falls back to the old viewport
+> percentile when `bounds` is `None` (a `MosaicScene` built directly, e.g. in a unit
+> test, without running ingestion).
+>
+> The bounds are **per scene**, not combined across the mosaic's visible scenes, even
+> though a shared min/max across all visible scenes would look more consistent when
+> scenes have very different value ranges. That was a deliberate trade-off: combined
+> bounds would have to change (and force a re-render) whenever visibility changes, which
+> breaks the `recomposite_only()` **zero-GDAL-reads** guarantee for visibility/z-order
+> changes described in [The per-scene cache and
+> `composite()`](#the-per-scene-cache-and-composite) below — a guarantee
+> `test_mosaic_view_gui.py` asserts by spying on `render_scene_argb`. Independent
+> per-scene bounds fully fix the zoom-instability bug (the actual report) without
+> touching that contract.
 
 ### The per-scene cache and `composite()`
 
@@ -697,8 +742,8 @@ the output geometry changes:
   Path](#the-export-path)); the v1 preview toggle is intentionally deferred.
 
 `ResolutionMode` change, band-metadata selection, resampling warning, and
-reorder-without-reads are covered by `src/tests/test_mosaic_pane_gui.py`, with the
-controller-side surface (resample round-trip, band-metadata fallback, no-grid-invalidation)
+reorder-without-reads are covered by `src/tests/test_mosaic_control_panel_gui.py`, with
+the controller-side surface (resample round-trip, band-metadata fallback, no-grid-invalidation)
 in `src/tests/test_mosaic_controller.py`.
 
 ---
@@ -941,18 +986,23 @@ worker never logs — progress and raised exceptions are its only channels out.
   preservation (pure `QTransform` math, no widget shown).
 - `src/tests/test_mosaic_compositor.py` — the Qt-free `render_scene_argb`: alpha is 0
   exactly on the nodata collar and 255 on the valid interior, RGBA shape/dtype, valid
-  pixels get color, a disjoint viewport comes back fully transparent (no Qt).
+  pixels get color, a disjoint viewport comes back fully transparent (no Qt). Issue
+  #675: with explicit `stretch_bounds` set on the scene, a gradient fixture renders
+  identically whether read at the full extent or a further-zoomed-in crop; a paired
+  test with `stretch_bounds=None` proves the same fixture *does* drift under the old
+  viewport-percentile fallback, confirming the regression coverage is meaningful.
 - `src/tests/test_mosaic_view_gui.py` — the overlay **and** pixel-layer wiring end to
   end, driven through the real `MosaicPane` ingestion path: geometry cache populates /
   re-invalidates; `composite()` stacks known ARGB layers (top opaque wins, holes reveal
   below); the per-scene cache populates; z-order reorder / visibility toggle trigger **no
   GDAL reads** (spy on `render_scene_argb`); and a pan burst **coalesces into a single
   debounced background read**.
-- `src/tests/test_mosaic_pane_gui.py` — the control panel (#638) end to end through the
-  real ingestion path: drag-reorder updates controller z-order and triggers **no GDAL
-  reads**; a resolution-mode change rebuilds the grid; a band-metadata selection sets the
-  canonical source without changing band count; and a non-Nearest-Neighbor resampling
-  choice surfaces the warning and invalidates the pixel cache.
+- `src/tests/test_mosaic_control_panel_gui.py` — the control panel (#638) end to end
+  through the real ingestion path: drag-reorder updates controller z-order and triggers
+  **no GDAL reads**; a resolution-mode change rebuilds the grid; a band-metadata
+  selection sets the canonical source without changing band count; and a
+  non-Nearest-Neighbor resampling choice surfaces the warning and invalidates the pixel
+  cache.
 - `src/tests/test_mosaic_export.py` — the Qt-free `export_mosaic` (#639): two overlapping
   fixtures give the correct z-order winner per pixel (and the reversed order flips it),
   nodata passthrough (a hole in the top scene reveals the lower one; outside every
@@ -966,7 +1016,10 @@ worker never logs — progress and raised exceptions are its only channels out.
   into WISER** (dataset count unchanged); plus the no-scenes guard (informs and never
   reaches the file picker).
 - `src/tests/test_mosaic_ingestion.py` — `validate_scene`, `build_overviews`,
-  `compute_footprint_wkt`, and progress-reporting behavior.
+  `compute_footprint_wkt`, and progress-reporting behavior. `compute_stretch_bounds`
+  (#675): nodata is excluded from the sampled bounds, a value gradient produces a
+  meaningfully wide (not collapsed) range, an all-nodata band is omitted from the
+  result rather than raising, and the no-overviews fallback (reads the full band).
 - `src/tests/test_mosaic_crs_dialog.py` — `ReprojectPromptDialog` in isolation
   (offscreen Qt), constructed directly from plain lists.
 - `src/tests/test_mosaic_crs_gui.py` — end-to-end through the real
@@ -974,7 +1027,8 @@ worker never logs — progress and raised exceptions are its only channels out.
   the auto-lock behavior described above with `mock.patch` on
   `wiser.gui.mosaic_pane.ReprojectPromptDialog` so nothing blocks the test.
 - `src/tests/test_mosaic_dialog_gui.py` — dialog shell, Add Scene ingestion flow,
-  progress modal.
+  progress modal; asserts the ingested `MosaicScene.stretch_bounds` is populated
+  (#675).
 - `src/tests/test_mosaic_georeference_gui.py` — re-georeferencing a scene in place
   (#685) end to end via `WiserTestModel`: the context menu opens a `GeoReferencerDialog`
   locked onto the scene (target + save path); a simulated `warp_completed` reingests and

--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -8,7 +8,7 @@ intended for developers reading, debugging, or extending the tool.
 This is an in-progress feature (EPIC #629). As of this writing, scene ingestion,
 materialization, common-grid/CRS resolution, the **vector overlay** (footprints,
 bounding box, overlap highlight), the **static-scene pixel compositor** (the composited
-preview, with an off-thread debounced per-scene cache and a stable, zoom-independent
+preview, with an off-thread debounced tiled cache (#674) and a stable, zoom-independent
 per-scene contrast stretch cached at ingest — see [Stretch
 bounds](#stretch-bounds-compute_stretch_bounds-mosaic_ingestionpy)), the **control panel**
 (drag-to-reorder z-order, resolution mode, resampling method, and the band-metadata
@@ -41,7 +41,7 @@ The feature is built from three cooperating layers:
   (not a subclass — a mosaic is N scenes on one shared world grid, not one dataset
   zoomed). It draws two layers on a QGIS-style unbounded canvas via a world→screen
   camera (`MosaicViewTransform`): the **pixel layer** (the composited scenes, from a
-  per-scene ARGB cache — see [The Pixel Layer](#the-pixel-layer-static-scene-compositor))
+  tiled ARGB cache — see [The Pixel Layer](#the-pixel-layer-static-scene-compositor))
   and, on top, the **vector overlay** (footprints, bounding box, overlap highlight — see
   [The Geometry Overlay](#the-geometry-overlay-vector-layer)).
 
@@ -105,9 +105,9 @@ classDiagram
     class MosaicView {
         mosaic_view.py
         -_controller : MosaicController
-        -_composite_pixmap : QPixmap
-        -_scene_layers : Dict~int, QImage~
-        -_render_signature : tuple
+        -_tile_cache : OrderedDict~TileKey, QImage~
+        -_inflight_tiles : Set~TileKey~
+        -_read_epoch : int
         -_transform : MosaicViewTransform
         -_footprint_paths : List~QPainterPath~
         -_hidden_paths : List~QPainterPath~
@@ -458,16 +458,20 @@ convention used throughout WISER (see the georeferencer's identical convention i
 `src/wiser/gui/mosaic_view.py` (cache, compositing, drawing, threading).
 
 Beneath the vector overlay, `MosaicView` draws the actual composited scenes (issue
-#637): each visible scene is read at **screen resolution** into an **ARGB `QImage`**
+#637): each visible scene is warped, one **tile** at a time, into an **ARGB `QImage`**
 whose alpha is its validity mask, and the scenes are stacked bottom-to-top honoring
-z-order so lower scenes show through upper scenes' nodata holes.
+z-order so lower scenes show through upper scenes' nodata holes. The tiling and caching
+(#674) live in `mosaic_view.py`; the renderer below is unchanged — it just receives a
+tile's world rectangle rather than the whole viewport.
 
 ### The per-scene renderer (`render_scene_argb`, Qt-free)
 
 `mosaic_compositor.render_scene_argb(scene, target_wkt, world_extent, w, h)` warps one
-scene onto the current viewport rectangle at output size `w×h` via
+scene onto the requested `world_extent` at output size `w×h` via
 `gdal.Warp(..., dstSRS=target_wkt, outputBounds=world_extent, dstAlpha=True)` and returns
-an `(h, w, 4)` uint8 RGBA array. A single `gdal.Warp` does four jobs at once:
+an `(h, w, 4)` uint8 RGBA array. Callers pass one tile's world rectangle at `256×256`
+(see [The tiled cache](#the-tiled-cache-and-composite)), but the renderer neither knows
+nor cares that it is a tile. A single `gdal.Warp` does four jobs at once:
 
 - **reprojection** onto the target CRS,
 - **downsampling** — because the output is far coarser than the source, GDAL reads from
@@ -502,52 +506,104 @@ background thread; the view wraps the array into a `QImage` on the GUI thread.
 > scenes have very different value ranges. That was a deliberate trade-off: combined
 > bounds would have to change (and force a re-render) whenever visibility changes, which
 > breaks the `recomposite_only()` **zero-GDAL-reads** guarantee for visibility/z-order
-> changes described in [The per-scene cache and
-> `composite()`](#the-per-scene-cache-and-composite) below — a guarantee
+> changes described in [The tiled cache and
+> `composite()`](#the-tiled-cache-and-composite) below — a guarantee
 > `test_mosaic_view_gui.py` asserts by spying on `render_scene_argb`. Independent
 > per-scene bounds fully fix the zoom-instability bug (the actual report) without
 > touching that contract.
 
-### The per-scene cache and `composite()`
+### The tiled cache and `composite()`
 
-`MosaicView` holds one ARGB `QImage` per visible scene in `_scene_layers` (keyed by
-`id(scene)`), built for the **current viewport** — the *render signature*
-`(center_x, center_y, world_units_per_pixel, width, height)`. `composite(layers)` stacks
-those layers bottom-to-top with `QPainter` `SourceOver` into a single image; `layers` is
-already in render order (index 0 = bottom), so z-order is encoded in the list and hidden
-scenes are simply `None`. `composite()` is the **single indirection point** where
-deferred seamline/feathering work will later re-implement the stacking (by territory
-mask) without touching callers.
+`MosaicView` caches the pixel layer as a grid of **tiles**, not one viewport-sized image
+per scene (issue #674). World space is quantized, **per discrete zoom bucket**, into a
+fixed grid of `_TILE_PX`-square (256×256) cells; one cached ARGB `QImage` is one scene's
+warp of one cell, keyed by `_TileKey = (id(scene), bucket, col, row)`. `_tile_cache` is an
+insertion-ordered LRU bounded to `_TILE_CACHE_MAX` tiles; `_inflight_tiles` holds the keys
+currently being warped so a tile is never submitted twice.
 
-This split gives the caching tiers the design calls for:
+The bucket is `round(log2(world_units_per_pixel))`, and a bucket's tiles are rendered at
+`bucket_wupp = 2**bucket` world-units-per-pixel — a power-of-two "pyramid level" (aligned
+with the #634 overviews) chosen so a whole *range* of continuous zooms reuses one set of
+tiles: the world→screen affine scales those tiles to the exact zoom (the standard
+slippy-map look) instead of re-reading on every scale change. Tiles are anchored at the
+CRS's real `(0, 0)`, so the same world area always maps to the same cell — which is why a
+pan is a cache hit on the tiles it slides back over.
 
-- **Z-order reorder / visibility toggle** (`recomposite_only()`) — a pure restack of the
-  cached layers, **no GDAL reads**. Hiding a scene just drops it from the composite (its
-  `visible` flag), and unhiding at the same viewport reuses its still-cached layer.
-  `recomposite_only()` falls back to a read only when *revealing* a scene that was hidden
-  at the last read (so it was never cached at this viewport).
-- **Pan / zoom** — changes the render signature, so every layer is re-read. This is the
-  cache's deliberate trade-off: it does **not** survive pan/zoom (the composite is
-  re-read), but it makes reorder/visibility at a fixed viewport free.
-- **Add / remove scene, target-CRS change** (`invalidate_pixels()`) — marks the cache
-  stale so the next paint re-reads.
+`_render_bucket()` **floors** that bucket at the common grid's resolution so the preview
+is never rendered *finer* than the mosaic's real data. Rendering finer would be pure
+waste — `gdal.Warp` would upsample the grid onto a denser output, producing no new detail
+(and, several multiples below native, getting slow). Past native zoom the render bucket
+is therefore pinned at the grid-resolution level: the same grid-resolution tiles are
+reused and the affine scales them up (one source pixel drawn as a screen block), so a deep
+zoom-in is **all cache hits, zero reads**. The floor is one view-wide value (the grid's
+finest pixel size), so every scene still renders at one shared bucket and the per-cell
+`composite()` stays pixel-aligned — a per-scene floor would put mixed-resolution scenes on
+different grids and break that alignment.
 
-### Off-thread, debounced reads
+`composite(layers)` is unchanged and remains the **single indirection point**: it stacks a
+list of ARGB layers bottom-to-top with `QPainter` `SourceOver`. It is now called **per
+cell** — every visible scene's tile at one `(bucket, col, row)` is the same size and
+pixel-aligned, so it stacks them exactly as it stacked full-viewport layers before, and
+deferred seamline/feathering still re-implements only its internals (by territory mask)
+without touching callers.
+
+This gives the same three caching tiers, now in tile terms:
+
+- **Z-order reorder / visibility toggle** (`recomposite_only()`) — a pure repaint from the
+  cache, **no GDAL reads**. Draw order in `paintEvent` applies z-order; hidden scenes are
+  skipped; re-showing a scene reuses its still-cached tiles (they are keyed per scene and
+  never evicted on hide). The only case that reads is *revealing* a scene hidden at every
+  prior read of this viewport — `_start_pixel_read` finds its cells missing and warps just
+  them, so an all-cached restack submits **zero** warp jobs (asserted in
+  `test_mosaic_view_gui.py` by spying on `render_scene_argb`).
+- **Pan / zoom** — reuses every tile the new viewport shares with the old and warps **only
+  the newly-exposed cells**, plus a one-tile prefetch ring (`_PREFETCH_RING`) so the loaded
+  margin travels ahead of the viewport. This is the #674 fix: the per-read cost scales with
+  the *newly-exposed* strip, not the whole viewport, so a pan no longer re-warps everything
+  and the black edge around the viewport is gone. Zoom reuses tiles too, because a range of
+  zooms shares one bucket.
+- **Add / remove scene, target-CRS change** (`invalidate_pixels()`) — clears the whole
+  cache and bumps `_read_epoch`, so a read already in flight drops its result instead of
+  inserting now-stale tiles; the next paint refills.
+
+### Off-thread, debounced reads, and the two-pass paint
 
 Reads run **off the UI thread** and pan/zoom re-reads are **debounced** so the view stays
-responsive. A `paintEvent` whose render signature changed (re)starts a single-shot
-`QTimer` (`_PIXEL_READ_DEBOUNCE_MS`, ~120 ms); a gesture's burst of paints collapses into
-one read once the camera settles. On fire, `_start_pixel_read` snapshots the viewport on
-the GUI thread (resolving footprints and the in-view intersect test — cheap OSR work),
-then hands only the heavy per-scene warps to `app_services.scheduler.submit_thread`. The
-worker returns NumPy arrays (no Qt off-thread); the future's done-callback emits the
-`_read_ready` signal, whose queued connection wraps them into `QImage`s and restacks on
-the GUI thread. `_reading_signature` tracks the in-flight read so a superseded (or
-out-of-order) result is discarded and never clobbers newer pixels. In the interim the
-prior composite keeps drawing, scaled by the camera (it is drawn mapped from its own
-`_composite_world_extent` through the world→screen affine), so pan/zoom shows a scaled
-preview until the sharp re-read lands. With no scheduler (e.g. a bare view in a unit
-test) the read falls back to synchronous.
+responsive. A `paintEvent` whose camera moved — plus `invalidate_pixels()` /
+`recomposite_only()` — (re)starts a single-shot `QTimer` (`_PIXEL_READ_DEBOUNCE_MS`,
+~80 ms); a gesture's burst of paints collapses into one read once the camera settles. On
+fire, `_start_pixel_read` snapshots the viewport on the GUI thread (target CRS, resampling
+method, footprints and the per-tile intersect test — cheap OSR work) and builds a warp job
+**only for each cell missing from `_tile_cache` and not already in `_inflight_tiles`**,
+then hands the heavy per-tile warps to `app_services.scheduler.submit_thread`. The worker
+returns NumPy arrays (no Qt off-thread); the done-callback emits the `_read_ready` signal,
+whose queued connection wraps them into `QImage`s and inserts them (evicting LRU) on the
+GUI thread. Reads are **additive** — a late or superseded result is still a valid tile for
+its cell — so there is no per-read "discard superseded" step; clearing the submitted keys
+from `_inflight_tiles` (and the `_read_epoch` check for invalidations) is all the
+bookkeeping needed. With no scheduler (a bare view in a unit test) the read runs
+synchronously.
+
+`paintEvent` draws the pixel layer in **two passes**, both mapping each tile's world rect
+through the world→screen affine (so off-screen tiles never land on the widget):
+
+1. **Fallback pass** — under-draws the nearest *other* populated zoom bucket's cached tiles
+   that intersect the viewport, drawn scaled by the camera. This keeps the frame filled
+   during a zoom into a not-yet-read bucket (coarser/finer tiles stretch until the sharp
+   bucket lands); a pan's leading edge is already covered by the prefetch ring, so together
+   they eliminate the black frame between a gesture and its read.
+2. **Sharp pass** — for each current-bucket cell covering the viewport, gathers each
+   visible scene's cached tile, `composite()`s them into one cell image, and blits it at the
+   cell's world rect. Cells still missing are exactly what the debounced read above is
+   fetching.
+
+> **The render bucket is floored at the grid resolution (`_render_bucket()`), so the
+> preview never warps finer than the mosaic's real data.** Beyond native zoom, tiles are
+> reused and scaled by the affine rather than re-warped — which both matches what the
+> viewer would actually see (upsampling adds no detail) and avoids the deep-upsample warp
+> cost, since `gdal.Warp` past native would read full-resolution source (no coarser
+> overview to shortcut through) for every tile. `test_mosaic_view_gui.py` asserts a deep
+> zoom-in past native triggers **zero** `render_scene_argb` calls.
 
 ---
 
@@ -573,10 +629,10 @@ flowchart TD
     E --> F
     F -->|yes| G["_rebuild_overlay_geometry()<br/>geometry_dirty = False"]
     F -->|no, cache is fresh| H
-    G --> P{"render signature<br/>changed / pixels dirty?"}
-    P -->|yes| Q["_schedule_pixel_read()<br/>(debounced, off-thread)"]
+    G --> P{"camera moved<br/>or pixels dirty?"}
+    P -->|yes| Q["_schedule_pixel_read()<br/>(debounced, off-thread, missing tiles only)"]
     P -->|no| H
-    Q --> H["draw pixel layer:<br/>_composite_pixmap mapped by world_to_screen"]
+    Q --> H["draw pixel layer:<br/>fallback bucket + per-cell composite tiles,<br/>each mapped by world_to_screen"]
     H --> H2["painter.setWorldTransform(world_to_screen)"]
     H2 --> J["draw bounding box (_bbox_extent)"]
     J --> K["per scene: clip to hidden_path (if any),<br/>fill + outline in the highlight color"]
@@ -654,7 +710,7 @@ rebuild) and is fully guarded: any OGR/OSR failure clears the cache and logs rat
 than letting an exception escape a paint. Pens are **cosmetic**, so outline width stays
 constant in screen pixels regardless of zoom.
 
-`paintEvent` draws, in order: the pixel layer (still stubbed, #637), then the bounding
+`paintEvent` draws, in order: the tiled pixel layer (#637/#674), then the bounding
 box, then per scene a clip to its hidden region filled + outlined in the highlight
 color, then all footprint outlines on top in green (so every boundary stays visible
 even where it crosses an overlap region).
@@ -991,12 +1047,15 @@ worker never logs — progress and raised exceptions are its only channels out.
   identically whether read at the full extent or a further-zoomed-in crop; a paired
   test with `stretch_bounds=None` proves the same fixture *does* drift under the old
   viewport-percentile fallback, confirming the regression coverage is meaningful.
-- `src/tests/test_mosaic_view_gui.py` — the overlay **and** pixel-layer wiring end to
-  end, driven through the real `MosaicPane` ingestion path: geometry cache populates /
+- `src/tests/test_mosaic_view_gui.py` — the overlay **and** tiled pixel-layer wiring end
+  to end, driven through the real `MosaicPane` ingestion path: geometry cache populates /
   re-invalidates; `composite()` stacks known ARGB layers (top opaque wins, holes reveal
-  below); the per-scene cache populates; z-order reorder / visibility toggle trigger **no
-  GDAL reads** (spy on `render_scene_argb`); and a pan burst **coalesces into a single
-  debounced background read**.
+  below); the tile cache populates; z-order reorder / visibility toggle trigger **no GDAL
+  reads** (spy on `render_scene_argb`); a pan burst **coalesces into a single debounced
+  background read**; and, for #674, a pan **reuses cached tiles and warps only the
+  newly-exposed cells**, a zoom bucket is **read once then reused** on return, a deep
+  zoom **past native reads nothing** (the render bucket is floored at the grid
+  resolution), and the cache is **LRU-bounded** by `_TILE_CACHE_MAX`.
 - `src/tests/test_mosaic_control_panel_gui.py` — the control panel (#638) end to end
   through the real ingestion path: drag-reorder updates controller z-order and triggers
   **no GDAL reads**; a resolution-mode change rebuilds the grid; a band-metadata

--- a/src/tests/test_mosaic_compositor.py
+++ b/src/tests/test_mosaic_compositor.py
@@ -94,6 +94,65 @@ def _make_scene(tmp_path, display_bands=(0,), num_bands=1):
     return scene, wkt
 
 
+def _write_gradient_tiff(path):
+    """
+    Like :func:`_write_collar_tiff` but the interior holds a linear value gradient
+    (varying across columns) rather than a flat fill, so a percentile computed over a
+    *cropped* extent differs from one computed over the *full* extent. This is what
+    exposes the zoom-dependent contrast bug (issue #675) that cached ``stretch_bounds``
+    fixes -- a flat fixture can't distinguish "stable" from "drifting" stretch bounds.
+    """
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(_EPSG)
+    ds = gdal.GetDriverByName("GTiff").Create(
+        path,
+        _SIZE,
+        _SIZE,
+        1,
+        gdal.GDT_Float32,
+        options=["TILED=YES", "BLOCKXSIZE=16", "BLOCKYSIZE=16"],
+    )
+    ox, oy = _ORIGIN
+    ds.SetGeoTransform([ox, _PIXEL, 0.0, oy, 0.0, -_PIXEL])
+    ds.SetProjection(srs.ExportToWkt())
+    gradient = np.linspace(0.0, 100.0, _SIZE, dtype=np.float32)
+    arr = np.tile(gradient, (_SIZE, 1))  # varies across columns, constant per row
+    arr[:_COLLAR, :] = _NODATA
+    arr[-_COLLAR:, :] = _NODATA
+    arr[:, :_COLLAR] = _NODATA
+    arr[:, -_COLLAR:] = _NODATA
+    band = ds.GetRasterBand(1)
+    band.WriteArray(arr)
+    band.SetNoDataValue(_NODATA)
+    ds.FlushCache()
+    ds = None
+    return srs.ExportToWkt()
+
+
+def _make_gradient_scene(tmp_path, stretch_bounds=None):
+    path = os.path.join(str(tmp_path), "gradient.tif")
+    wkt = _write_gradient_tiff(path)
+    scene = MosaicScene(dataset=_DatasetStub(wkt, (0,)), gdal_path=path, stretch_bounds=stretch_bounds)
+    return scene, wkt
+
+
+def _narrow_crop_extent():
+    """
+    A 1:1-resolution window zoomed in on just the first two columns of the gradient
+    fixture's valid interior (world columns 2-3). Unlike merely trimming the nodata
+    collar, this is a genuine *further* zoom into the visible data, so an on-the-fly
+    percentile computed over only this window covers a narrower value range than one
+    computed over the full extent -- exactly the scenario issue #675 describes.
+    """
+    ox, oy = _ORIGIN
+    return (
+        ox + _COLLAR * _PIXEL,
+        oy - _PIXEL * _SIZE,
+        ox + (_COLLAR + 2) * _PIXEL,
+        oy,
+    )
+
+
 def _expected_valid_mask():
     """True where the fixture has valid data (the interior, collar excluded)."""
     mask = np.zeros((_SIZE, _SIZE), dtype=bool)
@@ -144,3 +203,37 @@ def test_rgb_scene_uses_three_display_bands(tmp_path):
     assert np.all(rgba[valid, 0] == 255)
     assert np.all(rgba[valid, 1] == 255)
     assert np.all(rgba[valid, 2] == 255)
+
+
+def test_cached_bounds_are_stable_across_zoom(tmp_path):
+    """
+    Issue #675 regression: with explicit ``stretch_bounds`` set on the scene, the same
+    world pixels render identically whether the requested window is the full scene
+    extent or a further zoomed-in crop of it -- contrast must not depend on which
+    pixels happen to be inside the current viewport.
+    """
+    bounds = {0: (0.0, 100.0)}
+    scene, wkt = _make_gradient_scene(tmp_path, stretch_bounds=bounds)
+
+    full = render_scene_argb(scene, wkt, _source_extent(), _SIZE, _SIZE)
+    narrow = render_scene_argb(scene, wkt, _narrow_crop_extent(), 2, _SIZE)
+
+    # The narrow crop is exactly the full render's columns [_COLLAR, _COLLAR + 2).
+    full_slice = full[:, _COLLAR : _COLLAR + 2, :3]
+    assert np.array_equal(full_slice, narrow[:, :, :3])
+
+
+def test_uncached_bounds_still_drift_with_viewport(tmp_path):
+    """
+    Sanity check for the fixture above: WITHOUT cached ``stretch_bounds`` (the
+    fallback path), the pre-#675 viewport-percentile stretch still drifts between a
+    full and a further-zoomed-in crop -- proving the gradient fixture is sensitive
+    enough to have caught the bug the cached-bounds path fixes.
+    """
+    scene, wkt = _make_gradient_scene(tmp_path, stretch_bounds=None)
+
+    full = render_scene_argb(scene, wkt, _source_extent(), _SIZE, _SIZE)
+    narrow = render_scene_argb(scene, wkt, _narrow_crop_extent(), 2, _SIZE)
+
+    full_slice = full[:, _COLLAR : _COLLAR + 2, :3]
+    assert not np.array_equal(full_slice, narrow[:, :, :3])

--- a/src/tests/test_mosaic_compositor.py
+++ b/src/tests/test_mosaic_compositor.py
@@ -237,6 +237,8 @@ def test_uncached_bounds_still_drift_with_viewport(tmp_path):
 
     full_slice = full[:, _COLLAR : _COLLAR + 2, :3]
     assert not np.array_equal(full_slice, narrow[:, :, :3])
+
+
 def _write_gradient_tiff(path):
     """
     Write an all-valid 3-band GeoTIFF whose bands carry *distinguishable* patterns so

--- a/src/tests/test_mosaic_control_panel_gui.py
+++ b/src/tests/test_mosaic_control_panel_gui.py
@@ -129,7 +129,7 @@ class TestMosaicPaneGui(unittest.TestCase):
         real_render = mosaic_view.render_scene_argb
         with mock.patch.object(mosaic_view, "render_scene_argb", side_effect=real_render) as spy:
             view.grab()
-            self.assertTrue(self._wait_for(lambda: len(view._scene_layers) == 2))
+            self.assertTrue(self._wait_for(lambda: len(view._tile_cache) > 0))
             spy.reset_mock()
 
             # A reorder through the drag handler is a pure restack — no GDAL reads.

--- a/src/tests/test_mosaic_dialog_gui.py
+++ b/src/tests/test_mosaic_dialog_gui.py
@@ -151,6 +151,9 @@ class TestSeamlessMosaicAddScene(unittest.TestCase):
         self.assertTrue(scene.has_overviews)
         self.assertIsNotNone(scene.footprint_wkt)
         self.assertIsNotNone(scene.gdal_path)
+        # Stable stretch bounds (#675) are computed at ingest, before the scene is
+        # ever rendered.
+        self.assertTrue(scene.stretch_bounds)
 
         # Progress was reported and reached 100%.
         self.assertTrue(seen, "no progress was reported")

--- a/src/tests/test_mosaic_ingestion.py
+++ b/src/tests/test_mosaic_ingestion.py
@@ -19,6 +19,7 @@ from wiser.raster.mosaic_ingestion import (
     SceneValidationError,
     build_overviews,
     compute_footprint_wkt,
+    compute_stretch_bounds,
     validate_scene,
 )
 from wiser.raster.mosaic_materialize import materialize_to_tiled_geotiff, read_materialized_geotiff
@@ -218,6 +219,82 @@ def test_overviews_written_to_file():
             assert reopened.GetRasterBand(1).GetOverviewCount() > 0
         finally:
             reopened = None
+
+
+# -- compute_stretch_bounds (#675) ---------------------------------------------
+
+
+def test_stretch_bounds_excludes_nodata():
+    with tempfile.TemporaryDirectory() as d:
+        # A large collar relative to the level-4 overview's decimation, so the
+        # nodata region still shows up in the sampled overview -- if nodata masking
+        # were broken, it would drag the bounds far from the flat fill value.
+        path = _make_georeffed_tiff(d, nodata=-9999, bands=1, collar=8, size=64)
+        build_overviews(path)
+        bounds = compute_stretch_bounds(path, _valid_fake(bands=1))
+
+    assert 0 in bounds
+    lo, hi = bounds[0]
+    assert lo == pytest.approx(7.0)
+    assert hi == pytest.approx(7.0)
+
+
+def test_stretch_bounds_reflects_value_spread():
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "gradient.tif")
+        size = 64
+        driver = gdal.GetDriverByName("GTiff")
+        ds = driver.Create(
+            path, size, size, 1, gdal.GDT_Float32, options=["TILED=YES", "BLOCKXSIZE=16", "BLOCKYSIZE=16"]
+        )
+        ds.SetGeoTransform(list(_GOOD_GEO_TRANSFORM))
+        ds.SetProjection(_utm_wkt())
+        gradient = np.linspace(0.0, 1000.0, size, dtype=np.float32)
+        ds.GetRasterBand(1).WriteArray(np.tile(gradient, (size, 1)))
+        ds.FlushCache()
+        ds = None
+        build_overviews(path)
+        bounds = compute_stretch_bounds(path, _valid_fake(bands=1))
+
+    lo, hi = bounds[0]
+    assert 0.0 <= lo < hi <= 1000.0
+    # A 2-98 percentile of a 0..1000 gradient should span most of that range, not
+    # collapse to a narrow slice -- a coarse sanity check on the overview sampling.
+    assert hi - lo > 500.0
+
+
+def test_stretch_bounds_all_nodata_band_is_omitted():
+    with tempfile.TemporaryDirectory() as d:
+        path = _make_georeffed_tiff(d, nodata=-9999, bands=1, collar=0, size=16)
+        ds = gdal.Open(path, gdal.GA_Update)
+        ds.GetRasterBand(1).WriteArray(np.full((16, 16), -9999, dtype=np.float32))
+        ds.FlushCache()
+        ds = None
+        bounds = compute_stretch_bounds(path, _valid_fake(bands=1))
+
+    assert bounds == {}
+
+
+def test_stretch_bounds_falls_back_without_overviews():
+    with tempfile.TemporaryDirectory() as d:
+        path = _make_georeffed_tiff(d, nodata=-9999, bands=1, collar=2, size=16)
+        # No build_overviews() call: exercises the GetOverviewCount() == 0 fallback
+        # to a full-resolution read.
+        bounds = compute_stretch_bounds(path, _valid_fake(bands=1))
+
+    assert 0 in bounds
+    lo, hi = bounds[0]
+    assert lo == pytest.approx(7.0)
+    assert hi == pytest.approx(7.0)
+
+
+def test_stretch_bounds_reports_progress():
+    rec = _Recorder()
+    with tempfile.TemporaryDirectory() as d:
+        path = _make_georeffed_tiff(d, nodata=-9999, bands=3, collar=0, size=32)
+        build_overviews(path)
+        compute_stretch_bounds(path, _valid_fake(bands=3), progress=ProgressReporter(sink=rec))
+    _assert_monotonic_to_one(rec.fractions)
 
 
 # -- progress reporting -------------------------------------------------------

--- a/src/tests/test_mosaic_tile_math.py
+++ b/src/tests/test_mosaic_tile_math.py
@@ -1,0 +1,111 @@
+"""Unit tests for the tile-grid math backing the mosaic pixel cache (EPIC #629, #674).
+
+Pure arithmetic — no widget, no ``QApplication``, no GDAL. These cover the three
+building blocks the tiled pixel cache is keyed on: snapping a continuous camera scale to
+a discrete power-of-two zoom bucket, the world rectangle a cell covers, and the set of
+cells (with an optional prefetch ring) covering a viewport.
+"""
+import math
+import unittest
+
+import tests.context  # noqa: F401  (adds src/ to sys.path)
+from wiser.gui.mosaic_view import (
+    _PREFETCH_RING,
+    _TILE_PX,
+    _bucket_wupp,
+    _tile_world_extent,
+    _tiles_covering_extent,
+    _zoom_bucket,
+)
+
+import pytest
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.unit,
+]
+
+
+class TestZoomBucket(unittest.TestCase):
+    def test_exact_powers_of_two_map_to_their_exponent(self) -> None:
+        for exp in (-12, -3, 0, 5, 14):
+            self.assertEqual(_zoom_bucket(2.0**exp), exp)
+            self.assertEqual(_bucket_wupp(_zoom_bucket(2.0**exp)), 2.0**exp)
+
+    def test_snaps_to_nearest_bucket(self) -> None:
+        # 27.4 is between 2^4=16 and 2^5=32; log2(27.4)~=4.78 -> rounds to 5.
+        self.assertEqual(_zoom_bucket(27.4), 5)
+        # 20.0 -> log2~=4.32 -> rounds to 4.
+        self.assertEqual(_zoom_bucket(20.0), 4)
+
+    def test_draw_scale_stays_within_sqrt2(self) -> None:
+        # bucket_wupp / wupp must land in [1/sqrt2, sqrt2] for any continuous wupp,
+        # which is the whole point of rounding rather than flooring.
+        lo, hi = 1.0 / math.sqrt(2.0), math.sqrt(2.0)
+        for wupp in (0.0003, 1.0, 13.7, 27.4, 999.0, 1e6):
+            scale = _bucket_wupp(_zoom_bucket(wupp)) / wupp
+            self.assertTrue(lo - 1e-9 <= scale <= hi + 1e-9, f"{wupp} -> {scale}")
+
+    def test_degenerate_scales_fall_back_to_zero(self) -> None:
+        for bad in (0.0, -1.0, float("nan"), float("inf")):
+            self.assertEqual(_zoom_bucket(bad), 0)
+
+
+class TestTileWorldExtent(unittest.TestCase):
+    def test_cell_spans_tile_px_times_bucket_resolution(self) -> None:
+        bucket = 5  # bucket_wupp = 32
+        tws = _TILE_PX * 32.0
+        self.assertEqual(_tile_world_extent(bucket, 0, 0), (0.0, 0.0, tws, tws))
+        self.assertEqual(
+            _tile_world_extent(bucket, 3, -2),
+            (3 * tws, -2 * tws, 4 * tws, -1 * tws),
+        )
+
+    def test_adjacent_cells_share_an_edge_without_gap_or_overlap(self) -> None:
+        bucket = 2
+        left = _tile_world_extent(bucket, 0, 0)
+        right = _tile_world_extent(bucket, 1, 0)
+        self.assertEqual(left[2], right[0])  # left max_x == right min_x
+
+
+class TestTilesCoveringExtent(unittest.TestCase):
+    def test_single_cell_when_extent_is_inside_one_tile(self) -> None:
+        bucket = 0  # bucket_wupp = 1 -> tws = _TILE_PX
+        # A small rect fully inside cell (0, 0).
+        cells = _tiles_covering_extent(bucket, (1.0, 1.0, 10.0, 10.0))
+        self.assertEqual(cells, [(0, 0)])
+
+    def test_covers_all_straddled_cells(self) -> None:
+        bucket = 0
+        tws = _TILE_PX
+        # Straddle a 2x2 block of cells.
+        extent = (tws - 5.0, tws - 5.0, tws + 5.0, tws + 5.0)
+        cells = set(_tiles_covering_extent(bucket, extent))
+        self.assertEqual(cells, {(0, 0), (1, 0), (0, 1), (1, 1)})
+
+    def test_exact_boundary_does_not_pull_in_the_next_cell(self) -> None:
+        bucket = 0
+        tws = _TILE_PX
+        # max exactly on the cell-1 boundary should stay within cell 0 (half-open).
+        cells = _tiles_covering_extent(bucket, (0.0, 0.0, float(tws), float(tws)))
+        self.assertEqual(set(cells), {(0, 0)})
+
+    def test_prefetch_ring_adds_one_cell_on_every_side(self) -> None:
+        bucket = 0
+        no_ring = set(_tiles_covering_extent(bucket, (1.0, 1.0, 10.0, 10.0), ring=0))
+        with_ring = set(_tiles_covering_extent(bucket, (1.0, 1.0, 10.0, 10.0), ring=1))
+        self.assertEqual(no_ring, {(0, 0)})
+        # A 1-ring around a single cell is the surrounding 3x3 block.
+        self.assertEqual(
+            with_ring,
+            {(c, r) for c in (-1, 0, 1) for r in (-1, 0, 1)},
+        )
+        self.assertEqual(_PREFETCH_RING, 1)  # the wired-up default matches this test
+
+    def test_degenerate_extent_yields_no_cells(self) -> None:
+        self.assertEqual(_tiles_covering_extent(0, (5.0, 5.0, 5.0, 5.0)), [])
+        self.assertEqual(_tiles_covering_extent(0, (10.0, 0.0, 0.0, 10.0)), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_mosaic_view_gui.py
+++ b/src/tests/test_mosaic_view_gui.py
@@ -88,8 +88,11 @@ class TestMosaicViewGui(unittest.TestCase):
         self.assertGreaterEqual(index, 0)
         pane._dataset_combo.setCurrentIndex(index)
         pane._add_scene_button.click()
+        # Generous timeout: the larger tile-reuse fixtures (1024 px, with overviews +
+        # stretch) can take a while to materialize under load. This returns as soon as
+        # ingest finishes, so it does not slow the small-scene tests.
         self.assertTrue(
-            self._wait_for(lambda: controller.scene_count() == expected_count),
+            self._wait_for(lambda: controller.scene_count() == expected_count, timeout_ms=60000),
             "scene was not ingested within the timeout",
         )
 
@@ -326,6 +329,10 @@ class TestMosaicViewGui(unittest.TestCase):
             def _assert_no_read(mutate):
                 spy.reset_mock()
                 mutate()
+                # The pane rebuilds the grid before restacking (e.g. _on_scene_rows_moved
+                # -> _rebuild_grid_quietly); do the same so the render bucket, which is
+                # floored at the grid resolution, stays consistent with the cached tiles.
+                controller.build_common_grid()
                 view.recomposite_only()
                 view.grab()
                 QTest.qWait(2 * _PIXEL_READ_DEBOUNCE_MS)  # past the debounce window — nothing should read
@@ -439,16 +446,18 @@ class TestMosaicViewGui(unittest.TestCase):
             view._transform.center_y,
             view._transform.world_units_per_pixel,
         )
-        fit_bucket = mosaic_view._zoom_bucket(fit_state[2])
+        fit_bucket = view._render_bucket()
         before = set(view._tile_cache.keys())
         self.assertTrue(before)
 
         real_render = mosaic_view.render_scene_argb
-        # Zooming across a bucket boundary reads the new bucket's tiles.
+        # Zooming across a bucket boundary reads the new bucket's tiles. (3x from the
+        # fit zoom lands on the grid's native bucket, so the render floor does not clamp
+        # it — it is a genuine new, finer bucket.)
         with mock.patch.object(mosaic_view, "render_scene_argb", side_effect=real_render) as spy_in:
             view._transform.zoom(3.0, center, view.size())
             self.assertTrue(self._settle_reads(view))
-            self.assertNotEqual(mosaic_view._zoom_bucket(view._transform.world_units_per_pixel), fit_bucket)
+            self.assertNotEqual(view._render_bucket(), fit_bucket)
             new_bucket_keys = {k for k in view._tile_cache if k[1] != fit_bucket}
             self.assertTrue(new_bucket_keys, "crossing a bucket read no new-bucket tiles")
             self.assertGreater(spy_in.call_count, 0)
@@ -463,6 +472,37 @@ class TestMosaicViewGui(unittest.TestCase):
             self.assertTrue(self._settle_reads(view))
             self.assertTrue(before.issubset(view._tile_cache.keys()))
             self.assertEqual(spy_back.call_count, 0)
+
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_zoom_past_native_reuses_tiles_without_reading(self):
+        ds_a, ds_b = self._big_scene_pair()
+        _dlg, _pane, controller, view = self._open_pane_with_scenes(ds_a, ds_b)
+
+        # Settle, then view a small window at the mosaic's native (common-grid)
+        # resolution so a handful of grid-resolution tiles are cached.
+        self.assertTrue(self._settle_reads(view))
+        view.resize(256, 256)
+        gt = controller.get_common_grid().geotransform
+        grid_res = min(abs(gt[1]), abs(gt[5]))
+        view._transform.world_units_per_pixel = grid_res
+        self.assertTrue(self._settle_reads(view))
+        native_bucket = view._render_bucket()
+        before = set(view._tile_cache.keys())
+        self.assertTrue(before)
+
+        # Zooming far past native must NOT warp finer tiles: the render bucket stays
+        # floored at the grid resolution, and the cached grid-resolution tiles are reused
+        # (drawn scaled by the affine — one source pixel becomes a block on screen), so a
+        # deep zoom-in reads nothing.
+        real_render = mosaic_view.render_scene_argb
+        with mock.patch.object(mosaic_view, "render_scene_argb", side_effect=real_render) as spy:
+            view._transform.world_units_per_pixel = grid_res / 16.0
+            self.assertEqual(view._render_bucket(), native_bucket)
+            self.assertTrue(self._settle_reads(view))
+            self.assertEqual(spy.call_count, 0)
+            # No finer tiles were cached; the tiny viewport reuses a subset of native ones.
+            self.assertTrue(set(view._tile_cache.keys()).issubset(before))
 
         self.test_model.close_seamless_mosaic_dialog()
 

--- a/src/tests/test_mosaic_view_gui.py
+++ b/src/tests/test_mosaic_view_gui.py
@@ -78,9 +78,9 @@ class TestMosaicViewGui(unittest.TestCase):
             waited += step_ms
         return predicate()
 
-    def _load(self, name, origin):
+    def _load(self, name, origin, **kwargs):
         path = os.path.join(self._tmp.name, name)
-        _write_overlapping_tiff(path, origin)
+        _write_overlapping_tiff(path, origin, **kwargs)
         return self.test_model.load_dataset(path)
 
     def _ingest(self, pane, controller, dataset, expected_count):
@@ -92,6 +92,40 @@ class TestMosaicViewGui(unittest.TestCase):
             self._wait_for(lambda: controller.scene_count() == expected_count),
             "scene was not ingested within the timeout",
         )
+
+    def _settle_reads(self, view, timeout_ms=10000, step_ms=40):
+        """
+        Pump the event loop until any debounced/in-flight tile read has completed.
+
+        A tile read is armed by the debounce timer, runs on a scheduler thread, and lands
+        via a queued signal, so a plain ``grab()`` is not enough to observe it. This grabs
+        (to arm/repaint) and waits until neither the debounce timer nor an in-flight read
+        is outstanding across two consecutive checks, so the tile cache has stabilized.
+        """
+        waited = 0
+        while waited < timeout_ms:
+            view.grab()
+            QTest.qWait(step_ms)
+            waited += step_ms
+            if not view._debounce_timer.isActive() and not view._inflight_tiles:
+                view.grab()
+                QTest.qWait(step_ms)
+                waited += step_ms
+                if not view._debounce_timer.isActive() and not view._inflight_tiles:
+                    return True
+        return False
+
+    def _open_pane_with_scenes(self, *scenes):
+        """Open the mosaic dialog and ingest ``scenes`` (RasterDataSets) in order."""
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        view = pane.get_mosaic_view()
+        view.resize(800, 600)
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            for i, ds in enumerate(scenes, start=1):
+                self._ingest(pane, controller, ds, i)
+        return dlg, pane, controller, view
 
     def test_overlay_geometry_populates_for_overlapping_scenes(self):
         # Two same-CRS scenes whose valid footprints overlap in one corner.
@@ -340,6 +374,109 @@ class TestMosaicViewGui(unittest.TestCase):
             # ...via a single coalesced read, not one per pan event.
             QTest.qWait(2 * _PIXEL_READ_DEBOUNCE_MS)
             self.assertEqual(worker_spy.call_count, 1)
+
+        self.test_model.close_seamless_mosaic_dialog()
+
+    # -- tile reuse across pan / zoom (#674) ----------------------------------
+
+    def _big_scene_pair(self):
+        """
+        Two overlapping scenes large enough to span several tiles when zoomed in.
+
+        The default fixtures are 20x30 m == 600 m and fit inside a single tile, so a pan
+        never exposes a fresh in-footprint tile. These are 1024 px at 1 m == 1024 m with a
+        32 px nodata collar, giving a ~1280 m union — much larger than the viewport once
+        zoomed in ~4x, so the viewport + prefetch ring covers only a slice and a pan
+        crosses tile boundaries into new, still-in-data cells. At 4x the read lands on
+        bucket -1 (0.5 m, a mild 2x upsample) rather than a pathological deep upsample.
+        """
+        ds_a = self._load("big_a.tif", origin=(400000.0, 3800000.0), pixel=1.0, size=1024, collar=32)
+        ds_b = self._load("big_b.tif", origin=(400512.0, 3799488.0), pixel=1.0, size=1024, collar=32)
+        return ds_a, ds_b
+
+    def test_pan_reuses_cached_tiles(self):
+        ds_a, ds_b = self._big_scene_pair()
+        _dlg, _pane, _controller, view = self._open_pane_with_scenes(ds_a, ds_b)
+
+        # Settle once so the first paint frames the mosaic (the camera fit runs in
+        # paintEvent), then view a small window at the scenes' native 1 m resolution
+        # centered on the fitted (union-center) point. A small viewport at bucket 0 (no
+        # upsampling — fast/reliable) leaves most of the ~1536 m union uncached, so a pan
+        # is guaranteed to slide into fresh in-data cells.
+        self.assertTrue(self._settle_reads(view))
+        view.resize(256, 256)
+        view._transform.world_units_per_pixel = 1.0
+        self.assertTrue(self._settle_reads(view))
+        before = set(view._tile_cache.keys())
+        self.assertTrue(before, "native-resolution read cached no tiles")
+
+        real_render = mosaic_view.render_scene_argb
+        with mock.patch.object(mosaic_view, "render_scene_argb", side_effect=real_render) as spy:
+            view._transform.pan(300, 0)  # slide well past one tile to expose new cells
+            self.assertTrue(self._settle_reads(view))
+
+            after = set(view._tile_cache.keys())
+            new_keys = after - before
+            reused = before & after
+            # The pan exposed brand-new cells...
+            self.assertTrue(new_keys, "pan exposed no new tiles")
+            # ...while the already-loaded tiles were kept, not re-read...
+            self.assertTrue(reused, "pan dropped previously-cached tiles")
+            # ...and *only* the newly-exposed cells were warped (the whole point: the
+            # overlap region is reused with zero GDAL work, not re-warped).
+            self.assertEqual(spy.call_count, len(new_keys))
+
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_zoom_bucket_is_read_then_reused(self):
+        ds_a, ds_b = self._big_scene_pair()
+        _dlg, _pane, _controller, view = self._open_pane_with_scenes(ds_a, ds_b)
+        center = QPointF(view.width() / 2.0, view.height() / 2.0)
+
+        self.assertTrue(self._settle_reads(view))
+        fit_state = (
+            view._transform.center_x,
+            view._transform.center_y,
+            view._transform.world_units_per_pixel,
+        )
+        fit_bucket = mosaic_view._zoom_bucket(fit_state[2])
+        before = set(view._tile_cache.keys())
+        self.assertTrue(before)
+
+        real_render = mosaic_view.render_scene_argb
+        # Zooming across a bucket boundary reads the new bucket's tiles.
+        with mock.patch.object(mosaic_view, "render_scene_argb", side_effect=real_render) as spy_in:
+            view._transform.zoom(3.0, center, view.size())
+            self.assertTrue(self._settle_reads(view))
+            self.assertNotEqual(mosaic_view._zoom_bucket(view._transform.world_units_per_pixel), fit_bucket)
+            new_bucket_keys = {k for k in view._tile_cache if k[1] != fit_bucket}
+            self.assertTrue(new_bucket_keys, "crossing a bucket read no new-bucket tiles")
+            self.assertGreater(spy_in.call_count, 0)
+
+        # Returning to the exact fit camera reuses the still-cached fit-bucket tiles.
+        with mock.patch.object(mosaic_view, "render_scene_argb", side_effect=real_render) as spy_back:
+            (
+                view._transform.center_x,
+                view._transform.center_y,
+                view._transform.world_units_per_pixel,
+            ) = fit_state
+            self.assertTrue(self._settle_reads(view))
+            self.assertTrue(before.issubset(view._tile_cache.keys()))
+            self.assertEqual(spy_back.call_count, 0)
+
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_tile_cache_is_lru_bounded(self):
+        ds_a = self._load("a.tif", origin=(400000.0, 3800000.0))
+        ds_b = self._load("b.tif", origin=(400300.0, 3799700.0))
+
+        # A tiny cap makes the initial viewport+ring read (dozens of tiles) overflow the
+        # LRU, so eviction must hold the cache at the bound.
+        with mock.patch.object(mosaic_view, "_TILE_CACHE_MAX", 8):
+            _dlg, _pane, _controller, view = self._open_pane_with_scenes(ds_a, ds_b)
+            self.assertTrue(self._settle_reads(view))
+            self.assertGreater(len(view._tile_cache), 0)
+            self.assertLessEqual(len(view._tile_cache), 8)
 
         self.test_model.close_seamless_mosaic_dialog()
 

--- a/src/tests/test_mosaic_view_gui.py
+++ b/src/tests/test_mosaic_view_gui.py
@@ -255,14 +255,16 @@ class TestMosaicViewGui(unittest.TestCase):
             self._ingest(pane, controller, ds_b, 2)
 
         # The read is off the UI thread and debounced, so force a paint to schedule it
-        # then pump the loop until the layers arrive.
+        # then pump the loop until the tiles arrive.
         view.grab()
         self.assertTrue(
-            self._wait_for(lambda: len(view._scene_layers) == 2),
-            "per-scene layers were not read within the timeout",
+            self._wait_for(lambda: len(view._tile_cache) > 0),
+            "tiles were not read within the timeout",
         )
-        self.assertIsNotNone(view._composite_pixmap)
-        self.assertIsNotNone(view._composite_world_extent)
+        # Both scenes contributed tiles at the current viewport's zoom bucket.
+        scene_ids = {id(s) for s in controller.get_scenes()}
+        cached_scene_ids = {key[0] for key in view._tile_cache}
+        self.assertEqual(cached_scene_ids, scene_ids)
 
         self.test_model.close_seamless_mosaic_dialog()
 
@@ -282,9 +284,9 @@ class TestMosaicViewGui(unittest.TestCase):
 
         real_render = mosaic_view.render_scene_argb
         with mock.patch.object(mosaic_view, "render_scene_argb", side_effect=real_render) as spy:
-            # Initial debounced read populates the cache.
+            # Initial debounced read populates the tile cache.
             view.grab()
-            self.assertTrue(self._wait_for(lambda: len(view._scene_layers) == 2))
+            self.assertTrue(self._wait_for(lambda: len(view._tile_cache) > 0))
             self.assertGreater(spy.call_count, 0)
 
             def _assert_no_read(mutate):
@@ -317,12 +319,15 @@ class TestMosaicViewGui(unittest.TestCase):
             self._ingest(pane, controller, ds_b, 2)
 
         view.grab()
-        self.assertTrue(self._wait_for(lambda: len(view._scene_layers) == 2))
+        self.assertTrue(self._wait_for(lambda: len(view._tile_cache) > 0))
 
-        # A burst of pans must collapse into one background read, not one per event.
+        # Drop the cache so the pan below genuinely warps tiles (these ~600 m fixtures
+        # otherwise fit entirely inside the first read + prefetch ring, so a pan would
+        # reuse cached tiles and read nothing). This isolates the property under test:
+        # a burst of pan paints coalesces into a *single* background read.
+        view._tile_cache.clear()
         real_worker = mosaic_view._render_scene_layers
         with mock.patch.object(mosaic_view, "_render_scene_layers", side_effect=real_worker) as worker_spy:
-            initial_extent = view._composite_world_extent
             for _ in range(5):
                 view._transform.pan(40, 0)
                 view.grab()  # each paint restarts the debounce timer
@@ -330,8 +335,8 @@ class TestMosaicViewGui(unittest.TestCase):
             # Still mid-gesture: the debounce timer keeps restarting, so no read yet.
             self.assertEqual(worker_spy.call_count, 0)
 
-            # Once the gesture settles, the composite updates to the panned viewport...
-            self.assertTrue(self._wait_for(lambda: view._composite_world_extent != initial_extent))
+            # Once the gesture settles, the viewport's tiles are read back in...
+            self.assertTrue(self._wait_for(lambda: len(view._tile_cache) > 0))
             # ...via a single coalesced read, not one per pan event.
             QTest.qWait(2 * _PIXEL_READ_DEBOUNCE_MS)
             self.assertEqual(worker_spy.call_count, 1)

--- a/src/tests/test_mosaic_view_gui.py
+++ b/src/tests/test_mosaic_view_gui.py
@@ -96,7 +96,7 @@ class TestMosaicViewGui(unittest.TestCase):
             "scene was not ingested within the timeout",
         )
 
-    def _settle_reads(self, view, timeout_ms=10000, step_ms=40):
+    def _settle_reads(self, view, timeout_ms=60000, step_ms=40):
         """
         Pump the event loop until any debounced/in-flight tile read has completed.
 

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -403,7 +403,7 @@ class DataVisualizerApp(QMainWindow):
         act = self._tools_menu.addAction(self.tr("Similarity Transform"))
         act.triggered.connect(self.show_similarity_transform_dialog)
 
-        act = self._tools_menu.addAction(self.tr("Seamless Mosaic"))
+        act = self._tools_menu.addAction(self.tr("Mosaic"))
         act.triggered.connect(self.show_seamless_mosaic_dialog)
 
         # Help menu

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -4,9 +4,10 @@ Control panel for the Seamless Mosaic feature (EPIC #629).
 Hosts the :class:`MosaicView` alongside a controls area and owns the non-GUI
 :class:`MosaicController` that both share. The controls area offers: an "Add Scene"
 action (a dataset picker plus a button that ingests the chosen dataset -- materialize
--> build overviews -> compute footprint -- on a background thread and appends it to the
-controller); the scene stack with **drag-to-reorder** z-order and per-scene visibility
-(#638); resolution-mode, target-CRS, resampling-method, and canonical band-metadata
+-> build overviews -> compute stretch bounds -> compute footprint -- on a background
+thread and appends it to the controller); the scene stack with **drag-to-reorder**
+z-order and per-scene visibility (#638); resolution-mode, target-CRS,
+resampling-method, and canonical band-metadata
 controls (#638); and a disabled Export button (the export path lands in #639).
 
 Each control mutates the shared controller and then invalidates the view following the
@@ -47,6 +48,7 @@ from wiser.raster.mosaic_ingestion import (
     SceneValidationError,
     build_overviews,
     compute_footprint_wkt,
+    compute_stretch_bounds,
     validate_scene,
 )
 from wiser.utils.primitives import temp_dir
@@ -64,22 +66,29 @@ def _ingest_scene(
 ) -> MosaicScene:
     """
     Background I/O for one scene: materialize to a warpable temp GeoTIFF, build
-    internal overviews on it, and compute the valid-pixel footprint.
+    internal overviews on it, compute its stable stretch bounds, and compute the
+    valid-pixel footprint.
 
-    Runs on a scheduler thread (no Qt here). ``progress`` is split across the three
+    Runs on a scheduler thread (no Qt here). ``progress`` is split across the four
     phases (weighted by their rough cost) so the overall bar advances smoothly;
-    each phase reports fine-grained progress internally. Returns the fully-populated
-    :class:`MosaicScene` for the main thread to append to the controller.
+    each phase reports fine-grained progress internally. Stretch bounds are computed
+    right after overviews since :func:`compute_stretch_bounds` samples one (issue
+    #675) -- this is what keeps the pixel compositor's contrast stable across zoom.
+    Returns the fully-populated :class:`MosaicScene` for the main thread to append to
+    the controller.
     """
     progress = progress or ProgressReporter()
-    materialize_progress, overview_progress, footprint_progress = progress.split(
-        (0.5, "Materializing scene"),
-        (0.35, "Building overviews"),
+    materialize_progress, overview_progress, stretch_progress, footprint_progress = progress.split(
+        (0.45, "Materializing scene"),
+        (0.30, "Building overviews"),
+        (0.10, "Computing stretch bounds"),
         (0.15, "Computing footprint"),
     )
     gdal_path = materializer.gdal_source(dataset, progress=materialize_progress)
     progress.raise_if_cancelled()
     build_overviews(gdal_path, progress=overview_progress)
+    progress.raise_if_cancelled()
+    stretch_bounds = compute_stretch_bounds(gdal_path, dataset, progress=stretch_progress)
     progress.raise_if_cancelled()
     footprint_wkt = compute_footprint_wkt(gdal_path, progress=footprint_progress)
     progress.report_fraction(1.0, "Done")
@@ -88,6 +97,7 @@ def _ingest_scene(
         gdal_path=gdal_path,
         footprint_wkt=footprint_wkt,
         has_overviews=True,
+        stretch_bounds=stretch_bounds,
     )
 
 

--- a/src/wiser/gui/mosaic_view.py
+++ b/src/wiser/gui/mosaic_view.py
@@ -478,6 +478,29 @@ class MosaicView(QWidget):
             self.height(),
         )
 
+    def _render_bucket(self) -> int:
+        """
+        The zoom bucket tiles are rendered at — the camera's bucket, but never finer
+        than the mosaic's own resolution.
+
+        Rendering finer than the source data is pointless work: ``gdal.Warp`` would just
+        upsample the common grid onto a denser grid, producing no new detail while
+        (deeply below native) getting very slow. So the render bucket is floored at the
+        common grid's resolution: once the user zooms past native, the same
+        grid-resolution tiles are reused and the world->screen affine scales them up (one
+        source pixel drawn as a block), which is both correct and free. The floor is a
+        single view-wide value, so every scene still renders at one shared bucket and the
+        per-cell :meth:`composite` stays pixel-aligned.
+        """
+        camera_bucket = _zoom_bucket(self._transform.world_units_per_pixel)
+        gt = self._controller.get_common_grid().geotransform
+        if gt is None:
+            return camera_bucket
+        grid_res = min(abs(gt[1]), abs(gt[5]))  # finest of the grid's x/y pixel size
+        if grid_res <= 0.0:
+            return camera_bucket
+        return max(camera_bucket, _zoom_bucket(grid_res))  # never finer than the grid
+
     def _schedule_pixel_read(self) -> None:
         """
         Ask for a read of any tiles the current viewport needs but does not have.
@@ -508,7 +531,7 @@ class MosaicView(QWidget):
             return  # nothing to read yet (no grid, or the widget has no real size)
 
         world_extent = self._visible_world_extent()
-        bucket = _zoom_bucket(self._transform.world_units_per_pixel)
+        bucket = self._render_bucket()
         try:
             footprints = self._controller.visible_scene_footprints_in_common_crs()
         except Exception:  # noqa: BLE001 — never let a paint-driven read raise
@@ -623,7 +646,7 @@ class MosaicView(QWidget):
         """
         w2s = self._transform.world_to_screen(self.size())
         world_extent = self._visible_world_extent()
-        bucket = _zoom_bucket(self._transform.world_units_per_pixel)
+        bucket = self._render_bucket()
         # bottom-to-top so later (upper) scenes composite over lower ones
         visible_scenes = [s for s in self._controller.get_scenes() if s.visible]
         scene_order = {id(s): i for i, s in enumerate(visible_scenes)}

--- a/src/wiser/gui/mosaic_view.py
+++ b/src/wiser/gui/mosaic_view.py
@@ -17,6 +17,7 @@ Later issues fill in the two layers, both drawn through the seams stubbed here:
 """
 
 import logging
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
@@ -47,6 +48,83 @@ logger = logging.getLogger(__name__)
 # Debounce window for pan/zoom pixel re-reads: coalesce a gesture's burst of paints
 # into one background read once the camera settles for this long.
 _PIXEL_READ_DEBOUNCE_MS = 120
+
+# Tile-based pixel cache (#674). World space is quantized into a fixed grid of ARGB
+# tiles per discrete zoom bucket; a pan/zoom reuses already-cached tiles and only warps
+# the newly-exposed ones, so the loaded margin travels with the user without re-warping
+# the whole viewport each time.
+#
+#  * _TILE_PX        — the output size (px, square) each tile is warped at.
+#  * _TILE_CACHE_MAX — LRU bound on the number of cached tiles (~256 tiles of 256x256
+#                      ARGB ~= 64 MB). Tune alongside the debounce interval.
+#  * _PREFETCH_RING  — how many extra tile rings around the viewport to read, so the
+#                      loaded margin extends past the visible edge in every direction.
+_TILE_PX = 256
+_TILE_CACHE_MAX = 256
+_PREFETCH_RING = 1
+
+# Nudge the exclusive upper edge off an exact tile boundary so a rectangle whose max
+# lands precisely on a cell border does not pull in the next (empty) cell.
+_TILE_EPS = 1e-9
+
+
+def _zoom_bucket(world_units_per_pixel: float) -> int:
+    """
+    Snap a continuous camera scale to a discrete power-of-two zoom bucket.
+
+    The camera's ``world_units_per_pixel`` (wupp) is continuous, but caching tiles at
+    every exact wupp would make the tiniest zoom invalidate the whole cache. Instead we
+    render tiles at the nearest power-of-two resolution ``bucket_wupp = 2 ** bucket`` and
+    let the world->screen affine scale them to the actual zoom (the standard slippy-map
+    look), so a whole range of zooms shares one set of cached tiles.
+
+    ``round`` keeps the draw scale ``bucket_wupp / wupp`` within ``[1/sqrt2, sqrt2]``
+    (~[0.71, 1.41]); it is defined purely in terms of wupp, so it is CRS-agnostic
+    (degrees or metres, no per-CRS constant). Non-finite/non-positive scales fall back
+    to bucket 0.
+    """
+    if not math.isfinite(world_units_per_pixel) or world_units_per_pixel <= 0.0:
+        return 0
+    return round(math.log2(world_units_per_pixel))
+
+
+def _bucket_wupp(bucket: int) -> float:
+    """The quantized render resolution (world units per pixel) for a zoom ``bucket``."""
+    return 2.0**bucket
+
+
+def _tile_world_extent(bucket: int, col: int, row: int) -> Tuple[float, float, float, float]:
+    """
+    The world rectangle ``(min_x, min_y, max_x, max_y)`` a ``(col, row)`` cell covers.
+
+    Tiles are ``_TILE_PX`` pixels square at the bucket's resolution, so a cell spans
+    ``tws = _TILE_PX * bucket_wupp`` world units, anchored at the CRS's real ``(0, 0)``
+    origin. The anchoring makes the grid stable across pans at a fixed bucket, so the
+    same world area always maps to the same cell (hence a cache hit after a pan).
+    """
+    tws = _TILE_PX * _bucket_wupp(bucket)
+    return (col * tws, row * tws, (col + 1) * tws, (row + 1) * tws)
+
+
+def _tiles_covering_extent(
+    bucket: int, world_extent: Tuple[float, float, float, float], ring: int = 0
+) -> List[Tuple[int, int]]:
+    """
+    The ``(col, row)`` cells whose tiles cover ``world_extent`` at ``bucket``, plus an
+    optional ``ring`` of extra cells on every side (the prefetch margin).
+
+    ``world_extent`` is ``(min_x, min_y, max_x, max_y)`` in the target CRS. Returns the
+    cells in row-major order; an empty/degenerate extent yields no cells.
+    """
+    min_x, min_y, max_x, max_y = world_extent
+    if max_x <= min_x or max_y <= min_y:
+        return []
+    tws = _TILE_PX * _bucket_wupp(bucket)
+    col_lo = math.floor(min_x / tws) - ring
+    col_hi = math.floor((max_x - _TILE_EPS) / tws) + ring
+    row_lo = math.floor(min_y / tws) - ring
+    row_hi = math.floor((max_y - _TILE_EPS) / tws) + ring
+    return [(c, r) for r in range(row_lo, row_hi + 1) for c in range(col_lo, col_hi + 1)]
 
 
 def _render_scene_layers(

--- a/src/wiser/gui/mosaic_view.py
+++ b/src/wiser/gui/mosaic_view.py
@@ -18,6 +18,7 @@ Later issues fill in the two layers, both drawn through the seams stubbed here:
 
 import logging
 import math
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
@@ -47,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 # Debounce window for pan/zoom pixel re-reads: coalesce a gesture's burst of paints
 # into one background read once the camera settles for this long.
-_PIXEL_READ_DEBOUNCE_MS = 120
+_PIXEL_READ_DEBOUNCE_MS = 80
 
 # Tile-based pixel cache (#674). World space is quantized into a fixed grid of ARGB
 # tiles per discrete zoom bucket; a pan/zoom reuses already-cached tiles and only warps
@@ -127,19 +128,25 @@ def _tiles_covering_extent(
     return [(c, r) for r in range(row_lo, row_hi + 1) for c in range(col_lo, col_hi + 1)]
 
 
-def _render_scene_layers(
-    jobs: List[Tuple[int, MosaicScene, str, Tuple[float, float, float, float], int, int, int]],
-) -> List[Tuple[int, np.ndarray]]:
-    """
-    Warp each job's scene into an RGBA array. Runs on a **scheduler thread** (no Qt).
+# Identity of one cached tile: (id(scene), zoom bucket, tile col, tile row). Used as the
+# opaque key threaded through the warp worker and back so the GUI thread knows which cell
+# a returned RGBA array belongs to.
+_TileKey = Tuple[int, int, int, int]
 
-    ``jobs`` is ``(scene_key, scene, target_wkt, world_extent, width, height,
+
+def _render_scene_layers(
+    jobs: List[Tuple[_TileKey, MosaicScene, str, Tuple[float, float, float, float], int, int, int]],
+) -> List[Tuple[_TileKey, np.ndarray]]:
+    """
+    Warp each job's tile into an RGBA array. Runs on a **scheduler thread** (no Qt).
+
+    ``jobs`` is ``(tile_key, scene, target_wkt, world_extent, width, height,
     resample_alg)``; the result pairs each key with its ``(H, W, 4)`` RGBA array for
-    the GUI thread to wrap into a ``QImage``. A single scene that fails to render is
+    the GUI thread to wrap into a ``QImage``. A single tile that fails to render is
     skipped rather than failing the whole batch (mirrors the per-scene guard in the
     synchronous path).
     """
-    out: List[Tuple[int, np.ndarray]] = []
+    out: List[Tuple[_TileKey, np.ndarray]] = []
     for key, scene, target_wkt, world_extent, width, height, resample_alg in jobs:
         try:
             out.append((key, render_scene_argb(scene, target_wkt, world_extent, width, height, resample_alg)))
@@ -293,30 +300,30 @@ class MosaicView(QWidget):
         self._mosaicpane = mosaicpane
         self._app_services = app_services
 
-        # Pixel layer (#637): the composited, screen-resolution mosaic image plus the
-        # per-scene ARGB caches it is stacked from.
+        # Pixel layer (#674): a tiled ARGB cache. World space is quantized into a fixed
+        # grid of _TILE_PX-square tiles per discrete zoom bucket; each cached tile is one
+        # scene's warp of one cell (keyed by _TileKey = (id(scene), bucket, col, row)).
+        # A pan/zoom reuses already-cached tiles and only warps the newly-exposed ones,
+        # so the loaded margin travels with the user instead of the whole viewport being
+        # re-warped on every settle (fixes the black pan edge, #674).
         #
-        # _scene_layers holds one ARGB QImage per visible scene (keyed by id(scene)) at
-        # the *current viewport* — the render signature below. Any pan/zoom changes the
-        # signature and re-reads every layer; the cache's payoff is that a z-order
-        # reorder or visibility toggle at a fixed viewport is a pure restack with no
-        # GDAL reads. _read_scene_ids records which scenes were visible at the last read
-        # so a restack can tell "legitimately not cached (non-intersecting)" from
-        # "was hidden, needs a read to reveal".
-        self._composite_pixmap: Optional[QPixmap] = None
-        self._composite_world_extent: Optional[Tuple[float, float, float, float]] = None
-        # Below, int is the id() of a MosaicScene in the current viewport
-        self._scene_layers: Dict[int, QImage] = {}
-        self._read_scene_ids: Set[int] = set()
-        self._render_signature: Optional[Tuple[float, float, float, int, int]] = None
+        # _tile_cache is an LRU (insertion-ordered, oldest first) bounded to
+        # _TILE_CACHE_MAX. _inflight_tiles holds keys currently being warped so a tile is
+        # never submitted twice. _read_epoch bumps whenever the cache is invalidated
+        # (add/remove scene, CRS change) so a read submitted before the invalidation is
+        # dropped instead of inserting now-stale pixels.
+        self._tile_cache: "OrderedDict[_TileKey, QImage]" = OrderedDict()
+        self._inflight_tiles: Set[_TileKey] = set()
+        self._read_epoch = 0
         self._pixels_dirty = True
+        # Camera identity at the last paint, so pan/zoom (which moves the camera) arms a
+        # debounced read while a pure restack (reorder/visibility) does not.
+        self._last_paint_signature: Optional[Tuple[float, float, float, int, int]] = None
 
-        # Off-thread + debounced pixel reads (#637). Pan/zoom paints coalesce into one
+        # Off-thread + debounced tile reads (#674). Pan/zoom paints coalesce into one
         # background read once the camera settles for _PIXEL_READ_DEBOUNCE_MS. Reads are
-        # submitted to the scheduler (when available); the prior composite is drawn,
-        # scaled by the camera, in the interim. _reading_signature is the viewport the
-        # in-flight read targets, so a superseded read's late result is discarded.
-        self._reading_signature: Optional[Tuple[float, float, float, int, int]] = None
+        # submitted to the scheduler (when available); cached tiles (including a nearest
+        # other-bucket fallback) keep drawing in the interim so there is no black frame.
         self._pending_future = None
         self._debounce_timer = QTimer(self)
         self._debounce_timer.setSingleShot(True)
@@ -398,32 +405,35 @@ class MosaicView(QWidget):
 
     def invalidate_pixels(self) -> None:
         """
-        Mark the per-scene pixel cache stale (a GDAL re-read is required) and repaint.
+        Drop the whole tile cache (a GDAL re-read is required) and repaint.
 
-        Called after a controller change that alters *which pixels* to read — a scene
-        added/removed or a target-CRS change. The rebuild runs lazily in
-        :meth:`paintEvent`. Distinct from :meth:`recomposite_only`, which restacks the
-        existing cache without any reads.
+        Called after a controller change that alters *which pixels* a tile maps to — a
+        scene added/removed or a target-CRS change (world coordinates keep the same
+        ``(col, row)`` key but now cover different data, so the cached pixels are no
+        longer valid). Bumping ``_read_epoch`` makes any read already in flight drop its
+        result instead of inserting stale tiles. The refill is scheduled lazily by the
+        next :meth:`paintEvent`. Distinct from :meth:`recomposite_only`, which reuses the
+        cache with no reads.
         """
+        self._read_epoch += 1
+        self._tile_cache.clear()
+        self._inflight_tiles.clear()
         self._pixels_dirty = True
         self.update()
 
     def recomposite_only(self) -> None:
         """
-        Restack the cached per-scene layers with **no GDAL reads** and repaint.
+        Repaint from the existing tile cache, reading **only** genuinely missing tiles.
 
-        This is the fast path for a z-order reorder or a visibility toggle at a fixed
-        viewport: the cached layers are still valid, only their stacking order or
-        which ones are drawn changes. Falls back to :meth:`invalidate_pixels` when a
-        now-visible scene has no cached layer because it was hidden at the last read
-        (revealing it genuinely needs a read); a visible scene that is merely off-view
-        was still *considered* at the last read, so it stays on the no-read path.
+        The fast path for a z-order reorder or a visibility toggle: the cached tiles are
+        still valid (they are keyed per scene, independent of order/visibility), so a
+        reorder or a hide is a pure repaint with no reads, and re-showing a scene reuses
+        its still-cached tiles for free. The only case that reads is *revealing* a scene
+        that was hidden at every prior read of this viewport (so its tiles were never
+        warped); :meth:`_start_pixel_read` detects those missing tiles and warps just
+        them — an all-cached restack submits zero warp jobs.
         """
-        visible_ids = {id(s) for s in self._controller.get_scenes() if s.visible}
-        if not visible_ids.issubset(self._read_scene_ids):
-            self.invalidate_pixels()
-            return
-        self._recomposite()
+        self._schedule_pixel_read()
         self.update()
 
     def _visible_world_extent(self) -> Tuple[float, float, float, float]:
@@ -470,7 +480,7 @@ class MosaicView(QWidget):
 
     def _schedule_pixel_read(self) -> None:
         """
-        Ask for a fresh per-scene read of the current viewport.
+        Ask for a read of any tiles the current viewport needs but does not have.
 
         With a scheduler, this (re)starts the debounce timer so a pan/zoom gesture's
         burst of paints collapses into a single background read once the camera
@@ -484,23 +494,21 @@ class MosaicView(QWidget):
 
     def _start_pixel_read(self) -> None:
         """
-        Snapshot the current viewport on the GUI thread, then read its scenes.
+        Snapshot the viewport on the GUI thread and warp its **missing** tiles.
 
         The cheap, Qt-adjacent work (resolving the target CRS, reprojecting footprints,
-        the in-view intersect test) happens here; only the heavy per-scene warps are
-        handed to the worker. With no scheduler the worker runs inline.
+        the per-tile intersect test) happens here; only the heavy per-tile warps are
+        handed to the worker. Tiles already cached or already in flight are skipped, so
+        a pan warps only the newly-exposed cells and an all-cached restack warps
+        nothing. With no scheduler the worker runs inline.
         """
-        signature = self._current_signature()
         target_wkt = self._controller.get_target_crs()
         w, h = self.width(), self.height()
         if target_wkt is None or w <= 1 or h <= 1:
-            # Nothing to read; clear the cache and mark this viewport as done so we
-            # don't reschedule every paint.
-            self._apply_pixel_read((signature, None, set(), []))
-            self._reading_signature = signature
-            return
+            return  # nothing to read yet (no grid, or the widget has no real size)
 
         world_extent = self._visible_world_extent()
+        bucket = _zoom_bucket(self._transform.world_units_per_pixel)
         try:
             footprints = self._controller.visible_scene_footprints_in_common_crs()
         except Exception:  # noqa: BLE001 — never let a paint-driven read raise
@@ -510,26 +518,36 @@ class MosaicView(QWidget):
         # Snapshot the resampling method on the GUI thread so the warp (which runs off
         # the GUI thread) uses the controller's current choice (#638).
         resample_alg = self._controller.get_resample_alg()
-        read_scene_ids: Set[int] = set()
-        jobs: List[Tuple[int, MosaicScene, str, Tuple[float, float, float, float], int, int, int]] = []
+        cells = _tiles_covering_extent(bucket, world_extent, _PREFETCH_RING)
+        jobs: List[Tuple[_TileKey, MosaicScene, str, Tuple[float, float, float, float], int, int, int]] = []
         for scene, geom in footprints:
-            read_scene_ids.add(id(scene))
-            if self._envelope_intersects(geom, world_extent):
-                jobs.append((id(scene), scene, target_wkt, world_extent, w, h, resample_alg))
+            for col, row in cells:
+                key: _TileKey = (id(scene), bucket, col, row)
+                if key in self._tile_cache or key in self._inflight_tiles:
+                    continue
+                tile_extent = _tile_world_extent(bucket, col, row)
+                if not self._envelope_intersects(geom, tile_extent):
+                    continue  # this scene's data does not reach this cell — never warp it
+                jobs.append((key, scene, target_wkt, tile_extent, _TILE_PX, _TILE_PX, resample_alg))
 
-        self._reading_signature = signature
+        if not jobs:
+            return  # every needed tile is cached or already being read
+
+        submitted = tuple(job[0] for job in jobs)
+        self._inflight_tiles.update(submitted)
+        epoch = self._read_epoch
         if self._app_services is None:
-            self._apply_pixel_read((signature, world_extent, read_scene_ids, _render_scene_layers(jobs)))
+            self._apply_pixel_read((epoch, submitted, _render_scene_layers(jobs)))
             return
 
-        def _done(future, signature=signature, world_extent=world_extent, read_scene_ids=read_scene_ids):
+        def _done(future, epoch=epoch, submitted=submitted):
             # Runs on the scheduler thread; hop back to the GUI thread via the signal.
             try:
                 results = future.result()
             except Exception:  # noqa: BLE001 — surface nothing rather than crash a worker
                 logger.exception("Mosaic pixel read failed")
                 results = []
-            self._read_ready.emit((signature, world_extent, read_scene_ids, results))
+            self._read_ready.emit((epoch, submitted, results))
 
         self._pending_future = self._app_services.scheduler.submit_thread(
             PriorityClass.BACKGROUND, _render_scene_layers, jobs
@@ -538,38 +556,27 @@ class MosaicView(QWidget):
 
     def _apply_pixel_read(self, payload) -> None:
         """
-        Install a completed read on the GUI thread, unless it has been superseded.
+        Insert completed tiles into the LRU cache on the GUI thread.
 
-        Only the most recently *submitted* read (``_reading_signature``) is applied;
-        an out-of-order or stale result for an older viewport is dropped so it can
-        never clobber newer pixels. Wrapping RGBA into ``QImage`` happens here (Qt
-        objects must be built on the GUI thread), then the layers are restacked.
+        ``payload`` is ``(epoch, submitted_keys, results)``. Every submitted key is
+        cleared from ``_inflight_tiles`` first — including tiles the worker skipped on
+        error — so a transient failure can be retried on the next settle. Results are
+        dropped without inserting when ``epoch`` is stale (the cache was invalidated
+        after this read was submitted), so a CRS change / add / remove never installs
+        tiles that no longer match. Reads are otherwise **additive**: a late tile from a
+        superseded pan is still a valid entry for its cell, kept or evicted by the LRU.
         """
-        signature, world_extent, read_scene_ids, results = payload
-        if signature != self._reading_signature:
-            return  # superseded by a newer read; discard
-        self._reading_signature = None
-        self._scene_layers = {key: self._numpy_to_argb_qimage(rgba) for key, rgba in results}
-        self._read_scene_ids = read_scene_ids
-        self._composite_world_extent = world_extent
-        self._render_signature = signature
+        epoch, submitted_keys, results = payload
+        self._inflight_tiles.difference_update(submitted_keys)
+        if epoch != self._read_epoch:
+            return  # cache was invalidated since this read was submitted; drop it
+        for key, rgba in results:
+            self._tile_cache[key] = self._numpy_to_argb_qimage(rgba)
+            self._tile_cache.move_to_end(key)
+        while len(self._tile_cache) > _TILE_CACHE_MAX:
+            self._tile_cache.popitem(last=False)  # evict the least-recently-used tile
         self._pixels_dirty = False
-        self._recomposite()
         self.update()
-
-    def _recomposite(self) -> None:
-        """
-        Stack the cached per-scene layers bottom-to-top into ``_composite_pixmap``.
-
-        Walks the controller's bottom-to-top scene order and takes each visible
-        scene's cached layer (``None`` for hidden scenes or scenes with no cached
-        layer), so z-order and visibility are honored here purely from the cache — no
-        reads. ``_composite_world_extent`` is left as the last read set it.
-        """
-        scenes = self._controller.get_scenes()
-        layers = [self._scene_layers.get(id(s)) if s.visible else None for s in scenes]
-        result = self.composite(layers)
-        self._composite_pixmap = QPixmap.fromImage(result) if result is not None else None
 
     # -- pan / zoom -----------------------------------------------------------
 
@@ -599,6 +606,91 @@ class MosaicView(QWidget):
         if event.button() == Qt.MiddleButton and self._pan_anchor is not None:
             self._pan_anchor = None
             event.accept()
+
+    # -- tile drawing (#674) --------------------------------------------------
+
+    def _draw_pixel_layer(self, painter: QPainter) -> None:
+        """
+        Draw the tiled pixel layer for the current viewport, in two passes.
+
+        Pass 1 (fallback) draws the nearest *other* zoom bucket's cached tiles that
+        intersect the viewport, scaled through the camera, so a zoom into a not-yet-read
+        bucket is never black. Pass 2 (sharp) draws the current bucket: per cell it
+        stacks each visible scene's tile via :meth:`composite` (the single stacking
+        indirection point) and blits the result at the cell's world rect. Both passes
+        map world rects through the world->screen affine, so off-screen tiles simply do
+        not land on the widget.
+        """
+        w2s = self._transform.world_to_screen(self.size())
+        world_extent = self._visible_world_extent()
+        bucket = _zoom_bucket(self._transform.world_units_per_pixel)
+        # bottom-to-top so later (upper) scenes composite over lower ones
+        visible_scenes = [s for s in self._controller.get_scenes() if s.visible]
+        scene_order = {id(s): i for i, s in enumerate(visible_scenes)}
+
+        painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
+        self._draw_fallback_tiles(painter, w2s, scene_order, bucket, world_extent)
+
+        for col, row in _tiles_covering_extent(bucket, world_extent):
+            layers: List[Optional[QImage]] = []
+            for scene in visible_scenes:
+                key: _TileKey = (id(scene), bucket, col, row)
+                img = self._tile_cache.get(key)
+                if img is not None:
+                    self._tile_cache.move_to_end(key)  # drawn => most-recently-used
+                layers.append(img)
+            cell = self.composite(layers)
+            if cell is not None:
+                self._draw_tile_image(painter, w2s, bucket, col, row, cell)
+
+    def _draw_fallback_tiles(
+        self,
+        painter: QPainter,
+        w2s: QTransform,
+        scene_order: Dict[int, int],
+        bucket: int,
+        world_extent: Tuple[float, float, float, float],
+    ) -> None:
+        """
+        Under-draw the nearest cached bucket other than ``bucket`` (a scaled preview).
+
+        Picks, among cached tiles of currently-visible scenes that intersect the
+        viewport, the bucket closest to the current one and draws its tiles bottom-to-top
+        directly (no per-cell :meth:`composite` — cross-bucket tiles are not cell-aligned
+        across scenes, and this is only a transient fill under the sharp pass). Bounded by
+        the cache size, so it is cheap.
+        """
+        candidates = [
+            key
+            for key in self._tile_cache
+            if key[1] != bucket
+            and key[0] in scene_order
+            and self._tile_intersects_viewport(key[1], key[2], key[3], world_extent)
+        ]
+        if not candidates:
+            return
+        best_bucket = min(candidates, key=lambda k: abs(k[1] - bucket))[1]
+        tiles = [k for k in candidates if k[1] == best_bucket]
+        tiles.sort(key=lambda k: scene_order[k[0]])  # bottom-to-top
+        for _sid, b, col, row in tiles:
+            self._draw_tile_image(painter, w2s, b, col, row, self._tile_cache[(_sid, b, col, row)])
+
+    @staticmethod
+    def _tile_intersects_viewport(
+        bucket: int, col: int, row: int, world_extent: Tuple[float, float, float, float]
+    ) -> bool:
+        """Does a tile's world rect overlap the visible world rectangle?"""
+        tx0, ty0, tx1, ty1 = _tile_world_extent(bucket, col, row)
+        vx0, vy0, vx1, vy1 = world_extent
+        return not (tx1 <= vx0 or tx0 >= vx1 or ty1 <= vy0 or ty0 >= vy1)
+
+    def _draw_tile_image(
+        self, painter: QPainter, w2s: QTransform, bucket: int, col: int, row: int, img: QImage
+    ) -> None:
+        """Blit one tile ``img`` at its ``(bucket, col, row)`` world rect through ``w2s``."""
+        min_x, min_y, max_x, max_y = _tile_world_extent(bucket, col, row)
+        target_rect = w2s.mapRect(QRectF(min_x, min_y, max_x - min_x, max_y - min_y))
+        painter.drawImage(target_rect, img)
 
     def composite(self, layers: List[Optional[QImage]]) -> Optional[QImage]:
         """
@@ -649,29 +741,23 @@ class MosaicView(QWidget):
             self._rebuild_overlay_geometry()
             self._geometry_dirty = False
 
-        # Pixel layer: when the viewport (render signature) changed or the cache was
-        # explicitly invalidated, schedule a debounced background re-read — unless a
-        # read for this exact viewport is already in flight (wait for it instead). The
-        # prior composite keeps drawing, scaled by the camera, in the interim.
+        # Pixel layer: when the camera moved (pan/zoom) or the cache was explicitly
+        # invalidated, schedule a debounced read of whatever tiles the new viewport is
+        # missing. A pure restack (reorder/visibility) leaves the camera put, so it does
+        # not arm here — it schedules its own (usually no-op) read via recomposite_only.
         signature = self._current_signature()
-        if (
-            self._pixels_dirty or self._render_signature != signature
-        ) and signature != self._reading_signature:
+        if self._pixels_dirty or self._last_paint_signature != signature:
+            self._pixels_dirty = False
+            self._last_paint_signature = signature
             self._schedule_pixel_read()
 
         with get_painter(self) as painter:
             painter.fillRect(self.rect(), self.palette().window())
 
-            # --- Layer 1: pixel layer (#637) -------------------------------------
-            # Draw the composited pixmap mapped by the world->screen affine, so an
-            # interim pan/zoom simply scales the last composite until the next rebuild.
-            if self._composite_pixmap is not None and self._composite_world_extent is not None:
-                painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
-                min_x, min_y, max_x, max_y = self._composite_world_extent
-                target_rect = self._transform.world_to_screen(self.size()).mapRect(
-                    QRectF(min_x, min_y, max_x - min_x, max_y - min_y)
-                )
-                painter.drawPixmap(target_rect, self._composite_pixmap, QRectF(self._composite_pixmap.rect()))
+            # --- Layer 1: pixel layer (#674, tiled) ------------------------------
+            # Cached tiles drawn in world coordinates through the affine; a nearest
+            # other-bucket fallback under-draws so pan/zoom never shows a black frame.
+            self._draw_pixel_layer(painter)
 
             # --- Layer 2: vector overlay (#636) ----------------------------------
             painter.setRenderHint(QPainter.Antialiasing, True)

--- a/src/wiser/raster/mosaic_compositor.py
+++ b/src/wiser/raster/mosaic_compositor.py
@@ -103,7 +103,6 @@ def render_scene_argb(
         # No data bands, or nothing valid in view: leave RGB black, alpha as computed.
         return rgba
 
-    display_bands = select_display_bands(scene.dataset, num_data_bands)
     channels = [
         _stretch_band(
             warped.GetRasterBand(band_idx + 1).ReadAsArray().astype(np.float32),

--- a/src/wiser/raster/mosaic_compositor.py
+++ b/src/wiser/raster/mosaic_compositor.py
@@ -25,7 +25,7 @@ existing warp seam :func:`wiser.raster.mosaic_controller._warped_resolution`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, Tuple
+from typing import TYPE_CHECKING, Optional, Sequence, Tuple
 
 import numpy as np
 from osgeo import gdal
@@ -36,8 +36,10 @@ if TYPE_CHECKING:
 # Percentile bounds for the per-scene linear contrast stretch. A 2-98% stretch is a
 # common, robust default that ignores a few extreme outliers without needing the
 # main view's live stretch state (this preview is intentionally self-contained).
-_STRETCH_LO_PCT = 2.0
-_STRETCH_HI_PCT = 98.0
+# Public (not module-private) because wiser.raster.mosaic_ingestion.compute_stretch_bounds
+# uses the same bounds when precomputing a scene's stable stretch (issue #675).
+STRETCH_LO_PCT = 2.0
+STRETCH_HI_PCT = 98.0
 
 
 def render_scene_argb(
@@ -54,8 +56,11 @@ def render_scene_argb(
 
     ``world_extent`` is ``(min_x, min_y, max_x, max_y)`` in the target CRS (the
     view's visible world rectangle). RGB comes from the dataset's default display
-    bands (1 band -> grayscale, 3 bands -> RGB), contrast-stretched per band over the
-    valid pixels; alpha is the warp's validity mask (0 on nodata / outside coverage).
+    bands (1 band -> grayscale, 3 bands -> RGB), contrast-stretched per band against
+    ``scene.stretch_bounds`` -- precomputed, extent-independent 2-98 percentile bounds
+    cached at ingest (issue #675), so contrast does not drift with zoom -- falling back
+    to a viewport percentile stretch when a scene has no cached bounds. Alpha is the
+    warp's validity mask (0 on nodata / outside coverage).
 
     A scene whose data does not cover ``world_extent`` comes back fully transparent
     (alpha all 0), so callers can render it unconditionally.
@@ -95,11 +100,12 @@ def render_scene_argb(
         # No data bands, or nothing valid in view: leave RGB black, alpha as computed.
         return rgba
 
-    display_bands = _select_display_bands(scene, num_data_bands)
+    display_bands = select_display_bands(scene.dataset, num_data_bands)
     channels = [
         _stretch_band(
             warped.GetRasterBand(band_idx + 1).ReadAsArray().astype(np.float32),
             valid,
+            bounds=scene.stretch_bounds.get(band_idx) if scene.stretch_bounds else None,
         )
         for band_idx in display_bands
     ]
@@ -114,15 +120,19 @@ def render_scene_argb(
     return rgba
 
 
-def _select_display_bands(scene: "MosaicScene", num_data_bands: int) -> Sequence[int]:
+def select_display_bands(dataset, num_data_bands: int) -> Sequence[int]:
     """
     Pick the 0-based source band indices to render as RGB (or 1 for grayscale).
 
     Prefers the dataset's default display bands; falls back to the first three bands
     (or the single band) and clamps any out-of-range index defensively.
+
+    Takes ``dataset`` directly (rather than a :class:`MosaicScene`) so
+    :func:`wiser.raster.mosaic_ingestion.compute_stretch_bounds` can pick the same
+    display bands at ingest time, before a ``MosaicScene`` exists (issue #675).
     """
     bands = None
-    getter = getattr(scene.dataset, "get_default_display_bands", None)
+    getter = getattr(dataset, "get_default_display_bands", None)
     if getter is not None:
         try:
             bands = getter()
@@ -137,14 +147,27 @@ def _select_display_bands(scene: "MosaicScene", num_data_bands: int) -> Sequence
     return tuple(min(int(b), num_data_bands - 1) for b in bands[:3])
 
 
-def _stretch_band(band: np.ndarray, valid: np.ndarray) -> np.ndarray:
+def _stretch_band(
+    band: np.ndarray, valid: np.ndarray, bounds: Optional[Tuple[float, float]] = None
+) -> np.ndarray:
     """
-    Linearly stretch ``band`` to uint8 [0, 255] using the 2-98 percentile of its
-    valid pixels. A flat band (no spread) maps to full white so it stays visible.
+    Linearly stretch ``band`` to uint8 [0, 255] using ``bounds``, or the 2-98
+    percentile of its valid pixels when ``bounds`` is ``None``. A flat/degenerate
+    range (``hi <= lo``) maps to full white so it stays visible.
+
+    ``bounds`` is the scene's precomputed, extent-independent stretch (see
+    :func:`wiser.raster.mosaic_ingestion.compute_stretch_bounds`, issue #675) — passing
+    it decouples the on-screen contrast from whatever pixels happen to be in the
+    current viewport. ``None`` is the fallback for a scene with no cached bounds (e.g.
+    a :class:`MosaicScene` built directly in a test, bypassing ingestion), which
+    reproduces the pre-#675 viewport-percentile behavior.
     """
-    values = band[valid]
-    lo = float(np.percentile(values, _STRETCH_LO_PCT))
-    hi = float(np.percentile(values, _STRETCH_HI_PCT))
+    if bounds is not None:
+        lo, hi = bounds
+    else:
+        values = band[valid]
+        lo = float(np.percentile(values, STRETCH_LO_PCT))
+        hi = float(np.percentile(values, STRETCH_HI_PCT))
     if hi <= lo:
         out = np.full(band.shape, 255.0, dtype=np.float32)
     else:

--- a/src/wiser/raster/mosaic_controller.py
+++ b/src/wiser/raster/mosaic_controller.py
@@ -85,9 +85,14 @@ class MosaicScene:
         into this same file, so there is exactly one artifact file per scene.
       * ``footprint_wkt`` — the valid-pixel polygon as WKT in the dataset's own CRS.
       * ``has_overviews`` — whether pyramid overviews were built on ``gdal_path``.
+      * ``stretch_bounds`` — precomputed, extent-independent 2-98 percentile stretch
+        bounds per display band (source band index -> ``(lo, hi)``), populated at
+        ingest by :func:`wiser.raster.mosaic_ingestion.compute_stretch_bounds` so the
+        pixel compositor's contrast stays stable across zoom (issue #675). ``None``
+        until ingestion computes it.
 
-    All three default to ``None``/``False`` so a bare ``MosaicScene(dataset=...)``
-    (as used by the scaffolding tests) is still valid.
+    All fields besides ``dataset`` default to ``None``/``False`` so a bare
+    ``MosaicScene(dataset=...)`` (as used by the scaffolding tests) is still valid.
     """
 
     dataset: "RasterDataSet"
@@ -95,6 +100,7 @@ class MosaicScene:
     gdal_path: Optional[str] = None
     footprint_wkt: Optional[str] = None
     has_overviews: bool = False
+    stretch_bounds: Optional[Dict[int, Tuple[float, float]]] = None
 
 
 @dataclass

--- a/src/wiser/raster/mosaic_ingestion.py
+++ b/src/wiser/raster/mosaic_ingestion.py
@@ -10,21 +10,27 @@ few gates before it can be displayed or composited:
      (see the function docstring).
   2. :func:`build_overviews` — build internal pyramid overviews on the materialized
      temp GeoTIFF so preview rendering (#637) is fast without a first-paint stutter.
-  3. :func:`compute_footprint_wkt` — derive the valid-pixel outline via
+  3. :func:`compute_stretch_bounds` — sample a stable, extent-independent contrast
+     stretch per display band from an internal overview, so the pixel compositor's
+     contrast (#637) does not drift as the user zooms (#675).
+  4. :func:`compute_footprint_wkt` — derive the valid-pixel outline via
      ``gdal.Footprint`` so geometry rendering (#636) has the real shape.
 
 This module is **Qt-free** (GDAL + stdlib only) so it is unit-testable without a
 running application. The GUI orchestration (materialize -> build_overviews ->
-compute_footprint on a background thread) lives in the mosaic pane (#638-adjacent).
+compute_stretch_bounds -> compute_footprint on a background thread) lives in the
+mosaic pane (#638-adjacent).
 """
 
 from __future__ import annotations
 
 import math
-from typing import List, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
+import numpy as np
 from osgeo import gdal
 
+from wiser.raster.mosaic_compositor import STRETCH_HI_PCT, STRETCH_LO_PCT, select_display_bands
 from wiser.utils.progress import ProgressReporter, gdal_progress_callback
 
 if TYPE_CHECKING:
@@ -46,6 +52,12 @@ _IDENTITY_GEO_TRANSFORM: Tuple[float, float, float, float, float, float] = (
 # Pyramid decimation levels for preview overviews. Powers of two keep GDAL's
 # averaging cheap and cover a wide zoom range for typical scene sizes.
 _OVERVIEW_LEVELS: List[int] = [2, 4, 8, 16]
+
+# Overview decimation level compute_stretch_bounds samples from: coarser than the
+# finest overview (cheap -- no full-resolution read), but finer than the coarsest, so
+# the sample is large enough that a small bright/dark feature isn't missed by the
+# NEAREST-resampled overview's sparser pixels (#675).
+_STRETCH_SAMPLE_OVERVIEW_LEVEL = 4
 
 
 class SceneValidationError(ValueError):
@@ -144,6 +156,73 @@ def build_overviews(gdal_path: str, progress: Optional[ProgressReporter] = None)
         ds.BuildOverviews("NEAREST", _OVERVIEW_LEVELS, callback=gdal_progress_callback(progress))
     finally:
         ds = None  # flush/close
+
+
+def _stretch_sample_source(band: gdal.Band) -> gdal.Band:
+    """
+    Pick what :func:`compute_stretch_bounds` reads for one band: the
+    ``_STRETCH_SAMPLE_OVERVIEW_LEVEL`` overview when it was built, else the coarsest
+    overview available, else the full-resolution band (no overviews at all).
+    """
+    count = band.GetOverviewCount()
+    if count == 0:
+        return band
+    if _STRETCH_SAMPLE_OVERVIEW_LEVEL in _OVERVIEW_LEVELS:
+        target_index = _OVERVIEW_LEVELS.index(_STRETCH_SAMPLE_OVERVIEW_LEVEL)
+        if target_index < count:
+            return band.GetOverview(target_index)
+    return band.GetOverview(count - 1)
+
+
+def compute_stretch_bounds(
+    gdal_path: str,
+    dataset: "RasterDataSet",
+    progress: Optional[ProgressReporter] = None,
+) -> Dict[int, Tuple[float, float]]:
+    """
+    Compute stable, extent-independent 2-98 percentile stretch bounds per display
+    band for the materialized scene at ``gdal_path``.
+
+    Cached once at ingest (issue #675) so the pixel compositor's on-screen contrast
+    no longer drifts as the user zooms: :func:`wiser.raster.mosaic_compositor.render_scene_argb`
+    stretches every render against these fixed bounds instead of recomputing
+    percentiles from whatever pixels happen to be in the current viewport. Samples
+    from an internal overview (see :func:`_stretch_sample_source`) rather than a
+    full-resolution read, since ``build_overviews`` -- which always runs immediately
+    before this in the ingestion pipeline -- makes that cheap regardless of the
+    source's full-resolution size.
+
+    Returns a dict keyed by **source band index** (0-based, matching
+    :func:`~wiser.raster.mosaic_compositor.select_display_bands`), so it stays correct
+    regardless of channel ordering. A band with no valid (non-nodata) pixels in the
+    sample is simply omitted; :func:`~wiser.raster.mosaic_compositor._stretch_band`
+    falls back to an on-the-fly stretch for it.
+
+    ``progress`` reports coarse per-band fractions and defaults to a no-op reporter.
+    """
+    progress = progress or ProgressReporter()
+    gdal.UseExceptions()
+    ds = gdal.Open(gdal_path)
+    if ds is None:
+        raise RuntimeError(f"Cannot open {gdal_path} for stretch-bounds computation")
+
+    num_data_bands = ds.RasterCount
+    display_bands = select_display_bands(dataset, num_data_bands)
+
+    bounds: Dict[int, Tuple[float, float]] = {}
+    for i, band_idx in enumerate(display_bands):
+        band = ds.GetRasterBand(band_idx + 1)
+        arr = _stretch_sample_source(band).ReadAsArray().astype(np.float64)
+        nodata = band.GetNoDataValue()
+        valid = arr != nodata if nodata is not None else np.ones(arr.shape, dtype=bool)
+        values = arr[valid]
+        if values.size:
+            bounds[band_idx] = (
+                float(np.percentile(values, STRETCH_LO_PCT)),
+                float(np.percentile(values, STRETCH_HI_PCT)),
+            )
+        progress.report_fraction((i + 1) / len(display_bands), "Computing stretch bounds")
+    return bounds
 
 
 def compute_footprint_wkt(gdal_path: str, progress: Optional[ProgressReporter] = None) -> str:


### PR DESCRIPTION
## What does this change do?
Ensures that when zoom occurs, we do not calculate the 2% 98% contrast stretch based on just the currently viewed window but the pixels in the full scene (for a specific scene). 

Closes #675

Closes #674

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [X] Documentation Update
- [ ] Style
- [X] Code Refactor
- [ ] Performance Improvements
- [X] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
Needed so the colors don't keep changing when you zoom in. Good UX.

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [ ] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->