### PR TITLE
feat: Add ability to use a CRS wkt string to make a CRS object in WISER 

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/crs-creator-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/crs-creator-internals.md
@@ -8,18 +8,31 @@ become selectable as the output CRS when georeferencing.
 
 ## Overview
 
-A user describes a CRS in geodetic terms — a datum shape (sphere or ellipsoid), a prime
-meridian, and a map projection with its parameters — and the tool assembles those into a
-PROJ4 string, converts it to an `osr.SpatialReference`, and stores it by name in
-`ApplicationState`. From then on it behaves like any other CRS in WISER.
+The dialog is a `QTabWidget` with two ways to define a CRS, both of which end at the
+same `ApplicationState.add_user_created_crs(name, srs, state)` store:
+
+- **From Parameters** — a user describes a CRS in geodetic terms (a datum shape, a
+  prime meridian, and a map projection with its parameters) and the tool assembles
+  those into a PROJ4 string and converts it to an `osr.SpatialReference`.
+- **From CRS String** — a user pastes a ready-made CRS definition (WKT, PROJ, or an
+  authority code such as `EPSG:4326`) and the tool tries to load it, reporting whether
+  WISER can build it and, if so, letting the user name and store it.
+
+From then on either result behaves like any other CRS in WISER.
 
 ```{mermaid}
 flowchart LR
-    U["User fills dialog fields"] --> S["ReferenceCreatorDialog<br/>(validated state)"]
-    S --> P["_create_crs():<br/>build PROJ4 string"]
-    P --> Y["pyproj.CRS.from_proj4 → WKT"]
-    Y --> O["osr.SpatialReference<br/>(ImportFromWkt)"]
+    subgraph Params["From Parameters tab"]
+        U["User fills dialog fields"] --> P["_create_crs():<br/>build PROJ4 string"]
+        P --> Y["pyproj.CRS.from_proj4 → WKT"]
+        Y --> O["osr.SpatialReference<br/>(ImportFromWkt)"]
+    end
+    subgraph Str["From CRS String tab"]
+        US["User pastes WKT / PROJ / EPSG:code"] --> V["_build_srs_from_string():<br/>osr.SetFromUserInput"]
+        V --> O2["osr.SpatialReference<br/>(valid?)"]
+    end
     O --> A["ApplicationState.add_user_created_crs(name, srs, state)"]
+    O2 --> A
     A --> G["Georeferencer output-CRS chooser<br/>(as UserGeneratedCRS)"]
 ```
 
@@ -57,6 +70,8 @@ classDiagram
         +center_lon / latitude
         +latitude_choice
         +polar_stereo_scale / sign
+        +source_wkt
+        +is_string_origin
     }
     QDialog <|-- ReferenceCreatorDialog
     ReferenceCreatorDialog --> CrsCreatorState : exports / reloads
@@ -69,6 +84,9 @@ to ±180, the CRS name restricted to alphanumeric + underscore).
 **`CrsCreatorState`** is an immutable snapshot of every field. After a successful build
 it is stored *alongside* the resulting `osr.SpatialReference`, which is what lets a saved
 custom CRS be re-selected and have its parameters reloaded into the dialog for editing.
+Its `source_wkt` field (and the `is_string_origin` convenience property) marks a CRS
+that was built from a pasted string on the **From CRS String** tab rather than from the
+parameter fields — see [Validating a pasted CRS string](#validating-a-pasted-crs-string).
 
 The dialog's behavior is driven by several enums:
 
@@ -85,6 +103,14 @@ The dialog's behavior is driven by several enums:
 
 ## UI / Workflow
 
+The dialog is a `QTabWidget` (`tabWidget`) with two pages, and a single shared
+OK/Cancel `QDialogButtonBox` beneath the tabs. Which builder the **OK** button runs
+depends on the active tab: `accept()` calls `_create_crs()` for the parameter tab and
+`_on_add_crs_string()` for the string tab (and keeps the dialog open if the string tab
+has nothing valid to add).
+
+### From Parameters tab
+
 The form is organized into the groups a CRS definition needs:
 
 - **Datum shape** — `SPHEROID` (a single radius) or `ELLIPSOID` (semi-major axis plus
@@ -97,7 +123,43 @@ The form is organized into the groups a CRS definition needs:
   (central-latitude mode) or a pole sign (true-scale mode).
 - **Name** — the key the CRS is stored and displayed under.
 
-A reset button clears the fields; the create/accept button runs `_create_crs()`.
+A reset button clears the fields (both tabs); the create/accept button runs
+`_create_crs()`.
+
+### From CRS String tab
+
+A `QPlainTextEdit` (`pedit_crs_string`) to paste the definition into, a name field
+(`ledit_string_crs_name`), a **Validate** button, an **Add to WISER** button (disabled
+until a validation succeeds), and a read-only result box (`pedit_crs_string_result`)
+that shows a green success summary or a red error. See below.
+
+---
+
+## Validating a pasted CRS string
+
+The **From CRS String** tab lets a user check whether WISER can load an arbitrary CRS
+definition without hand-entering every parameter.
+
+`_build_srs_from_string(text)` is the core helper. It builds an `osr.SpatialReference`
+and calls `SetFromUserInput(text)` — the broadest GDAL entry point, which accepts WKT
+(WKT1 and WKT2), PROJ strings, and authority codes like `EPSG:4326`. It returns
+`(srs, None)` on success or `(None, error)` on failure, catching both the exception and
+non-zero return-code styles GDAL uses. On success the axis mapping is forced to
+`OAMS_TRADITIONAL_GIS_ORDER`, the same convention the parameter path and the
+georeferencer apply.
+
+- **Validate** (`_on_validate_crs_string`) parses the text and shows either a green
+  summary (name, geographic/projected, authority:code if present) or the red error, and
+  enables **Add to WISER** only on success. Editing the text afterwards
+  (`_on_crs_string_text_changed`) invalidates the prior result and re-disables Add.
+- **Add to WISER** (`_on_add_crs_string`) requires a name and a validated CRS (it
+  re-validates if needed), then stores it via `add_user_created_crs` with a
+  `CrsCreatorState` whose `source_wkt` is set to the CRS's WKT.
+
+Because a string-origin CRS has no parameter fields to reload, selecting one in the
+**Starting Ref System** combo is special-cased in `_on_starting_crs_changed`: instead of
+driving the parameter widgets it switches to the string tab, repopulates
+`pedit_crs_string` with the stored `source_wkt`, and re-validates.
 
 ---
 
@@ -136,7 +198,10 @@ self._user_created_crs: Dict[str, Tuple[osr.SpatialReference, CrsCreatorState]] 
 
 (keyed by name, with a confirmation prompt before overwriting an existing name). The
 Georeferencer reads this map in `_update_output_srs_cbox_items` and wraps each entry in a
-`UserGeneratedCRS` so it appears in the output-CRS chooser. The stored `CrsCreatorState`
-is what lets the CRS Creator reload a previously created CRS back into its fields for
+`UserGeneratedCRS` so it appears in the output-CRS chooser. The store is identical
+whether the CRS came from the parameter form or from a pasted string, so a
+string-imported CRS is usable as an output CRS just like any other. The stored
+`CrsCreatorState` is what lets the CRS Creator reload a previously created CRS back into
+its fields (parameter tab) or its pasted text (string tab, via `source_wkt`) for
 editing. See [Georeferencer Internals](georeferencer-internals.md) for how the resulting
 CRS feeds the warp.

--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -1683,6 +1683,65 @@ class WiserTestModel:
             raise RuntimeError("OK/Cancel buttons not found in buttonBox")
         QTest.mouseClick(button, Qt.LeftButton)
 
+    # ------------------------------------------
+    # "From CRS String" tab helpers
+    # ------------------------------------------
+    @run_in_wiser_decorator
+    def crs_creator_select_string_tab(self) -> None:
+        """Switch the CRS creator to the 'From CRS String' tab."""
+        dlg = self.main_window._crs_creator_dialog
+        dlg._ui.tabWidget.setCurrentWidget(dlg._ui.page_string)
+
+    @run_in_wiser_decorator
+    def crs_creator_get_active_tab(self) -> str:
+        """Return 'params' or 'string' for the currently active tab."""
+        dlg = self.main_window._crs_creator_dialog
+        current = dlg._ui.tabWidget.currentWidget()
+        return "string" if current is dlg._ui.page_string else "params"
+
+    @run_in_wiser_decorator
+    def crs_creator_set_crs_string(self, text: str) -> None:
+        dlg = self.main_window._crs_creator_dialog
+        dlg._ui.pedit_crs_string.setPlainText(text)
+
+    @run_in_wiser_decorator
+    def crs_creator_set_string_crs_name(self, name: str) -> None:
+        dlg = self.main_window._crs_creator_dialog
+        le = dlg._ui.ledit_string_crs_name
+        le.clear()
+        QTest.keyClicks(le, name)
+        le.editingFinished.emit()
+
+    @run_in_wiser_decorator
+    def crs_creator_press_validate_string(self) -> None:
+        dlg = self.main_window._crs_creator_dialog
+        QTest.mouseClick(dlg._ui.btn_validate_crs_string, Qt.LeftButton)
+
+    @run_in_wiser_decorator
+    def crs_creator_press_add_string(self) -> None:
+        dlg = self.main_window._crs_creator_dialog
+        QTest.mouseClick(dlg._ui.btn_add_crs_string, Qt.LeftButton)
+
+    @run_in_wiser_decorator
+    def crs_creator_get_string_result(self) -> str:
+        dlg = self.main_window._crs_creator_dialog
+        return dlg._ui.pedit_crs_string_result.toPlainText()
+
+    @run_in_wiser_decorator
+    def crs_creator_string_add_enabled(self) -> bool:
+        dlg = self.main_window._crs_creator_dialog
+        return dlg._ui.btn_add_crs_string.isEnabled()
+
+    @run_in_wiser_decorator
+    def crs_creator_get_string_crs_name(self) -> str:
+        dlg = self.main_window._crs_creator_dialog
+        return dlg._ui.ledit_string_crs_name.text().strip()
+
+    @run_in_wiser_decorator
+    def crs_creator_get_crs_string(self) -> str:
+        dlg = self.main_window._crs_creator_dialog
+        return dlg._ui.pedit_crs_string.toPlainText()
+
     # ==========================================
     # region Similarity Transform
     # ==========================================

--- a/src/tests/test_crs_creator_gui.py
+++ b/src/tests/test_crs_creator_gui.py
@@ -301,6 +301,106 @@ class TestCRSCreator(unittest.TestCase):
 
         self.assertTrue(np.allclose(test_geo_transform, ground_truth_geo_transform))
 
+    # ------------------------------------------------------------------
+    # "From CRS String" tab
+    # ------------------------------------------------------------------
+
+    # A minimal, valid WKT (WGS 84 geographic) used across the string-tab tests.
+    VALID_WKT = (
+        'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],'
+        'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]'
+    )
+
+    def test_string_tab_validate_valid(self):
+        """A valid CRS string validates, reports success, and enables Add."""
+        self.test_model.open_crs_creator()
+        self.test_model.crs_creator_select_string_tab()
+
+        self.test_model.crs_creator_set_crs_string(self.VALID_WKT)
+        self.test_model.crs_creator_press_validate_string()
+
+        result = self.test_model.crs_creator_get_string_result()
+        self.assertIn("Valid", result)
+        self.assertTrue(self.test_model.crs_creator_string_add_enabled())
+
+    def test_string_tab_validate_epsg_code(self):
+        """An authority code (EPSG:4326) is accepted, not just full WKT."""
+        self.test_model.open_crs_creator()
+        self.test_model.crs_creator_select_string_tab()
+
+        self.test_model.crs_creator_set_crs_string("EPSG:4326")
+        self.test_model.crs_creator_press_validate_string()
+
+        self.assertIn("Valid", self.test_model.crs_creator_get_string_result())
+        self.assertTrue(self.test_model.crs_creator_string_add_enabled())
+
+    def test_string_tab_validate_invalid(self):
+        """A garbage string reports an error, leaves Add disabled, stores nothing."""
+        self.test_model.open_crs_creator()
+        self.test_model.crs_creator_select_string_tab()
+
+        self.test_model.crs_creator_set_crs_string("this is not a CRS")
+        self.test_model.crs_creator_press_validate_string()
+
+        result = self.test_model.crs_creator_get_string_result()
+        self.assertIn("Invalid", result)
+        self.assertFalse(self.test_model.crs_creator_string_add_enabled())
+        self.assertNotIn("bad_crs", self.test_model.app_state.get_user_created_crs())
+
+    def test_string_tab_add_persists_crs(self):
+        """Validating + naming + Add stores a usable CRS in ApplicationState."""
+        name = "wkt_crs"
+        self.test_model.open_crs_creator()
+        self.test_model.crs_creator_select_string_tab()
+
+        self.test_model.crs_creator_set_crs_string(self.VALID_WKT)
+        self.test_model.crs_creator_press_validate_string()
+        self.test_model.crs_creator_set_string_crs_name(name)
+        self.test_model.crs_creator_press_add_string()
+
+        stored = self.test_model.app_state.get_user_created_crs()
+        self.assertIn(name, stored)
+
+        srs = stored[name][0]
+        self.assertTrue(srs.IsGeographic())
+        # The stored state remembers it came from a pasted string.
+        self.assertTrue(stored[name][1].is_string_origin)
+
+    def test_string_tab_editing_text_invalidates_validation(self):
+        """Editing the pasted text after validating disables Add again."""
+        self.test_model.open_crs_creator()
+        self.test_model.crs_creator_select_string_tab()
+
+        self.test_model.crs_creator_set_crs_string(self.VALID_WKT)
+        self.test_model.crs_creator_press_validate_string()
+        self.assertTrue(self.test_model.crs_creator_string_add_enabled())
+
+        # Any change to the text should require re-validation.
+        self.test_model.crs_creator_set_crs_string("EPSG:4326 changed")
+        self.assertFalse(self.test_model.crs_creator_string_add_enabled())
+
+    def test_string_origin_crs_reloads_into_string_tab(self):
+        """
+        Selecting a string-origin CRS as the 'Starting Ref System' switches to the
+        string tab and repopulates the pasted text rather than the param fields.
+        """
+        name = "reload_wkt"
+        self.test_model.open_crs_creator()
+        self.test_model.crs_creator_select_string_tab()
+        self.test_model.crs_creator_set_crs_string(self.VALID_WKT)
+        self.test_model.crs_creator_press_validate_string()
+        self.test_model.crs_creator_set_string_crs_name(name)
+        self.test_model.crs_creator_press_add_string()
+
+        # Reopen, clear, and reload the saved CRS.
+        self.test_model.open_crs_creator()
+        self.test_model.crs_creator_press_field_reset()
+        self.test_model.crs_creator_set_starting_crs(name)
+
+        self.assertEqual("string", self.test_model.crs_creator_get_active_tab())
+        self.assertEqual(name, self.test_model.crs_creator_get_string_crs_name())
+        self.assertIn("6378137", self.test_model.crs_creator_get_crs_string())
+
 
 """
 The below code is just for testing the tests so we know the tests

--- a/src/wiser/gui/reference_creator_dialog.py
+++ b/src/wiser/gui/reference_creator_dialog.py
@@ -67,6 +67,7 @@ class CrsCreatorState:
         polar_stereo_scale: Optional[float] = None,
         polar_stereo_latitude_sign: Optional[str] = None,
         shape_type: Optional[ShapeTypes] = None,
+        source_wkt: Optional[str] = None,
     ):
         self._lon_meridian = lon_meridian
         self._proj_type = proj_type
@@ -79,6 +80,11 @@ class CrsCreatorState:
         self._polar_stereo_scale = polar_stereo_scale
         self._polar_stereo_latitude_sign = polar_stereo_latitude_sign
         self._shape_type = shape_type
+        # When set, this CRS was built by pasting a raw CRS string on the "From
+        # CRS String" tab rather than from the parameter fields.  The stored WKT
+        # lets the dialog reload it into the string tab instead of trying (and
+        # failing) to drive the parameter widgets.
+        self._source_wkt = source_wkt
 
     @property
     def lon_meridian(self) -> Optional[float]:
@@ -124,6 +130,14 @@ class CrsCreatorState:
     def shape_type(self) -> Optional[str]:
         return self._shape_type
 
+    @property
+    def source_wkt(self) -> Optional[str]:
+        return self._source_wkt
+
+    @property
+    def is_string_origin(self) -> bool:
+        return self._source_wkt is not None
+
 
 class ReferenceCreatorDialog(QDialog):
     def __init__(self, app_state: ApplicationState, parent=None):
@@ -150,6 +164,9 @@ class ReferenceCreatorDialog(QDialog):
         self._current_starting_crs_name: Optional[str] = None
         self._crs_name: Optional[str] = None
 
+        # The last CRS successfully parsed on the "From CRS String" tab, if any.
+        self._validated_string_srs: Optional[osr.SpatialReference] = None
+
         # Initialize UI
         self._init_user_created_crs()
         self._init_projection_chooser()
@@ -163,6 +180,7 @@ class ReferenceCreatorDialog(QDialog):
         self._init_reset_button()
         self._init_create_crs_button()
         self._init_extra_polar_stereo_params()
+        self._init_crs_string_tab()
 
     def _init_extra_polar_stereo_params(self):
         # Initialize the central lat cbox
@@ -241,6 +259,14 @@ class ReferenceCreatorDialog(QDialog):
         ):
             le.clear()
 
+        # Clear the "From CRS String" tab too, if it has been built yet.
+        if hasattr(self._ui, "pedit_crs_string"):
+            self._validated_string_srs = None
+            self._ui.pedit_crs_string.clear()
+            self._ui.ledit_string_crs_name.clear()
+            self._ui.pedit_crs_string_result.clear()
+            self._ui.btn_add_crs_string.setEnabled(False)
+
         # Put the "Starting CRS" combo back to "(None)"
         cbox = self._ui.cbox_user_crs
         none_idx = cbox.findText(self.tr(NO_CRS_NAME))
@@ -261,6 +287,140 @@ class ReferenceCreatorDialog(QDialog):
             raise AttributeError("Create-CRS button not found in UI")
 
         create_btn.clicked.connect(self._create_crs)
+
+    # region CRS-string tab
+
+    def _init_crs_string_tab(self):
+        """
+        Wire up the "From CRS String" tab, where a user pastes a raw CRS
+        definition (WKT, PROJ, or an authority code such as ``EPSG:4326``) and
+        checks whether WISER can load it.
+        """
+        # Restrict the name to the same character set as the parameter tab.
+        regex = QRegularExpression(r"^[A-Za-z0-9_]+$")
+        validator = QRegularExpressionValidator(regex, self._ui.ledit_string_crs_name)
+        self._ui.ledit_string_crs_name.setValidator(validator)
+
+        self._ui.btn_validate_crs_string.clicked.connect(self._on_validate_crs_string)
+        self._ui.btn_add_crs_string.clicked.connect(self._on_add_crs_string)
+
+        # Any edit to the pasted text invalidates the previous validation.
+        self._ui.pedit_crs_string.textChanged.connect(self._on_crs_string_text_changed)
+
+        self._validated_string_srs = None
+        self._ui.btn_add_crs_string.setEnabled(False)
+
+    def _build_srs_from_string(self, text: str):
+        """
+        Try to build an ``osr.SpatialReference`` from a user-supplied CRS
+        string.  Returns ``(srs, None)`` on success or ``(None, error)`` on
+        failure, where ``error`` is a human-readable message.
+        """
+        srs = osr.SpatialReference()
+        try:
+            # SetFromUserInput accepts WKT (1 & 2), PROJ strings, and authority
+            # codes like "EPSG:4326" - the broadest entry point GDAL offers.
+            err = srs.SetFromUserInput(text)
+        except Exception as exc:  # GDAL may raise when exceptions are enabled
+            return None, str(exc)
+
+        if err != 0:
+            return None, "GDAL could not interpret the given CRS string."
+
+        # Match the axis convention the parameter path (and the georeferencer)
+        # uses, so the CRS behaves the same everywhere in WISER.
+        srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        return srs, None
+
+    def _describe_srs(self, srs: osr.SpatialReference) -> str:
+        """Build a short success summary for a validated CRS."""
+        name = srs.GetName() or "(unnamed)"
+        if srs.IsProjected():
+            kind = "Projected CRS"
+        elif srs.IsGeographic():
+            kind = "Geographic CRS"
+        else:
+            kind = "CRS"
+
+        lines = [
+            "Valid — WISER can load this CRS.",
+            "",
+            f"Name: {name}",
+            f"Type: {kind}",
+        ]
+        authority = srs.GetAuthorityName(None)
+        code = srs.GetAuthorityCode(None)
+        if authority and code:
+            lines.append(f"Authority: {authority}:{code}")
+        return "\n".join(lines)
+
+    def _set_string_result(self, text: str, ok: bool) -> None:
+        """Show ``text`` in the result box, coloured green (ok) or red (error)."""
+        self._ui.pedit_crs_string_result.setPlainText(text)
+        color = "#137333" if ok else "#a50e0e"
+        self._ui.pedit_crs_string_result.setStyleSheet(f"color: {color};")
+
+    def _on_crs_string_text_changed(self) -> None:
+        """Invalidate any prior validation whenever the pasted text changes."""
+        self._validated_string_srs = None
+        self._ui.btn_add_crs_string.setEnabled(False)
+
+    def _on_validate_crs_string(self) -> None:
+        """Validate the pasted CRS string and report success or the error."""
+        self._validated_string_srs = None
+        self._ui.btn_add_crs_string.setEnabled(False)
+
+        text = self._ui.pedit_crs_string.toPlainText().strip()
+        if not text:
+            self._set_string_result("Please paste a CRS string to validate.", ok=False)
+            return
+
+        srs, error = self._build_srs_from_string(text)
+        if srs is None:
+            self._set_string_result(f"Invalid — WISER cannot load this CRS.\n\n{error}", ok=False)
+            return
+
+        self._validated_string_srs = srs
+        self._ui.btn_add_crs_string.setEnabled(True)
+        self._set_string_result(self._describe_srs(srs), ok=True)
+
+    def _on_add_crs_string(self) -> bool:
+        """
+        Persist the validated string CRS into ``ApplicationState`` under the
+        name in the name field.  Returns ``True`` on success.
+        """
+        name = self._ui.ledit_string_crs_name.text().strip()
+        if not name:
+            QMessageBox.warning(
+                self,
+                self.tr("Missing value"),
+                self.tr("Please supply a name for the CRS."),
+            )
+            return False
+
+        srs = self._validated_string_srs
+        if srs is None:
+            # The user may click Add without validating first - try now.
+            text = self._ui.pedit_crs_string.toPlainText().strip()
+            srs, error = self._build_srs_from_string(text)
+            if srs is None:
+                self._set_string_result(f"Invalid — WISER cannot load this CRS.\n\n{error}", ok=False)
+                QMessageBox.warning(
+                    self,
+                    self.tr("Invalid CRS"),
+                    self.tr("The CRS string could not be validated. Fix it and try again."),
+                )
+                return False
+            self._validated_string_srs = srs
+            self._set_string_result(self._describe_srs(srs), ok=True)
+
+        state = self._export_creator_state(source_wkt=srs.ExportToWkt())
+        self._app_state.add_user_created_crs(name, srs, state)
+        self._update_user_created_crs_cbox()
+        self._switch_user_crs_cbox_selection(name)
+        return True
+
+    # endregion
 
     def _init_user_created_crs(self):
         """
@@ -358,6 +518,18 @@ class ReferenceCreatorDialog(QDialog):
                     cbox.blockSignals(True)
                     cbox.setCurrentIndex(old_idx)
                     cbox.blockSignals(False)
+            return
+
+        # A CRS that was created by pasting a raw string has no parameter state
+        # to reload into the form.  Show it on the "From CRS String" tab
+        # instead of driving the parameter widgets (which would fail).
+        if creator_state is not None and creator_state.is_string_origin:
+            self._ui.tabWidget.setCurrentWidget(self._ui.page_string)
+            self._ui.ledit_string_crs_name.setText(name)
+            self._ui.pedit_crs_string.setPlainText(creator_state.source_wkt)
+            self._on_validate_crs_string()
+            self._crs_name = name
+            self._current_starting_crs_name = name
             return
 
         # Convert to pyproj for convenient interrogation
@@ -835,7 +1007,7 @@ class ReferenceCreatorDialog(QDialog):
 
         self._switch_user_crs_cbox_selection(self._crs_name)
 
-    def _export_creator_state(self) -> CrsCreatorState:
+    def _export_creator_state(self, source_wkt: Optional[str] = None) -> CrsCreatorState:
         crs_creator_state = CrsCreatorState(
             lon_meridian=self._lon_meridian,
             proj_type=self._proj_type,
@@ -848,10 +1020,19 @@ class ReferenceCreatorDialog(QDialog):
             polar_stereo_scale=self._polar_stereo_scale,
             polar_stereo_latitude_sign=self._polar_stereo_latitude_sign,
             shape_type=self._shape_type,
+            source_wkt=source_wkt,
         )
         return crs_creator_state
 
     def accept(self):
-        self._create_crs()
+        # Which builder runs depends on the active tab: the parameter form or
+        # the pasted-string tab.
+        if self._ui.tabWidget.currentWidget() is self._ui.page_string:
+            if not self._on_add_crs_string():
+                # Validation/name problem - keep the dialog open so the user
+                # can fix it rather than silently discarding their input.
+                return
+        else:
+            self._create_crs()
 
         super().accept()

--- a/src/wiser/gui/ui_files/reference_system_creator.ui
+++ b/src/wiser/gui/ui_files/reference_system_creator.ui
@@ -25,7 +25,15 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="page_params">
+      <attribute name="title">
+       <string>From Parameters</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
      <item>
       <layout class="QGridLayout" name="gridLayout">
        <property name="sizeConstraint">
@@ -374,7 +382,75 @@
        </item>
       </layout>
      </item>
-    </layout>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_string">
+      <attribute name="title">
+       <string>From CRS String</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="vlayout_string">
+       <item>
+        <widget class="QLabel" name="lbl_string_instructions">
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>Paste a CRS definition string (WKT, PROJ, or an authority code such as EPSG:4326) and click Validate to check whether WISER can load it. If it is valid you can give it a name and add it to WISER.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlayout_string_name">
+         <item>
+          <widget class="QLabel" name="lbl_string_crs_name">
+           <property name="text">
+            <string>Ref System Name</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="ledit_string_crs_name"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QPlainTextEdit" name="pedit_crs_string">
+         <property name="placeholderText">
+          <string>Paste WKT / PROJ / EPSG:xxxx here…</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="hlayout_string_buttons">
+         <item>
+          <widget class="QPushButton" name="btn_validate_crs_string">
+           <property name="text">
+            <string>Validate</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btn_add_crs_string">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Add to WISER</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QPlainTextEdit" name="pedit_crs_string_result">
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
## What does this change do?
If a user has a WKT string describing a CRS or SRS, they should be able to load it in WISER. This PR adds that feature. 

Closes #660

Closes #696

## What type of PR is this? (check all applicable) 
- [x] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
<!-- Context, problem solved, issue/ticket link -->

## How did you implement the change?
<!-- High-level approach -->

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [ ] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->