### PR TITLE
GUI app-state ↔ view sync for CRS combo and stretch clearing (#689)

### DIFF
--- a/src/tests/test_reference_creator_crs_sync_gui.py
+++ b/src/tests/test_reference_creator_crs_sync_gui.py
@@ -1,0 +1,60 @@
+"""GUI sync tests: Reference System Creator CRS combo <-> ApplicationState (issue #689).
+
+The Reference System Creator's starting-CRS combo box (``cbox_user_crs``) is populated
+from ApplicationState's user-created-CRS store.  These tests drive the real dialog
+against a real ApplicationState (offscreen ``WiserTestModel``) and assert the combo
+reflects the store: a dialog constructed after the store is populated shows the stored
+CRS, and refreshing an open dialog after the store gains an entry surfaces it.  The
+store emits no change signal, so the dialog re-reads it on construction and on the
+explicit refresh the creation flow already calls.
+"""
+
+import unittest
+
+import tests.context  # noqa: F401
+
+from osgeo import osr
+from PySide6.QtCore import Qt
+
+from test_utils.test_model import WiserTestModel
+from wiser.gui.reference_creator_dialog import ReferenceCreatorDialog
+
+
+def _make_srs(epsg):
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(epsg)
+    return srs
+
+
+class TestReferenceCreatorCrsSync(unittest.TestCase):
+    def setUp(self):
+        self.test_model = WiserTestModel()
+        self.app_state = self.test_model.app_state
+
+    def tearDown(self):
+        self.test_model.close_app()
+        del self.test_model
+
+    def _make_dialog(self):
+        dialog = ReferenceCreatorDialog(self.app_state, parent=self.test_model.main_window)
+        dialog.setAttribute(Qt.WA_DontShowOnScreen, True)
+        self.addCleanup(dialog.close)
+        return dialog
+
+    def test_dialog_seeds_crs_combo_from_app_state(self):
+        self.app_state.add_user_created_crs("MyTestCRS", _make_srs(26915), None)
+        dialog = self._make_dialog()
+        self.assertGreaterEqual(dialog._ui.cbox_user_crs.findText("MyTestCRS"), 0)
+
+    def test_crs_combo_refreshes_after_store_change(self):
+        dialog = self._make_dialog()
+        self.assertEqual(dialog._ui.cbox_user_crs.findText("LaterCRS"), -1)
+
+        self.app_state.add_user_created_crs("LaterCRS", _make_srs(32611), None)
+        dialog._update_user_created_crs_cbox()
+
+        self.assertGreaterEqual(dialog._ui.cbox_user_crs.findText("LaterCRS"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_stretch_view_sync_gui.py
+++ b/src/tests/test_stretch_view_sync_gui.py
@@ -1,0 +1,74 @@
+"""GUI sync test: clearing a stretch resets the view image (issue #689).
+
+A contrast stretch applied to a ``(dataset, band)`` is stored on ApplicationState and
+reaches the displayed image through the ``stretch_changed`` signal.  This test drives
+the real path (offscreen ``WiserTestModel``): a stretch applied through the Stretch
+Builder changes the rendered image, and clearing the dataset's stretches on
+ApplicationState -- setting them back to ``None`` -- reverts the image to its
+unstretched baseline and leaves no stretch on the dataset or the view.
+"""
+
+import unittest
+
+import numpy as np
+
+import tests.context  # noqa: F401
+
+from PySide6.QtWidgets import QApplication
+
+from test_utils.test_model import WiserTestModel
+
+
+class TestStretchViewSync(unittest.TestCase):
+    def setUp(self):
+        self.test_model = WiserTestModel()
+        self.app_state = self.test_model.app_state
+
+    def tearDown(self):
+        self.test_model.close_app()
+        del self.test_model
+
+    def _load_gradient_dataset(self):
+        band = [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.25, 0.25, 0.25, 0.25],
+            [0.5, 0.5, 0.5, 0.5],
+            [0.75, 0.75, 0.75, 0.75],
+            [1.0, 1.0, 1.0, 1.0],
+        ]
+        cube = np.array([band, band, band])
+        return self.test_model.load_dataset(cube)
+
+    def test_clearing_stretch_resets_view_image(self):
+        ds = self._load_gradient_dataset()
+        ds_id = ds.get_id()
+        QApplication.processEvents()
+
+        rv = self.test_model.get_main_view_rv()
+        self.assertIsNotNone(rv.get_raster_data())
+        self.assertEqual(rv.get_raster_data().get_id(), ds_id)
+        bands = rv.get_display_bands()
+        self.assertIsNotNone(bands)
+
+        baseline = self.test_model.get_main_view_rv_image_data()
+        self.assertIsNotNone(baseline)
+        baseline = baseline.copy()
+
+        # Apply a stretch through the real Stretch Builder path; the view re-renders.
+        self.test_model.click_stretch_hist_equalize()
+        self.test_model.click_log_conditioner()
+        with_stretch = self.test_model.get_main_view_rv_image_data().copy()
+        self.assertFalse(np.array_equal(baseline, with_stretch))
+        self.assertTrue(any(s is not None for s in self.app_state.get_stretches(ds_id, bands)))
+
+        # Clearing the dataset's stretches on app state resets the view to baseline.
+        self.app_state.set_stretches(ds_id, bands, [None] * len(bands))
+        QApplication.processEvents()
+        after_clear = self.test_model.get_main_view_rv_image_data().copy()
+        self.assertTrue(np.array_equal(after_clear, baseline))
+        self.assertTrue(all(s is None for s in self.app_state.get_stretches(ds_id, bands)))
+        self.assertTrue(all(s is None for s in rv.get_stretches()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this change do?
Adds GUI regression tests that assert `ApplicationState` mutation
the GUI. Two slices of issue #689: the Reference System Creator's user-CRS combo box
tracks the user-created-CRS store, and clearing a dataset's stret
`ApplicationState` resets the rendered view image. Test-only — no product-code changes.

## What type of PR is this? (check all applicable)
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-tmit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
There was no coverage asserting that app-state changes propagate
regression in that wiring would go unnoticed. Filed as issue #689 while reviewing the
save-to-project stack (#680). This PR covers the **CRS** and **st
**band-math** slice (saved-expression dialog ↔ app state) is covered separately in #679.

Addresses #689 (CRS + stretch slices).

## How did you implement the change?
`unittest.TestCase` tests against the repo's offscreen `QApplicat
(`WiserTestModel`, no pytest-qt), driving the real dialogs/views and asserting on both
widget and app state:
- `test_reference_creator_crs_sync_gui.py` — populate the user-created-CRS store, assert
  `ReferenceCreatorDialog.cbox_user_crs` reflects it (seeded on c
  refreshed after the store changes).
- `test_stretch_view_sync_gui.py` — load a dataset, apply a stret
  Builder (rendered image changes), then clear the dataset's stretches on
  `ApplicationState` and assert the view reverts to its unstretch
  stretch left on the dataset or the view.

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?
- [ ] yes
- [x] no documentation needed

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [ ] All CI checks passed

## Desktop Screenshots/Recordings
N/A — headless, test-only change.

## [optional] Are there any post-merge tasks we need to perform?
Once this and #679 merge, issue #689's CRS / stretch / band-math slices are covered and
#689 can be closed.