### PR TITLE
feat: Better status updates and ability to cancel dataset save operation

### DIFF
--- a/src/tests/test_mosaic_view_gui.py
+++ b/src/tests/test_mosaic_view_gui.py
@@ -96,7 +96,7 @@ class TestMosaicViewGui(unittest.TestCase):
             "scene was not ingested within the timeout",
         )
 
-    def _settle_reads(self, view, timeout_ms=10000, step_ms=40):
+    def _settle_reads(self, view, timeout_ms=60000, step_ms=40):
         """
         Pump the event loop until any debounced/in-flight tile read has completed.
 

--- a/src/tests/test_save_dataset.py
+++ b/src/tests/test_save_dataset.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -5,11 +7,14 @@ import numpy as np
 import gc
 import tests.context
 
+from PySide6.QtTest import QTest
+
 from test_utils.test_model import WiserTestModel
 from wiser.raster.dataset import RasterDataSet, band_info_list_equal
-from wiser.raster.dataset_impl import NetCDF_GDALRasterDataImpl
+from wiser.raster.dataset_impl import ENVI_GDALRasterDataImpl, NetCDF_GDALRasterDataImpl
 from wiser.raster.loader import RasterDataLoader
 from wiser.raster.utils import spectral_unit_to_string
+from wiser.utils.progress import ProgressCancelled, ProgressReporter
 
 ID_SET_1 = 6174
 ID_SET_2 = 42
@@ -37,6 +42,16 @@ class TestSaveDataset(unittest.TestCase):
             np.asarray(expected_ma.data)[valid],
             equal_nan=True,
         )
+
+    def _wait_for(self, predicate, timeout_ms: int = 180000, step_ms: int = 50) -> bool:
+        """Pump the Qt event loop until ``predicate()`` is true or the timeout elapses."""
+        waited = 0
+        while waited < timeout_ms:
+            if predicate():
+                return True
+            QTest.qWait(step_ms)
+            waited += step_ms
+        return predicate()
 
     def _assert_equal_or_both_none_or_empty(self, left, right, msg=None) -> None:
         """``None`` and ``''`` compare equal to each other; otherwise require ``==``."""
@@ -77,13 +92,17 @@ class TestSaveDataset(unittest.TestCase):
 
         reopened = None
         try:
-            future = self.test_model.main_window._save_dataset_helper(
+            # The save now runs on a worker thread via run_with_progress and reports
+            # completion through the returned runner (its `_done` flag flips on the GUI
+            # thread once the threaded write finishes).
+            runner = self.test_model.main_window._save_dataset_helper(
                 dataset=dataset,
                 path=str(save_path),
                 format="ENVI",
                 config=config,
             )
-            future.result(timeout=180)
+            completed = self._wait_for(lambda: getattr(runner, "_done", False))
+            self.assertTrue(completed, "save did not complete within timeout")
             self.test_model.app.processEvents()
 
             self.assertTrue(save_path.exists())
@@ -217,3 +236,48 @@ class TestSaveDataset(unittest.TestCase):
             / "netcdf_reflectance_saved.img"
         ).resolve()
         self._run_save_roundtrip_test(dataset, save_path)
+
+    def _make_small_float_dataset(self, num_bands: int = 4) -> RasterDataSet:
+        loader = RasterDataLoader()
+        cache = self.test_model.app_state.get_cache()
+        arr = np.arange(num_bands * 3 * 5, dtype=np.float32).reshape(num_bands, 3, 5)
+        dataset = loader.dataset_from_numpy_array(arr, cache)
+        dataset.set_id(ID_SET_1)
+        return dataset
+
+    def test_save_dataset_reports_monotonic_per_band_progress(self):
+        """The writer reports non-decreasing progress that reaches 1.0, with at least
+        one report per band."""
+        dataset = self._make_small_float_dataset(num_bands=4)
+        with tempfile.TemporaryDirectory() as tmp:
+            save_path = os.path.join(tmp, "progress_test.img")
+            fractions = []
+            reporter = ProgressReporter(sink=lambda frac, _msg: fractions.append(frac))
+
+            ENVI_GDALRasterDataImpl.save_dataset_as(dataset, save_path, {}, progress=reporter)
+
+            self.assertTrue(fractions, "no progress was reported")
+            self.assertEqual(fractions, sorted(fractions), "progress must be non-decreasing")
+            self.assertLessEqual(max(fractions), 1.0)
+            self.assertAlmostEqual(fractions[-1], 1.0, places=6)
+            # One report per written band, plus the trailing header report.
+            self.assertGreaterEqual(len(fractions), dataset.num_bands())
+
+    def test_save_dataset_cancellation_removes_partial_files(self):
+        """A cancelled save raises ProgressCancelled and leaves no partial output."""
+        dataset = self._make_small_float_dataset(num_bands=4)
+        with tempfile.TemporaryDirectory() as tmp:
+            save_path = os.path.join(tmp, "cancel_test.img")
+            # Report "already cancelled" so the first band-boundary checkpoint raises,
+            # after GDAL has already created the (now partial) output file.
+            reporter = ProgressReporter(sink=lambda frac, _msg: None, is_cancelled=lambda: True)
+
+            with self.assertRaises(ProgressCancelled):
+                ENVI_GDALRasterDataImpl.save_dataset_as(dataset, save_path, {}, progress=reporter)
+
+            gc.collect()
+            for fname in ENVI_GDALRasterDataImpl.get_save_filenames(save_path):
+                self.assertFalse(
+                    os.path.exists(fname),
+                    f"cancelled save left a partial file behind: {fname}",
+                )

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -37,7 +37,7 @@ from wiser.raster.spectrum import (
     SpectrumAtPoint,
     SpectrumAverageMode,
 )
-from wiser.utils.primitives import ExternalRasterHandle, PriorityClass
+from wiser.utils.primitives import PriorityClass
 from wiser.utils.task_stage_utils import get_save_external_dataset_pipeline
 from wiser.utils.task_system import SemanticTask
 from . import bug_reporting
@@ -56,6 +56,7 @@ from .import_spectra_text import ImportSpectraTextDialog
 from .infoview import DatasetInfoView
 from .main_view import MainViewWidget
 from .pixel_value_widget import PixelValueWidget
+from .progress_task import run_with_progress
 from .rasterpane import RecenterMode
 from .reference_creator_dialog import ReferenceCreatorDialog
 from .mosaic_dialog import SeamlessMosaicDialog
@@ -571,22 +572,29 @@ class DataVisualizerApp(QMainWindow):
         """
         We use the dataset helper to consolidate the actual saving functionality
         into one function. This way we can more easily test the saving functionality.
+
+        The save runs on a worker thread via ``run_with_progress`` so it can report
+        fine-grained per-band progress (and be cancelled) through both a progress
+        dialog and the Activity Monitor.
         """
-        dataset_ref = self._app_services.storage_service.register_external(
-            ExternalRasterHandle(dataset_obj=dataset)
-        )
-        save_task = SaveDatasetSemanticTask(
-            app_state=self._app_state,
-            dataset=dataset,
-            input_ref=dataset_ref,
-            path=path,
-            format=format,
-            config=config,
-        )
-        task_plan = self._app_services.task_planner.plan_semantic_task(save_task)
-        return self._app_services.task_manager.register_and_submit_task_plan(
-            self._app_services.scheduler,
-            task_plan,
+        dataset_id = dataset.get_id()
+
+        def _do_save(progress):
+            self._app_state.get_loader().save_dataset_as(dataset, path, format, config, progress=progress)
+
+        def _on_ok(_result):
+            # Mark the dataset clean now that its contents are safely on disk.
+            if dataset_id is not None and self._app_state.has_dataset(dataset_id):
+                self._app_state.get_dataset(dataset_id).set_dirty(False)
+
+        return run_with_progress(
+            self._app_services,
+            self,
+            self.tr("Saving dataset"),
+            _do_save,
+            on_success=_on_ok,
+            on_error=lambda msg: logger.error("Save dataset failed: %s", msg),
+            meta={"Dataset": dataset.get_name(), "Path": path},
         )
 
     def _on_close_dataset(self, ds_id: int):

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -36,6 +36,7 @@ from PySide6.QtWidgets import *
 import difflib
 
 from wiser.gui.subdataset_file_opener_dialog import SubdatasetFileOpenerDialog
+from wiser.utils.progress import ProgressCancelled, ProgressReporter
 
 logger = logging.getLogger(__name__)
 
@@ -1780,7 +1781,12 @@ class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
         src_dataset: "RasterDataSet",
         path: str,
         options: Optional[Dict[str, Any]] = None,
+        progress: Optional[ProgressReporter] = None,
     ) -> "ENVI_GDALRasterDataImpl":
+        # A no-op reporter keeps this callable from non-GUI/test contexts without
+        # threading a real reporter through every caller.
+        progress = progress or ProgressReporter()
+
         def map_default_display_bands(display_bands, include_bands):
             # Build a mapping of source-image band-indexes to
             # destination-image band-indexes
@@ -1951,62 +1957,86 @@ class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
         dst_bad_bands = []
         dst_index = 1
 
+        # Band writes dominate the runtime; reserve a small slice for the trailing
+        # header write so the reported progress reaches 1.0 only once we are done.
+        bands_progress, header_progress = progress.split((0.97, "Saving bands"), (0.03, "Writing header"))
+
         chunk_size = 0
-        for band_info in src_dataset.band_list():
-            src_index = band_info["index"]
+        bands_written = 0
+        try:
+            for band_info in src_dataset.band_list():
+                # Cooperative cancellation checkpoint at each band boundary.
+                bands_progress.raise_if_cancelled()
 
-            # If band is to be excluded, continue.
-            if not dst_include_bands[src_index]:
-                # print(f'Skipping source-band {src_index}; excluded from destination.')
-                continue
+                src_index = band_info["index"]
 
-            dst_band = dst_gdal_dataset.GetRasterBand(dst_index)
-            src_data = src_dataset.get_band_data(src_index)
+                # If band is to be excluded, continue.
+                if not dst_include_bands[src_index]:
+                    # print(f'Skipping source-band {src_index}; excluded from destination.')
+                    continue
 
-            # Apply spatial subsetting here
+                dst_band = dst_gdal_dataset.GetRasterBand(dst_index)
+                src_data = src_dataset.get_band_data(src_index)
 
-            # print(f'Source-array shape:  {src_data.shape}')
-            dst_data = src_data[
-                src_offset_y : src_offset_y + dst_height,
-                src_offset_x : src_offset_x + dst_width,
-            ]
-            # print(f"Destination-array size: {dst_data.size}")
-            # print(f'Destination-array shape:  {dst_data.shape}')
-            if dst_data.dtype != band_write_dtype:
-                dst_data = np.asarray(dst_data, dtype=band_write_dtype)
-            dst_band.WriteArray(dst_data, 0, 0)
-            chunk_size += dst_data.size
-            if chunk_size >= CHUNK_WRITE_SIZE:
-                chunk_size = 0
-                dst_gdal_dataset.FlushCache()
+                # Apply spatial subsetting here
 
-            # Metadata for the band
+                # print(f'Source-array shape:  {src_data.shape}')
+                dst_data = src_data[
+                    src_offset_y : src_offset_y + dst_height,
+                    src_offset_x : src_offset_x + dst_width,
+                ]
+                # print(f"Destination-array size: {dst_data.size}")
+                # print(f'Destination-array shape:  {dst_data.shape}')
+                if dst_data.dtype != band_write_dtype:
+                    dst_data = np.asarray(dst_data, dtype=band_write_dtype)
+                dst_band.WriteArray(dst_data, 0, 0)
+                chunk_size += dst_data.size
+                if chunk_size >= CHUNK_WRITE_SIZE:
+                    chunk_size = 0
+                    dst_gdal_dataset.FlushCache()
 
-            # TODO(donnie):  This fails with an error.  Not supported by ENVI format?
-            # if dst_data_ignore is not None:
-            #     dst_band.SetNoDataValue(float(dst_data_ignore))
+                bands_written += 1
+                bands_progress.report(bands_written, dst_bands, f"Saving band {bands_written} of {dst_bands}")
 
-            if "wavelength_str" in band_info:
-                dst_wavelengths.append(band_info["wavelength_str"])
+                # Metadata for the band
 
-                if dst_wavelength_units is None:
-                    dst_wavelength_units = band_info["wavelength_units"]
+                # TODO(donnie):  This fails with an error.  Not supported by ENVI format?
+                # if dst_data_ignore is not None:
+                #     dst_band.SetNoDataValue(float(dst_data_ignore))
 
-                # TODO(donnie):  This check doesn't play well when we are
-                #     _changing_ the unit-type from the source dataset's unit-
-                #     type to some other unit-type.  Not sure of the best
-                #     solution
-                # else:
-                #     if band_info['wavelength_units'] != dst_wavelength_units:
-                #         print('WARNING:  wavelength_units differs across bands')
+                if "wavelength_str" in band_info:
+                    dst_wavelengths.append(band_info["wavelength_str"])
 
-            dst_bad_bands.append(src_bad_bands[src_index])
+                    if dst_wavelength_units is None:
+                        dst_wavelength_units = band_info["wavelength_units"]
 
-            dst_index += 1
+                    # TODO(donnie):  This check doesn't play well when we are
+                    #     _changing_ the unit-type from the source dataset's unit-
+                    #     type to some other unit-type.  Not sure of the best
+                    #     solution
+                    # else:
+                    #     if band_info['wavelength_units'] != dst_wavelength_units:
+                    #         print('WARNING:  wavelength_units differs across bands')
+
+                dst_bad_bands.append(src_bad_bands[src_index])
+
+                dst_index += 1
+        except ProgressCancelled:
+            # (Rebind to None rather than `del` so the name stays bound for the
+            # linter's control-flow analysis on the normal path below.)
+            dst_gdal_dataset = None
+            for fname in ENVI_GDALRasterDataImpl.get_save_filenames(path):
+                try:
+                    os.remove(fname)
+                except OSError:
+                    pass
+            raise
 
         # Make sure all the data is written to the file.
         dst_gdal_dataset.FlushCache()
         del dst_gdal_dataset
+
+        header_progress.report_fraction(1.0, "Writing header")
 
         # Generate the header file now.
         # TODO(donnie):  What to do if an exception is raised???

--- a/src/wiser/raster/loader.py
+++ b/src/wiser/raster/loader.py
@@ -1,11 +1,13 @@
 import logging
 import os
 
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 import numpy as np
 
 from osgeo import gdal
+
+from wiser.utils.progress import ProgressReporter
 
 from .dataset import RasterDataSet
 from .dataset_impl import (
@@ -151,10 +153,15 @@ class RasterDataLoader:
             raise ValueError(f'Unsupported format "{format}"')
 
     def save_dataset_as(
-        self, dataset: RasterDataSet, path: str, format: str, config: Dict[str, Any]
+        self,
+        dataset: RasterDataSet,
+        path: str,
+        format: str,
+        config: Dict[str, Any],
+        progress: Optional[ProgressReporter] = None,
     ) -> ENVI_GDALRasterDataImpl:
         if format == "ENVI":
-            return ENVI_GDALRasterDataImpl.save_dataset_as(dataset, path, config)
+            return ENVI_GDALRasterDataImpl.save_dataset_as(dataset, path, config, progress=progress)
         else:
             raise ValueError(f'Unsupported format "{format}"')
 


### PR DESCRIPTION
## What does this change do?
Adds more granular status updates to save dataset (saving by band and saving header). And adds ability to ancel the operation. 

Closes #701 

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [x] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
Better user experience.

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [ ] yes
- [x] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed