### PR TITLE
feat: Add checkbox to create form for plugin developers

### DIFF
--- a/src/tests/test_ui_library.py
+++ b/src/tests/test_ui_library.py
@@ -14,12 +14,16 @@ from test_utils.test_function_decorator import run_in_wiser_decorator
 import numpy as np
 from astropy import units as u
 
+from unittest.mock import patch
+
 from wiser.gui.ui_library import (
     DatasetChooserDialog,
     SpectrumChooserDialog,
     ROIChooserDialog,
     BandChooserDialog,
     TableDisplayWidget,
+    DynamicInputDialog,
+    DynamicInputType,
 )
 
 from wiser.raster.spectrum import NumPyArraySpectrum
@@ -183,6 +187,32 @@ class TestUILibrary(unittest.TestCase):
         self.assertTrue(table_widget._table.columnCount() == len(header))
         self.assertTrue(table_widget.windowTitle() == window_title)
         self.assertTrue(table_widget._description_label.text() == description)
+
+    def test_dynamic_input_dialog_checkbox(self):
+        """A CHECK_BOX input returns a bool and honors its initial state."""
+        dialog = DynamicInputDialog(dialog_title="Checkbox Test")
+
+        inputs = [
+            # 4th element seeds the initial checked state
+            ("Enable feature", "enabled", DynamicInputType.CHECK_BOX, [True]),
+            # No 4th element -> defaults to unchecked
+            ("Verbose", "verbose", DynamicInputType.CHECK_BOX, None),
+        ]
+
+        # Patch exec so the modal dialog doesn't block the test.
+        with patch.object(DynamicInputDialog, "exec", return_value=QDialog.Accepted):
+            result = dialog.create_input_dialog(inputs)
+
+        self.assertIsInstance(result["enabled"], bool)
+        self.assertTrue(result["enabled"])
+        self.assertIsInstance(result["verbose"], bool)
+        self.assertFalse(result["verbose"])
+
+        # Toggling a checkbox updates the returned value.
+        checkboxes = dialog.findChildren(QCheckBox)
+        self.assertEqual(len(checkboxes), 2)
+        checkboxes[0].setChecked(False)
+        self.assertFalse(result["enabled"])
 
     def test_spectrum_plot_generic(self):
         test_spectrum_y = np.array(

--- a/src/wiser/gui/ui_library.py
+++ b/src/wiser/gui/ui_library.py
@@ -6,6 +6,7 @@ from PySide6.QtGui import QDoubleValidator, QIntValidator
 from PySide6.QtWidgets import (
     QDialog,
     QLabel,
+    QCheckBox,
     QComboBox,
     QGridLayout,
     QDialogButtonBox,
@@ -108,6 +109,7 @@ class DynamicInputType(IntEnum):
     INT_NO_UNITS = 3
     INT_UNITS = 4
     STRING = 5
+    CHECK_BOX = 6
 
 
 class DynamicInputDialog(QDialog):
@@ -143,8 +145,10 @@ class DynamicInputDialog(QDialog):
                     ]
 
                 For ``DynamicInputType.COMBO_BOX``, provide a 4th element: a list
-                of items for the combo box. No other ``DynamicInputType`` values
-                need this element.
+                of items for the combo box. For ``DynamicInputType.CHECK_BOX``,
+                the 4th element is optional and, if given, its first item is used
+                as the initial checked state (defaults to unchecked). No other
+                ``DynamicInputType`` values need this element.
 
         Returns:
             Optional[Dict]: ``{"<return_key>": value, ...}`` on Accept, or
@@ -256,6 +260,20 @@ class DynamicInputDialog(QDialog):
 
                 self._return_dict[return_key] = None
                 layout.addWidget(line, row, 1)
+            elif input_type == DynamicInputType.CHECK_BOX:
+                checkbox = QCheckBox(self)
+
+                # An optional 4th element supplies the initial checked state.
+                initial_checked = bool(options[0]) if options else False
+                checkbox.setChecked(initial_checked)
+
+                self._return_dict[return_key] = initial_checked
+
+                checkbox.toggled.connect(
+                    lambda checked, key=return_key: self._return_dict.__setitem__(key, checked)
+                )
+
+                layout.addWidget(checkbox, row, 1)
             else:
                 raise ValueError(f"Unsupported DynamicInputType for '{display_name}'.")
 


### PR DESCRIPTION
## What does this change do?
Adds a `CHECK_BOX` input type to `DynamicInputDialog` (and therefore to
`ApplicationState.create_form`), so plugin authors can request a boolean value from the
user. The form renders a `QCheckBox` and returns a Python `bool` under the input's return
key. An optional 4th tuple element seeds the initial checked state (defaults to unchecked).

Closes #693
Closes #604

## What type of PR is this? (check all applicable)
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
Issue: #693 and #604

`create_form` / `DynamicInputDialog` let plugin authors build a dialog of dynamic inputs,
but the supported `DynamicInputType` values only covered combo boxes, float/int (with and
without units), and strings. There was no way to collect a simple boolean, forcing plugin
authors to fake it with a two-item combo box.

## How did you implement the change?
- Added `CHECK_BOX = 6` to the `DynamicInputType` enum in `src/wiser/gui/ui_library.py`.
- Added a `QCheckBox` branch in `DynamicInputDialog.create_input_dialog`: the widget's
  `toggled` signal writes a `bool` into the return dict, and the optional 4th tuple element
  seeds the initial checked state (defaults to `False`).
- Imported `QCheckBox` and updated the `create_input_dialog` docstring to document the new
  type and its optional initial-state element.
- No change was needed to `ApplicationState.create_form` — it forwards the input specs
  through to `create_input_dialog`, so it supports the new type automatically.

## Added tests?
- [x] yes

Added `test_dynamic_input_dialog_checkbox` in `src/tests/test_ui_library.py`: it builds a
form with two checkbox inputs (one seeded checked, one default), patches the dialog's blocking
`exec()` to accept immediately, and asserts the returned values are `bool`, honor their
initial state, and update when the checkbox is toggled.

## Added to documentation?
- [x] yes

Updated the `create_input_dialog` docstring to describe `DynamicInputType.CHECK_BOX` and its
optional initial-state 4th element.

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [ ] Branch is up-to-date with main/master
- [ ] All CI checks passed
