### PR TITLE
feat(mosaic): Allow mosaic to have scenes without a CRS

### DIFF
--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -64,7 +64,7 @@ jobs:
     # If triggered by workflow_run, only run when upstream succeeded.
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     needs: [lint]
     defaults:
         run:

--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -13,9 +13,12 @@ per-scene contrast stretch cached at ingest — see [Stretch
 bounds](#stretch-bounds-compute_stretch_bounds-mosaic_ingestionpy)), the **control panel**
 (drag-to-reorder z-order, resolution mode, resampling method, and the band-metadata
 chooser), the **full-resolution export path** (streaming ENVI compositor on the
-common grid — see [The Export Path](#the-export-path)), and **in-place scene
+common grid — see [The Export Path](#the-export-path)), **in-place scene
 re-georeferencing** (right-click → warp → swap; see [Re-georeferencing a Scene In
-Place](#re-georeferencing-a-scene-in-place)) are implemented and wired into the GUI.
+Place](#re-georeferencing-a-scene-in-place)), and **pending (disabled) scenes**
+(non-georeferenced or CRS-incompatible scenes carried in the list until georeferenced;
+see [Pending Scenes](#pending-scenes-disabled-scenes)) are implemented and wired into
+the GUI.
 ```
 
 For the design rationale and full child-issue breakdown, see `EPIC_seamless_mosaic.md`
@@ -58,8 +61,8 @@ SRS/geotransform/nodata/band metadata from the dataset object, not from its `_im
 | `src/wiser/gui/mosaic_pane.py` | `MosaicPane` — control panel; ingestion orchestration, scene list (drag-reorder + visibility), resolution / CRS / resampling / band-metadata controls |
 | `src/wiser/gui/mosaic_view.py` | `MosaicView` — the two-layer paint surface (pixel + vector), currently a stub |
 | `src/wiser/gui/mosaic_crs_dialog.py` | `ReprojectPromptDialog` — modal target-CRS chooser |
-| `src/wiser/raster/mosaic_controller.py` | `MosaicController`, `MosaicScene`, `CommonGrid`, `ResolutionMode` — the non-GUI model |
-| `src/wiser/raster/mosaic_ingestion.py` | `validate_scene`, `build_overviews`, `compute_stretch_bounds`, `compute_footprint_wkt` — Qt-free ingestion gates |
+| `src/wiser/raster/mosaic_controller.py` | `MosaicController`, `MosaicScene`, `CommonGrid`, `ResolutionMode`, `ScenePendingReason` — the non-GUI model (incl. the live/pending classifier) |
+| `src/wiser/raster/mosaic_ingestion.py` | `is_dataset_georeferenced`, `validate_scene_addable`, `validate_scene`, `build_overviews`, `compute_stretch_bounds`, `compute_footprint_wkt` — Qt-free ingestion gates |
 | `src/wiser/raster/mosaic_compositor.py` | `render_scene_argb` — Qt-free per-scene warp→RGBA renderer (alpha = validity) for the pixel layer |
 | `src/wiser/raster/mosaic_export.py` | `export_mosaic` — warps each scene onto the common grid and streams the mosaic to ENVI |
 | `src/wiser/raster/mosaic_materialize.py` | `SceneMaterializer`, `materialize_to_tiled_geotiff` — the object-model adapter |
@@ -167,6 +170,10 @@ classDiagram
         +scene_crs_summary()
         +scene_crs_choices()
         +validate_target_crs(wkt)
+        +is_scene_pending(scene) bool
+        +scene_pending_reason(scene) ScenePendingReason
+        +live_scenes() List~MosaicScene~
+        +has_pending_scenes() bool
     }
 
     class MosaicScene {
@@ -229,10 +236,13 @@ sequenceDiagram
     participant Ctrl as MosaicController
 
     User->>Pane: click "Add Scene…"
-    Pane->>Pane: validate_scene(dataset, existing_scenes)
-    alt validation fails
+    Pane->>Pane: validate_scene_addable(dataset, existing_scenes)
+    alt duplicate / band-count mismatch
         Pane-->>User: QMessageBox.warning
-    else validation passes
+    else not georeferenced
+        Pane->>Ctrl: add_scene(MosaicScene(dataset)) [pending placeholder]
+        Pane->>Pane: _refresh_scene_list() [warning icon + tooltip]
+    else georeferenced (may still land pending)
         Pane->>Sched: run_with_progress(_ingest_scene, dataset, materializer)
         Note over Pane: ProgressDialog shown, block_window disabled
         Sched->>Ingest: run on scheduler thread
@@ -249,20 +259,35 @@ sequenceDiagram
     end
 ```
 
-### Validation (`validate_scene`, `mosaic_ingestion.py`)
+### Validation (`validate_scene_addable`, `mosaic_ingestion.py`)
 
 Runs synchronously on the **main thread** before any background work starts, so
-rejection is immediate (no spinner churn). Rejects:
+rejection is immediate (no spinner churn). The pane calls **`validate_scene_addable`**,
+which enforces only the two gates that make a scene *fundamentally un-addable*
+regardless of georeferencing:
 
-- **Ungeoreferenced scenes** — geotransform is GDAL's identity sentinel.
-- **No SRS** — empty/missing spatial reference.
 - **Duplicate** — the dataset is already in the mosaic (by dataset id).
 - **Band-count mismatch** — differs from the first existing scene's band count.
 
-Deliberately **not** rejected: missing nodata (a coarser, full-rectangle footprint is
-still valid) and dtype mismatches across scenes (the future compositor promotes to the
-widest common type at warp time). See `# TODO(#640)` in the source for a planned
+Being ungeoreferenced or CRS-incompatible is **no longer a rejection**: such scenes are
+added as disabled **pending** scenes (see [Pending
+Scenes](#pending-scenes-disabled-scenes)). The pane branches on
+`is_dataset_georeferenced(dataset)` (a non-identity geotransform **and** a non-empty
+SRS): a georeferenced dataset runs the full ingest pipeline below (it may still land
+pending if its CRS can't reach the target), while a non-georeferenced one is appended
+immediately as a bare `MosaicScene(dataset=...)` placeholder with **no** background work.
+
+Deliberately **not** rejected either: missing nodata (a coarser, full-rectangle
+footprint is still valid) and dtype mismatches across scenes (the compositor promotes to
+the widest common type at warp time). See `# TODO(#640)` in the source for a planned
 warn-but-allow path for band-count mismatches.
+
+```{note}
+`validate_scene` (the strict "must be immediately placeable" gate that also rejects
+ungeoreferenced / no-SRS inputs) is retained in `mosaic_ingestion.py` and now delegates
+to `is_dataset_georeferenced` + `validate_scene_addable`. The pane no longer calls it —
+it is kept as the canonical full check and for its unit tests.
+```
 
 ### Materialization (`SceneMaterializer.gdal_source`, `mosaic_materialize.py`)
 
@@ -344,13 +369,13 @@ the scene list, z-order, visibility, resolution mode, custom resolution, or targ
 flowchart TD
     A[build_common_grid] --> B{grid_dirty?}
     B -->|no| C[return cached CommonGrid]
-    B -->|yes| D{any visible scenes?}
+    B -->|yes| D{"any live scenes?<br/>(visible, non-pending)"}
     D -->|no| E[return empty CommonGrid]
-    D -->|yes| F["target = target_crs_wkt or common_scene_crs_wkt()"]
+    D -->|yes| F["target = target_crs_wkt or<br/>_common_crs_wkt(live scenes)"]
     F --> G{target resolved?}
     G -->|no| H[raise TargetCrsRequired]
-    G -->|yes| I["persist target_crs_wkt<br/>validate_target_crs(target)"]
-    I --> J["per scene: reproject footprint envelope<br/>into target CRS → union extent"]
+    G -->|yes| I["persist target_crs_wkt"]
+    I --> J["per live scene: reproject footprint envelope<br/>into target CRS → union extent"]
     J --> K["per scene: SuggestedWarpOutput resolution<br/>in target CRS (AutoCreateWarpedVRT)"]
     K --> L["pick xres/yres from ResolutionMode"]
     L --> M["north-up geotransform:<br/>(min_x, xres, 0, max_y, 0, -yres)<br/>width/height = ceil(extent / res)"]
@@ -397,10 +422,15 @@ In practice this means:
   manual **"Choose Target CRS…"** button (`MosaicPane._on_choose_target_crs`), which
   calls `_prompt_for_target_crs()` unconditionally — not gated on
   `TargetCrsRequired` — so the user can override the auto-locked target at any time.
-- `validate_target_crs()` still runs on every `build_common_grid()` call, so an
-  incoming scene that is genuinely unmappable to the locked target (e.g. no CRS at
-  all) still raises `UnmappableCrsError`, which `_ensure_common_grid` surfaces as a
-  `QMessageBox.warning` rather than a dialog.
+- **Changing the target CRS no longer rejects incompatible scenes.** `build_common_grid`
+  builds from **live** scenes only, and `_prompt_for_target_crs` sets the chosen target
+  unconditionally (it no longer calls `validate_target_crs` as a blocker). A scene the new
+  target can't reach simply becomes [pending](#pending-scenes-disabled-scenes) instead of
+  failing the change; if the choice leaves *no* live scenes, `_on_choose_target_crs` warns
+  that the preview is empty but still commits the CRS.
+
+`validate_target_crs()` and `validate_new_scene_crs()` remain on the controller (and are
+still unit-tested) but are now **advisory** — no GUI path uses them as hard gates.
 
 `_ensure_common_grid()` (`mosaic_pane.py`) is the call site, and stays a standalone
 method (not inlined into `_on_scene_ingested`) so a future resolution-mode/CRS control
@@ -422,7 +452,12 @@ flowchart TD
 
 As noted above, the `TargetCrsRequired` branch is effectively dead in the ingestion
 path today but is kept because it is the correct, defensive behavior if the locking
-assumption ever changes (e.g. a future "clear target CRS" control).
+assumption ever changes (e.g. a future "clear target CRS" control). The
+`UnmappableCrsError` branches are likewise defensive now: since the pending-scene work,
+`build_common_grid` builds from `_live_scenes()` — scenes that are *by construction*
+mappable to the target — and no longer calls `validate_target_crs`, so an incompatible
+scene becomes [pending](#pending-scenes-disabled-scenes) instead of raising here. The
+`except` clauses are retained as a safety net.
 
 ### Removal and visibility changes
 
@@ -443,12 +478,130 @@ since a prompt triggered by a *removal* would be a surprising, unrelated interru
   scene's CRS; seeds the dialog's target-CRS combo and its default selection.
 - `validate_target_crs(target_wkt)` — raises `UnmappableCrsError` naming any scene
   (by name) that cannot be transformed to the target, via
-  `wiser.raster.utils.can_transform_between_srs`.
+  `wiser.raster.utils.can_transform_between_srs`. Now **advisory** — the GUI classifies
+  incompatible scenes as pending rather than calling this as a hard gate (see [Pending
+  Scenes](#pending-scenes-disabled-scenes)).
+- `is_scene_pending(scene)` / `scene_pending_reason(scene)` — classify a scene as
+  live (`None`) or pending (`ScenePendingReason.NO_CRS` / `INCOMPATIBLE_CRS`).
+- `live_scenes()` / `has_live_scenes()` / `has_pending_scenes()` — the live/pending
+  partition used by the grid builder, overlay, compositor, and export.
 
 All SRS objects used for transforms are built with
 `OAMS_TRADITIONAL_GIS_ORDER` (long/lat, x/y axis order), matching the geotransform
 convention used throughout WISER (see the georeferencer's identical convention in
 [Georeferencer Internals](georeferencer-internals.md)).
+
+---
+
+## Pending Scenes (Disabled Scenes)
+
+**Files:** `src/wiser/raster/mosaic_controller.py` (the classifier),
+`src/wiser/raster/mosaic_ingestion.py` (the add gate), and `src/wiser/gui/mosaic_pane.py`
+(add path, list decoration, CRS change, export guard).
+
+A scene can now be added to the mosaic even when it cannot yet be placed on the common
+grid — because it is **not georeferenced**, or because its CRS **cannot be transformed**
+into the mosaic's locked target CRS. Rather than rejecting it at Add-Scene time, the
+mosaic carries it as a **pending** (disabled) scene: it stays in the list, greyed out with
+a warning icon, and is excluded from the grid, the overlay, the pixel compositor, and
+export until it is georeferenced into a compatible CRS. This lets a user assemble a
+working set — including scenes they still intend to register — without the add being a
+dead end.
+
+### Live vs. pending is a derived classification, not stored state
+
+There is no `pending` flag on `MosaicScene`. A scene's status is **computed on demand**
+from the controller's current state by `scene_pending_reason(scene)`, so it re-evaluates
+for free whenever the target CRS or the scene's own georeferencing changes — no bookkeeping
+to keep in sync. A scene is pending when:
+
+- **`ScenePendingReason.NO_CRS`** — it never went through ingestion (no `gdal_path` /
+  `footprint_wkt`). `_is_ingested` is the controller's Qt-free proxy for "georeferenced":
+  the pane only runs the ingest pipeline on georeferenced datasets, so the presence of
+  ingestion artifacts *is* the georeferenced signal (and it works with the lightweight
+  dataset stand-ins used in tests, without re-reading a geotransform).
+- **`ScenePendingReason.INCOMPATIBLE_CRS`** — it is ingested, but its SRS cannot be
+  transformed (`can_transform_between_srs`) into the **resolved target CRS**.
+
+`_resolved_target_wkt()` defines what "compatible" is measured against: the explicit
+`_target_crs_wkt` if one is set (or was auto-locked by the first grid build), otherwise the
+shared CRS of the *georeferenced* visible scenes. When it returns `None` (empty mosaic,
+all-pending mosaic, or georeferenced scenes that disagree with no explicit target), an
+ingested scene is treated as **live** — there is nothing yet to be incompatible with, and a
+multi-CRS disagreement is still the existing `TargetCrsRequired` path, unchanged.
+
+### The live-scene partition drives everything downstream
+
+`_live_scenes()` = visible scenes that are not pending, and it is the input to every
+grid-consuming operation:
+
+- `build_common_grid()` unions extents and picks resolution from `_live_scenes()` only, so
+  a pending scene never perturbs the output grid.
+- `visible_scene_footprints_in_common_crs()` (the overlay) and the pixel compositor iterate
+  live scenes, so a pending scene draws nothing.
+- Export composites `live_scenes()` (see [The Export Path](#the-export-path)).
+
+Because the grid is built from live scenes, an **all-pending mosaic yields an empty grid**
+(not an error): `has_live_scenes()` is `False`, the view shows blank canvas, and the CRS
+stays unlocked until the first live scene resolves it.
+
+### Add path (`MosaicPane._on_add_scene_clicked`)
+
+Add-Scene calls `validate_scene_addable` (duplicate + band-count only) and then branches on
+`is_dataset_georeferenced`:
+
+```{mermaid}
+flowchart TD
+    A["Add Scene…"] --> B["validate_scene_addable<br/>(duplicate / band count)"]
+    B -->|fails| W[QMessageBox.warning, stop]
+    B -->|ok| C{is_dataset_georeferenced?}
+    C -->|no| D["add_scene(MosaicScene(dataset))<br/>bare pending placeholder"]
+    C -->|yes| E["run ingest pipeline<br/>(materialize/overviews/stretch/footprint)"]
+    D --> F["_refresh_scene_list()<br/>(warning icon + tooltip)"]
+    E --> G["_on_scene_ingested → add_scene,<br/>_ensure_common_grid"]
+    G --> H{scene compatible<br/>with target?}
+    H -->|yes| I[live: grid rebuilds, preview shows it]
+    H -->|no| J["INCOMPATIBLE_CRS pending<br/>(ingested but off-grid)"]
+```
+
+A non-georeferenced dataset is appended as a bare `MosaicScene(dataset=...)` with **no**
+background work — there is nothing to materialize until it has real georeferencing. A
+georeferenced dataset still runs the full pipeline (its artifacts are what a later
+compatibility check reads), and may end up live or `INCOMPATIBLE_CRS`-pending depending on
+the locked target.
+
+### List decoration (`_refresh_scene_list`)
+
+For each pending scene the list item gets a warning icon (`SP_MessageBoxWarning`), a greyed
+foreground, and a hover tooltip explaining *why* it is disabled (no georeferencing vs.
+incompatible CRS) and how to fix it. The visibility checkbox is deliberately left
+**enabled** — pending is an independent axis from user-hidden, and a scene's classification
+is what excludes it from the grid, not its checkbox.
+
+### Promotion: georeference in place
+
+A pending scene is fixed through the **same** right-click → "Georeference…" flow documented
+in [Re-georeferencing a Scene In Place](#re-georeferencing-a-scene-in-place). The warp bakes
+a real CRS + geotransform into the scene and reingests it, so it gains `gdal_path` /
+`footprint_wkt` in a CRS that (if compatible) makes `scene_pending_reason` return `None` on
+the next `_ensure_common_grid` — the scene goes live and the grid rebuilds to include it.
+No separate "promote" code path exists; promotion is just "it is no longer pending after the
+re-georeference reingest."
+
+### Target-CRS change re-evaluates every scene
+
+Because status is derived, `_on_choose_target_crs` doesn't reject an incompatible target —
+it commits the new target and lets the classifier re-partition: scenes that can't reach the
+new CRS become `INCOMPATIBLE_CRS`-pending, and previously-pending scenes that *can* reach it
+go live. If the change leaves no live scenes at all, the pane warns that the preview is
+empty but still keeps the chosen CRS. Removal / visibility changes rebuild quietly as before
+(see [Removal and visibility changes](#removal-and-visibility-changes)).
+
+### Export guard
+
+Export operates on `live_scenes()`. If `has_pending_scenes()` is `True`,
+`_on_export_clicked` warns and asks for confirmation before proceeding, then **skips** the
+pending scenes (they are silently absent from the output rather than blocking the export).
 
 ---
 
@@ -767,8 +920,11 @@ the output geometry changes:
   `n-1-v`), and Qt's destination `row` is indexed *before* the dragged row is removed
   (shifted down by one on a downward move). It then `move_scene`s, rebuilds the grid
   quietly (a reorder can change the top scene, hence the `TOP`-mode pixel size, but never
-  the CRS constraint), defers a `_refresh_scene_list()` to rewrite the now-stale
+  the CRS constraint),   defers a `_refresh_scene_list()` to rewrite the now-stale
   `Qt.UserRole` indices safely after the drop, and does the pure-restack invalidation.
+  `_refresh_scene_list()` also decorates any [pending](#pending-scenes-disabled-scenes)
+  scene with a warning icon, greyed text, and a why-disabled tooltip (visibility checkbox
+  left enabled).
 
 - **Resolution mode.** A combo over `ResolutionMode` (Top / Highest / Lowest / Average /
   Custom); Custom reveals two positive-only pixel-size spin boxes (target-CRS units),
@@ -1005,8 +1161,11 @@ why the on-disk header must be fully self-describing.
 
 ### GUI wiring and threading
 
-`MosaicPane._on_export_clicked` (GUI thread) requires ≥1 visible scene, resolves the grid
-via `_ensure_common_grid()` (surfacing `TargetCrsRequired`/`UnmappableCrsError` as a
+`MosaicPane._on_export_clicked` (GUI thread) requires ≥1 **live** scene
+(`live_scenes()` — pending scenes can't be placed and are excluded), and if any pending
+scenes exist it **warns and asks for confirmation** before continuing (they are then
+silently skipped — see [Pending Scenes](#pending-scenes-disabled-scenes)). It resolves the
+grid via `_ensure_common_grid()` (surfacing `TargetCrsRequired`/`UnmappableCrsError` as a
 warning), asks for an output path with `QFileDialog.getSaveFileName`, resolves the output
 nodata (`_resolve_output_nodata`: the band-metadata dataset's Data Ignore Value, else the
 top-most visible scene that has one), snapshots the controller state, and hands the heavy
@@ -1037,6 +1196,11 @@ worker never logs — progress and raised exceptions are its only channels out.
   resolution/validation, cache invalidation, and the Qt-free geometry helpers
   (`reprojected_footprint_geometry`, `compute_union_overlaps`,
   `visible_scene_footprints_in_common_crs`) — all pure `MosaicController`, no Qt.
+  Pending scenes: a non-georeferenced scene is `NO_CRS`-pending and excluded from the
+  grid, an all-pending mosaic yields an empty grid, and an ingested-but-incompatible
+  scene (built incrementally so the first scene auto-locks the target) is
+  `INCOMPATIBLE_CRS`-pending — asserting `is_scene_pending`, `scene_pending_reason`,
+  `has_live_scenes`, `has_pending_scenes`, and `_live_scenes`.
 - `src/tests/test_mosaic_view_transform.py` — `MosaicViewTransform` camera math:
   world↔screen round-trip, y-flip orientation, zoom-anchor invariance, aspect-ratio
   preservation (pure `QTransform` math, no widget shown).
@@ -1075,7 +1239,10 @@ worker never logs — progress and raised exceptions are its only channels out.
   into WISER** (dataset count unchanged); plus the no-scenes guard (informs and never
   reaches the file picker).
 - `src/tests/test_mosaic_ingestion.py` — `validate_scene`, `build_overviews`,
-  `compute_footprint_wkt`, and progress-reporting behavior. `compute_stretch_bounds`
+  `compute_footprint_wkt`, and progress-reporting behavior, plus the pending-scene add
+  split: `is_dataset_georeferenced` (real geotransform + SRS vs. identity/no-SRS) and
+  `validate_scene_addable` (duplicate + band-count only; does **not** reject
+  ungeoreferenced input). `compute_stretch_bounds`
   (#675): nodata is excluded from the sampled bounds, a value gradient produces a
   meaningfully wide (not collapsed) range, an all-nodata band is omitted from the
   result rather than raising, and the no-overviews fallback (reads the full band).
@@ -1084,7 +1251,10 @@ worker never logs — progress and raised exceptions are its only channels out.
 - `src/tests/test_mosaic_crs_gui.py` — end-to-end through the real
   `MosaicPane._on_scene_ingested` path via the `WiserTestModel` harness; documents
   the auto-lock behavior described above with `mock.patch` on
-  `wiser.gui.mosaic_pane.ReprojectPromptDialog` so nothing blocks the test.
+  `wiser.gui.mosaic_pane.ReprojectPromptDialog` so nothing blocks the test. Also
+  `test_manual_choose_target_crs_incompatible_marks_pending`: choosing an incompatible
+  target CRS **commits** the choice, leaves no live scenes, marks the scenes pending, and
+  warns (rather than rejecting the change).
 - `src/tests/test_mosaic_dialog_gui.py` — dialog shell, Add Scene ingestion flow,
   progress modal; asserts the ingested `MosaicScene.stretch_bounds` is populated
   (#675).
@@ -1094,7 +1264,9 @@ worker never logs — progress and raised exceptions are its only channels out.
   swaps the corrected scene in at its original z-order slot (blocking the georeferencer
   dialog, not the mosaic window); a repeated warp **replaces** rather than stacks; the
   warp output is **not** registered as a global dataset; Cancel restores the original at
-  its slot while "Save to Mosaic" keeps the warped one.
+  its slot while "Save to Mosaic" keeps the warped one. `test_add_non_georeferenced_scene_is_pending`
+  loads a truly ungeoreferenced TIFF, adds it, and asserts it lands as a `NO_CRS`-pending
+  placeholder with the warning icon/tooltip and excluded from the grid.
 
 GUI tests use `@pytest.mark.functional`/`@pytest.mark.smoke` with the
 `WiserTestModel` harness (`src/test_utils/test_model.py`), not pytest-qt/qtbot. Run

--- a/src/test_utils/test_model.py
+++ b/src/test_utils/test_model.py
@@ -1288,14 +1288,31 @@ class WiserTestModel:
         The warp now runs off the GUI thread via ``run_with_progress`` and signals
         completion through ``warp_completed``, so this helper waits for that signal (up to
         ``timeout_ms``) before returning, keeping callers effectively synchronous.
+
+        If the warp *fails*, the dialog's ``_on_warp_error`` would normally pop a modal
+        ``QMessageBox.critical`` — which has no one to dismiss it in a headless test and
+        would block the event loop until the whole run times out (240s), hiding the real
+        GDAL error. To keep failures debuggable, this helper temporarily shadows
+        ``_on_warp_error`` for the duration of the wait: it captures the error message,
+        stops waiting, and re-raises it as a ``RuntimeError`` so the test fails fast with
+        the actual message instead of hanging.
         """
         dialog = self.main_window._geo_ref_dialog
         completed = []
+        errors = []
 
         def _on_done(path):
             completed.append(path)
 
+        def _capture_error(message):
+            # Record the failure without showing the blocking modal dialog.
+            errors.append(message)
+
         dialog.warp_completed.connect(_on_done)
+        # Shadow the bound method with an instance attribute *before* the click, since
+        # ``_create_warped_output`` reads ``self._on_warp_error`` when it launches the warp.
+        original_on_warp_error = dialog.__dict__.get("_on_warp_error", None)
+        dialog._on_warp_error = _capture_error
         try:
 
             def func():
@@ -1305,11 +1322,19 @@ class WiserTestModel:
 
             waited = 0
             step_ms = 50
-            while not completed and waited < timeout_ms:
+            while not completed and not errors and waited < timeout_ms:
                 QTest.qWait(step_ms)
                 waited += step_ms
         finally:
             dialog.warp_completed.disconnect(_on_done)
+            if original_on_warp_error is None:
+                # Remove the instance-level shadow so the class method is used again.
+                dialog.__dict__.pop("_on_warp_error", None)
+            else:
+                dialog._on_warp_error = original_on_warp_error
+
+        if errors:
+            raise RuntimeError(f"Warp failed: {errors[0]}")
 
     # ---------- GCP creation helpers ----------
 

--- a/src/tests/test_mosaic_controller.py
+++ b/src/tests/test_mosaic_controller.py
@@ -1,6 +1,7 @@
 import math
 import os
 import unittest
+from unittest import mock
 
 import numpy as np
 from osgeo import gdal, ogr, osr
@@ -10,6 +11,7 @@ from wiser.raster.mosaic_controller import (
     MosaicController,
     MosaicScene,
     ResolutionMode,
+    ScenePendingReason,
     TargetCrsRequired,
     UnmappableCrsError,
     compute_union_overlaps,
@@ -473,6 +475,82 @@ def test_validate_target_crs_names_unmappable_scene(tmp_path):
     with pytest.raises(UnmappableCrsError) as excinfo:
         c.validate_target_crs(_wkt_for_epsg(32611))
     assert "no_crs_scene" in str(excinfo.value)
+
+
+# -- live / pending scene status ---------------------------------------------
+
+
+def test_non_georeferenced_scene_is_pending_and_excluded(tmp_path):
+    # A real (ingested) scene plus a bare, non-georeferenced placeholder.
+    live = _make_scene(tmp_path, "live", epsg=32611)
+    ghost = _no_crs_scene("ghost")
+    c = MosaicController()
+    c.add_scene(live)
+    c.add_scene(ghost)
+
+    # The placeholder is pending (NO_CRS); the real scene is live.
+    assert c.is_scene_pending(ghost) is True
+    assert c.scene_pending_reason(ghost) is ScenePendingReason.NO_CRS
+    assert c.is_scene_pending(live) is False
+    assert c.scene_pending_reason(live) is None
+    assert c.has_pending_scenes() is True
+    assert c.has_live_scenes() is True
+    assert [s.dataset.get_name() for s in c.live_scenes()] == ["live"]
+
+    # The grid builds from the live scene alone (the placeholder never reaches it), and
+    # the target auto-locks to the live scene's CRS.
+    grid = c.build_common_grid()
+    assert grid.geotransform is not None
+    assert c.get_target_crs() is not None
+    # Footprint overlay excludes the placeholder too.
+    fps = c.visible_scene_footprints_in_common_crs()
+    assert [s.dataset.get_name() for s, _ in fps] == ["live"]
+
+
+def test_all_pending_yields_empty_grid():
+    c = MosaicController()
+    c.add_scene(_no_crs_scene("only_ghost"))
+    # Nothing placeable -> an empty grid (blank preview), not an error.
+    grid = c.build_common_grid()
+    assert grid.geotransform is None
+    assert grid.extent is None
+    assert c.has_live_scenes() is False
+
+
+def test_incompatible_crs_scene_is_pending(tmp_path):
+    a = _make_scene(tmp_path, "a", epsg=32611)
+    b = _make_scene(tmp_path, "b", epsg=4326, origin=(-117.0, 34.0), pixel=0.001)
+    c = MosaicController()
+    c.add_scene(a)
+    c.build_common_grid()  # locks the target to a's CRS (32611) while it is alone
+    c.add_scene(b)  # 4326 maps to the locked 32611 target -> live
+    c.build_common_grid()
+    assert c.has_pending_scenes() is False
+
+    # Force b's CRS to be un-transformable to the (locked) target: it becomes pending
+    # with an INCOMPATIBLE_CRS reason, while a stays live.
+    target_srs = a.dataset.get_spatial_ref()
+    with mock.patch(
+        "wiser.raster.mosaic_controller.can_transform_between_srs",
+        side_effect=lambda srs, tgt: srs.IsSame(target_srs),
+    ):
+        assert c.is_scene_pending(b) is True
+        assert c.scene_pending_reason(b) is ScenePendingReason.INCOMPATIBLE_CRS
+        assert c.is_scene_pending(a) is False
+        assert [s.dataset.get_name() for s in c.live_scenes()] == ["a"]
+
+
+def test_hidden_scene_is_not_live_but_may_be_pending(tmp_path):
+    a = _make_scene(tmp_path, "a", epsg=32611)
+    b = _make_scene(tmp_path, "b", epsg=32611, origin=(400500.0, 3800500.0))
+    c = MosaicController()
+    c.add_scene(a)
+    c.add_scene(b)
+    c.build_common_grid()
+
+    c.set_visibility(1, False)  # hide b
+    # A hidden scene is not part of the live set (visibility still gates rendering).
+    assert [s.dataset.get_name() for s in c.live_scenes()] == ["a"]
 
 
 # -- scene_crs_choices -------------------------------------------------------

--- a/src/tests/test_mosaic_crs_gui.py
+++ b/src/tests/test_mosaic_crs_gui.py
@@ -24,7 +24,6 @@ import numpy as np
 
 import tests.context  # noqa: F401  (adds src/ to sys.path)
 from test_utils.test_model import WiserTestModel
-from wiser.raster.mosaic_controller import UnmappableCrsError
 
 import pytest
 
@@ -209,9 +208,9 @@ class TestMosaicCrsGui(unittest.TestCase):
 
         self.test_model.close_seamless_mosaic_dialog()
 
-    # -- manual "Choose Target CRS": unmappable choice warns, no commit -------
+    # -- manual "Choose Target CRS": incompatible choice commits + marks pending --
 
-    def test_manual_choose_target_crs_unmappable_warns(self):
+    def test_manual_choose_target_crs_incompatible_marks_pending(self):
         ds_a = self._load("a_utm.tif", 32611)
         ds_b = self._load("b_geo.tif", 4326)
 
@@ -225,21 +224,28 @@ class TestMosaicCrsGui(unittest.TestCase):
 
         target_geo = osr.SpatialReference()
         target_geo.ImportFromEPSG(4326)
+        # Force every scene to be un-transformable to the chosen target so the change
+        # exercises the "no live scenes" path. The new behavior *accepts* the CRS and
+        # marks the scenes pending instead of rejecting the choice.
+        # Pending status is computed live, so the incompatibility patch must stay active
+        # while we assert on it (it reverts the moment the patch exits).
         with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog") as Dlg, mock.patch(
             "wiser.gui.mosaic_pane.QMessageBox.warning"
-        ) as warn, mock.patch.object(
-            controller,
-            "validate_target_crs",
-            side_effect=UnmappableCrsError("cannot map"),
+        ) as warn, mock.patch(
+            "wiser.raster.mosaic_controller.can_transform_between_srs",
+            return_value=False,
         ):
             inst = Dlg.return_value
             inst.exec.return_value = QDialog.Accepted
             inst.selected_target_wkt.return_value = target_geo.ExportToWkt()
             pane._on_choose_target_crs()
 
-        warn.assert_called_once()
-        # The unmappable choice was not committed; the locked 32611 target stands.
-        self.assertTrue(_same_as_epsg(controller.get_target_crs(), 32611))
+            # The choice is committed (not rejected), every scene is now pending, and the
+            # user is warned that the preview has nothing left to show.
+            self.assertTrue(_same_as_epsg(controller.get_target_crs(), 4326))
+            self.assertFalse(controller.has_live_scenes())
+            self.assertTrue(controller.has_pending_scenes())
+            warn.assert_called_once()
 
         self.test_model.close_seamless_mosaic_dialog()
 

--- a/src/tests/test_mosaic_dialog_gui.py
+++ b/src/tests/test_mosaic_dialog_gui.py
@@ -198,9 +198,12 @@ class TestSeamlessMosaicAddScene(unittest.TestCase):
 
         self.test_model.close_seamless_mosaic_dialog()
 
-    def test_add_invalid_scene_rejected(self):
-        # A numpy-array dataset is ungeoreferenced (identity transform, no SRS), so
-        # validation must reject it before any background work runs.
+    def test_add_non_georeferenced_scene_is_pending(self):
+        # A numpy-array dataset is ungeoreferenced (identity transform, no SRS). It is
+        # no longer rejected: it is added immediately as a disabled "pending" placeholder
+        # (no background work), to be promoted later via the in-place georeferencer.
+        from wiser.raster.mosaic_controller import ScenePendingReason
+
         ungeoreffed = self.test_model.load_dataset(np.zeros((3, 10, 10), dtype=np.float32))
 
         dlg = self.test_model.open_seamless_mosaic_dialog()
@@ -208,14 +211,20 @@ class TestSeamlessMosaicAddScene(unittest.TestCase):
         controller = pane.get_controller()
 
         self._select_dataset(pane, ungeoreffed.get_id())
-        # The rejection surfaces a modal QMessageBox.warning; patch it so the test
-        # does not block, and assert it fired.
+        # No warning should fire (adding is allowed); patch it so a stray one would be
+        # caught rather than blocking the test.
         with mock.patch("wiser.gui.mosaic_pane.QMessageBox.warning") as warn:
             pane._add_scene_button.click()
             QTest.qWait(100)
 
-        warn.assert_called_once()
-        self.assertEqual(controller.scene_count(), 0)
+        warn.assert_not_called()
+        self.assertEqual(controller.scene_count(), 1)
+
+        scene = controller.get_scenes()[0]
+        self.assertTrue(controller.is_scene_pending(scene))
+        self.assertEqual(controller.scene_pending_reason(scene), ScenePendingReason.NO_CRS)
+        self.assertTrue(controller.has_pending_scenes())
+        self.assertFalse(controller.has_live_scenes())
 
         self.test_model.close_seamless_mosaic_dialog()
 

--- a/src/tests/test_mosaic_georeference_gui.py
+++ b/src/tests/test_mosaic_georeference_gui.py
@@ -20,6 +20,7 @@ from PySide6.QtTest import QTest
 import tests.context  # noqa: F401  (adds src/ to sys.path)
 from test_utils.test_model import WiserTestModel
 from wiser.gui.geo_reference_config import GeoReferencerConfig
+from wiser.raster.mosaic_controller import ScenePendingReason
 from wiser.utils.primitives import temp_dir
 
 import pytest
@@ -56,6 +57,58 @@ def _write_tiff(path, origin, epsg=32611, pixel=30.0, size=20, collar=2, bands=3
         band.SetNoDataValue(-9999.0)
     ds.FlushCache()
     ds = None
+
+
+def _write_ungeoreferenced_tiff(path, size=20, bands=3):
+    """Write a TIFF with no geotransform and no projection (an ungeoreferenced image)."""
+    ds = gdal.GetDriverByName("GTiff").Create(path, size, size, bands, gdal.GDT_Float32)
+    for b in range(1, bands + 1):
+        ds.GetRasterBand(b).WriteArray(np.full((size, size), 7, dtype=np.float32))
+    ds.FlushCache()
+    ds = None
+
+
+class TestMosaicPendingScene(unittest.TestCase):
+    """Adding a non-georeferenced dataset yields a disabled 'pending' scene (#685+)."""
+
+    def setUp(self):
+        self.test_model = WiserTestModel()
+        self._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(self._tmp.cleanup)
+
+    def tearDown(self):
+        self.test_model.close_app()
+        del self.test_model
+
+    def test_add_non_georeferenced_scene_is_pending(self):
+        path = os.path.join(self._tmp.name, "plain.tif")
+        _write_ungeoreferenced_tiff(path)
+        dataset = self.test_model.load_dataset(path)
+
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+
+        index = pane._dataset_combo.findData(dataset.get_id())
+        self.assertGreaterEqual(index, 0)
+        pane._dataset_combo.setCurrentIndex(index)
+        # Non-georeferenced scenes are added synchronously (no ingest pipeline).
+        pane._add_scene_button.click()
+
+        # It is in the mosaic, but pending (NO_CRS) and excluded from the live set.
+        self.assertEqual(controller.scene_count(), 1)
+        scene = controller.get_scenes()[0]
+        self.assertTrue(controller.is_scene_pending(scene))
+        self.assertIs(controller.scene_pending_reason(scene), ScenePendingReason.NO_CRS)
+        self.assertFalse(controller.has_live_scenes())
+        self.assertTrue(controller.has_pending_scenes())
+
+        # The list row carries the warning icon + an explanatory tooltip.
+        item = pane._scene_list.item(0)
+        self.assertFalse(item.icon().isNull())
+        self.assertIn("no CRS", item.toolTip())
+
+        self.test_model.close_seamless_mosaic_dialog()
 
 
 class TestMosaicRegeoreferenceEntryPoint(unittest.TestCase):

--- a/src/tests/test_mosaic_ingestion.py
+++ b/src/tests/test_mosaic_ingestion.py
@@ -20,7 +20,9 @@ from wiser.raster.mosaic_ingestion import (
     build_overviews,
     compute_footprint_wkt,
     compute_stretch_bounds,
+    is_dataset_georeferenced,
     validate_scene,
+    validate_scene_addable,
 )
 from wiser.raster.mosaic_materialize import materialize_to_tiled_geotiff, read_materialized_geotiff
 from wiser.utils.progress import ProgressReporter
@@ -74,6 +76,9 @@ class _FakeDataset:
 
     def get_wkt_spatial_reference(self):
         return self._wkt
+
+    def get_name(self):
+        return None
 
     def num_bands(self):
         return self._bands
@@ -169,6 +174,42 @@ def test_validate_accepts_dtype_mismatch():
 def test_validate_accepts_valid_scene():
     existing = [MosaicScene(dataset=_valid_fake(bands=3))]
     validate_scene(_valid_fake(bands=3), existing_scenes=existing)
+
+
+# -- is_dataset_georeferenced / validate_scene_addable (pending-scene feature) -
+
+
+def test_is_dataset_georeferenced_true():
+    assert is_dataset_georeferenced(_valid_fake(bands=3)) is True
+
+
+def test_is_dataset_georeferenced_false_on_identity_geotransform():
+    ds = _FakeDataset(_IDENTITY_GEO_TRANSFORM, _utm_wkt(), bands=3)
+    assert is_dataset_georeferenced(ds) is False
+
+
+def test_is_dataset_georeferenced_false_without_srs():
+    ds = _FakeDataset(_GOOD_GEO_TRANSFORM, "", bands=3)
+    assert is_dataset_georeferenced(ds) is False
+
+
+def test_addable_accepts_non_georeferenced_scene():
+    # The "addable" gate must NOT reject an ungeoreferenced scene (it is added pending).
+    ds = _FakeDataset(_IDENTITY_GEO_TRANSFORM, "", bands=3)
+    validate_scene_addable(ds, existing_scenes=[])  # no exception
+
+
+def test_addable_rejects_band_mismatch():
+    existing = [MosaicScene(dataset=_valid_fake(bands=3))]
+    with pytest.raises(SceneValidationError):
+        validate_scene_addable(_valid_fake(bands=1), existing_scenes=existing)
+
+
+def test_addable_rejects_duplicate():
+    ds = _valid_fake(bands=3)
+    existing = [MosaicScene(dataset=ds)]
+    with pytest.raises(SceneValidationError):
+        validate_scene_addable(ds, existing_scenes=existing)
 
 
 # -- compute_footprint_wkt ----------------------------------------------------

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -40,6 +40,7 @@ from wiser.raster.mosaic_controller import (
     MosaicController,
     MosaicScene,
     ResolutionMode,
+    ScenePendingReason,
     TargetCrsRequired,
     UnmappableCrsError,
 )
@@ -49,7 +50,8 @@ from wiser.raster.mosaic_ingestion import (
     build_overviews,
     compute_footprint_wkt,
     compute_stretch_bounds,
-    validate_scene,
+    is_dataset_georeferenced,
+    validate_scene_addable,
 )
 from wiser.utils.primitives import temp_dir
 from wiser.utils.progress import ProgressReporter
@@ -415,17 +417,29 @@ class MosaicPane(QWidget):
         dataset = self._app_state.get_dataset(ds_id)
         name = dataset.get_name() or f"Dataset {ds_id}"
 
-        # Validate on the main thread so rejection is immediate (no spinner churn)
-        # and so a scene that can't join the mosaic never pays for the
-        # materialize/build-overviews/footprint pipeline it would just be rejected
-        # after anyway.
+        # Only the "can't be added at all" gates (duplicate, band-count) block here. A
+        # non-georeferenced or CRS-incompatible dataset is *not* rejected: it is added as
+        # a disabled "pending" scene and fixed later via the in-place georeferencer.
         try:
-            validate_scene(dataset, self._controller.get_scenes())
-            self._controller.validate_new_scene_crs(name, dataset.get_spatial_ref())
-        except (SceneValidationError, UnmappableCrsError) as exc:
+            validate_scene_addable(dataset, self._controller.get_scenes())
+        except SceneValidationError as exc:
             QMessageBox.warning(self, self.tr("Cannot add scene"), str(exc))
             return
 
+        if not is_dataset_georeferenced(dataset):
+            # Non-georeferenced: there is nothing to materialize and no grid
+            # contribution, so add a bare placeholder immediately (no background work).
+            # It appears in the list as pending until the user right-clicks →
+            # Georeference…, at which point the swap promotes it to a live scene.
+            self._controller.add_scene(MosaicScene(dataset=dataset))
+            self._refresh_scene_list()
+            self._refresh_target_crs_label()
+            self._mosaic_view.invalidate_overlay()
+            return
+
+        # Georeferenced (whether or not it is compatible with a locked target): ingest
+        # now so that, if it lands pending, a later promotion is instant. The scene is
+        # classified live/pending automatically once it reaches the controller.
         # Run the ingestion on the scheduler with a progress dialog and a mirrored
         # Activity Monitor row. Pass the window (the SeamlessMosaicDialog) as the block
         # target so only it is disabled while ingesting; the rest of WISER stays live.
@@ -470,19 +484,41 @@ class MosaicPane(QWidget):
         # Controller order is bottom-to-top; show the top-most first so the list reads
         # like a layer stack. Each item carries its real controller index in UserRole.
         for index in reversed(range(len(scenes))):
+            scene = scenes[index]
             name, crs_display = summary[index]
             item = QListWidgetItem(f"{name}   ·   {crs_display}")
             item.setData(Qt.UserRole, index)
             # Checkable + draggable, but not a drop target itself, so a dragged row
             # lands *between* rows (reorder) rather than "onto" another row.
             item.setFlags((item.flags() | Qt.ItemIsUserCheckable) & ~Qt.ItemIsDropEnabled)
-            item.setCheckState(Qt.Checked if scenes[index].visible else Qt.Unchecked)
+            item.setCheckState(Qt.Checked if scene.visible else Qt.Unchecked)
+            # Flag pending scenes (non-georeferenced, or a CRS that can't reach the
+            # target) with a warning icon + explanatory tooltip. The visibility checkbox
+            # stays enabled: it records the user's intent for when the scene becomes live.
+            reason = self._controller.scene_pending_reason(scene)
+            if reason is not None:
+                item.setIcon(self.style().standardIcon(QStyle.SP_MessageBoxWarning))
+                item.setToolTip(self._pending_tooltip(reason))
+                item.setForeground(QColor(150, 150, 150))
             self._scene_list.addItem(item)
             if index == previous:
                 self._scene_list.setCurrentItem(item)
         self._scene_list.blockSignals(False)
         self._on_scene_selection_changed()
         self._refresh_band_metadata_combo()
+
+    @staticmethod
+    def _pending_tooltip(reason: ScenePendingReason) -> str:
+        """Hover text explaining why a pending scene is excluded, and how to fix it."""
+        if reason is ScenePendingReason.INCOMPATIBLE_CRS:
+            return (
+                "Can't add scene to preview/final output because its CRS isn't "
+                "compatible with the mosaic. Right-click \u2192 Georeference\u2026 to fix it."
+            )
+        return (
+            "Can't add scene to preview/final output because it has no CRS. "
+            "Right-click \u2192 Georeference\u2026 to fix it."
+        )
 
     def _refresh_band_metadata_combo(self) -> None:
         """
@@ -827,14 +863,32 @@ class MosaicPane(QWidget):
         if self._app_services is None:
             return
 
-        visible = [scene for scene in self._controller.get_scenes() if scene.visible]
+        # Only live scenes are composited; pending scenes (non-georeferenced or
+        # CRS-incompatible) cannot be placed on the grid and are skipped.
+        visible = self._controller.live_scenes()
         if not visible:
             QMessageBox.information(
                 self,
                 self.tr("Nothing to export"),
-                self.tr("Add at least one visible scene before exporting."),
+                self.tr("Add at least one visible, georeferenced scene before exporting."),
             )
             return
+
+        # Warn before silently dropping any pending scenes from the output.
+        if self._controller.has_pending_scenes():
+            proceed = QMessageBox.warning(
+                self,
+                self.tr("Pending scenes will be skipped"),
+                self.tr(
+                    "Some scenes are pending (not georeferenced, or their CRS is not "
+                    "compatible with the mosaic) and will be skipped in the export. "
+                    "Continue anyway?"
+                ),
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if proceed != QMessageBox.Yes:
+                return
 
         # Resolve the output grid first (may prompt for a target CRS), then confirm it
         # actually produced a usable extent before asking for an output path.
@@ -949,19 +1003,30 @@ class MosaicPane(QWidget):
         """Let the user pick / override the target CRS at any time (manual button)."""
         if not self._prompt_for_target_crs():
             return
-        try:
-            self._controller.build_common_grid()
-        except UnmappableCrsError as exc:
-            QMessageBox.warning(self, self.tr("Cannot reproject"), str(exc))
-        self._refresh_target_crs_label()
+        # A target change re-evaluates every scene: some may go pending (their CRS can no
+        # longer reach the target), some may be promoted. Rebuild from the live scenes,
+        # refresh the pending flags, and warn only if nothing is left to display.
+        self._rebuild_grid_quietly()
+        self._refresh_scene_list()
         self._mosaic_view.invalidate_overlay()
         self._mosaic_view.invalidate_pixels()
+        if not self._controller.has_live_scenes():
+            QMessageBox.warning(
+                self,
+                self.tr("No compatible scenes"),
+                self.tr(
+                    "No scene can be transformed into the chosen target CRS, so the "
+                    "mosaic preview is empty. Right-click a scene and choose "
+                    "Georeference\u2026 to bring it into a compatible CRS."
+                ),
+            )
 
     def _prompt_for_target_crs(self) -> bool:
         """
-        Show the reproject dialog and, on accept, validate + set the chosen target
-        CRS. Returns ``True`` when a target CRS was set, ``False`` otherwise (no
-        scenes, cancelled, or the choice was unmappable).
+        Show the reproject dialog and, on accept, set the chosen target CRS. Returns
+        ``True`` when a target CRS was set, ``False`` otherwise (no scenes, or the user
+        cancelled). A choice that some scenes cannot reach is *not* rejected here — those
+        scenes become pending — so the only failure modes are an empty mosaic or cancel.
         """
         if self._controller.scene_count() == 0:
             QMessageBox.information(
@@ -980,11 +1045,9 @@ class MosaicPane(QWidget):
         if dlg.exec() != QDialog.Accepted:
             return False
         target = dlg.selected_target_wkt()
-        try:
-            self._controller.validate_target_crs(target)
-        except UnmappableCrsError as exc:
-            QMessageBox.warning(self, self.tr("Cannot reproject"), str(exc))
-            return False
+        # No longer a hard gate: a target that some scenes cannot reach is accepted, and
+        # those scenes become pending (flagged in the list) instead of blocking the
+        # change. The caller re-evaluates pending status and refreshes the view.
         self._controller.set_target_crs(target)
         return True
 

--- a/src/wiser/raster/mosaic_controller.py
+++ b/src/wiser/raster/mosaic_controller.py
@@ -55,6 +55,26 @@ class UnmappableCrsError(Exception):
     """
 
 
+class ScenePendingReason(enum.Enum):
+    """
+    Why a scene is currently **pending** (disabled: excluded from the common grid, the
+    vector overlay, the pixel compositor, and export) rather than live.
+
+    A scene is pending when it cannot be placed on the mosaic's shared grid yet. The
+    reason drives the scene-list warning tooltip and is recomputed on every scene-list
+    or target-CRS change (pending is a status, not a one-way creation mode):
+
+      * ``NO_CRS`` — never ingested: added as a raw, non-georeferenced placeholder (no
+        geotransform / no SRS). Right-click → Georeference… to fix it.
+      * ``INCOMPATIBLE_CRS`` — georeferenced and ingested, but its CRS cannot be
+        transformed into the mosaic's resolved target CRS (e.g. a different planet, or
+        the target CRS was changed to one this scene can't reach).
+    """
+
+    NO_CRS = "no-crs"
+    INCOMPATIBLE_CRS = "incompatible-crs"
+
+
 class ResolutionMode(enum.Enum):
     """
     How the common output grid's pixel size is chosen.
@@ -276,12 +296,28 @@ class MosaicController:
     def _visible_scenes(self) -> List[MosaicScene]:
         return [s for s in self._scenes if s.visible]
 
-    def common_scene_crs_wkt(self) -> Optional[str]:
+    @staticmethod
+    def _is_ingested(scene: MosaicScene) -> bool:
         """
-        Return the shared CRS (as WKT) if every visible scene's spatial reference is
-        the same; otherwise ``None`` (a target CRS must then be chosen explicitly).
+        True if ``scene`` has been through the ingestion pipeline (materialized to a
+        warpable GeoTIFF with a footprint).
+
+        This is the controller's proxy for "georeferenced": the mosaic pane only runs
+        ingestion on georeferenced datasets, so a scene with both a ``gdal_path`` and a
+        ``footprint_wkt`` is georeferenced and placeable, while a non-georeferenced
+        placeholder has neither. Keying off the artifacts (rather than re-reading the
+        dataset's geotransform) keeps this pure and works with the lightweight dataset
+        stand-ins used in tests.
         """
-        scenes = self._visible_scenes()
+        return scene.gdal_path is not None and scene.footprint_wkt is not None
+
+    @staticmethod
+    def _common_crs_wkt(scenes: List[MosaicScene]) -> Optional[str]:
+        """
+        Return the shared CRS (as WKT) if every scene in ``scenes`` has the same spatial
+        reference; otherwise ``None``. An empty list or any scene without a CRS yields
+        ``None``.
+        """
         if not scenes:
             return None
         first_srs = scenes[0].dataset.get_spatial_ref()
@@ -292,6 +328,69 @@ class MosaicController:
             if srs is None or not first_srs.IsSame(srs):
                 return None
         return first_srs.ExportToWkt()
+
+    def common_scene_crs_wkt(self) -> Optional[str]:
+        """
+        Return the shared CRS (as WKT) if every visible scene's spatial reference is
+        the same; otherwise ``None`` (a target CRS must then be chosen explicitly).
+        """
+        return self._common_crs_wkt(self._visible_scenes())
+
+    # -- live / pending status (pending-scene feature) ------------------------
+
+    def _resolved_target_wkt(self) -> Optional[str]:
+        """
+        The CRS a scene's compatibility is measured against: the explicit target if the
+        user (or a prior grid build) has set one, otherwise the shared CRS of the
+        *georeferenced* visible scenes.
+
+        Returns ``None`` when there is nothing to be compatible with yet — an empty
+        mosaic, an all-pending mosaic, or georeferenced scenes that disagree on a CRS
+        with no explicit target chosen (the latter is the existing ``TargetCrsRequired``
+        prompt path, unchanged by the pending-scene feature).
+        """
+        if self._target_crs_wkt is not None:
+            return self._target_crs_wkt
+        georeferenced = [s for s in self._visible_scenes() if self._is_ingested(s)]
+        return self._common_crs_wkt(georeferenced)
+
+    def is_scene_pending(self, scene: MosaicScene) -> bool:
+        """True if ``scene`` is currently excluded from the grid/overlay/compositor/export."""
+        return self.scene_pending_reason(scene) is not None
+
+    def scene_pending_reason(self, scene: MosaicScene) -> Optional[ScenePendingReason]:
+        """
+        Classify ``scene`` as live (``None``) or pending (a :class:`ScenePendingReason`).
+
+        Pending when the scene was never ingested (``NO_CRS`` — a non-georeferenced
+        placeholder), or when it is ingested but its CRS cannot be transformed into the
+        resolved target CRS (``INCOMPATIBLE_CRS``). When no target is resolved yet, an
+        ingested scene is treated as live (there is nothing to be incompatible with).
+        """
+        if not self._is_ingested(scene):
+            return ScenePendingReason.NO_CRS
+        target_wkt = self._resolved_target_wkt()
+        if target_wkt is None:
+            return None
+        srs = scene.dataset.get_spatial_ref()
+        if srs is None or not can_transform_between_srs(srs, _srs_from_wkt(target_wkt)):
+            return ScenePendingReason.INCOMPATIBLE_CRS
+        return None
+
+    def _live_scenes(self) -> List[MosaicScene]:
+        """Visible scenes that are placeable on the grid right now (not pending)."""
+        return [s for s in self._visible_scenes() if not self.is_scene_pending(s)]
+
+    def live_scenes(self) -> List[MosaicScene]:
+        """Public copy of the current live (visible, non-pending) scenes, bottom-to-top."""
+        return list(self._live_scenes())
+
+    def has_live_scenes(self) -> bool:
+        return any(not self.is_scene_pending(s) for s in self._visible_scenes())
+
+    def has_pending_scenes(self) -> bool:
+        """True if any scene in the mosaic (visible or not) is currently pending."""
+        return any(self.is_scene_pending(s) for s in self._scenes)
 
     def scene_crs_summary(self) -> List[Tuple[str, str]]:
         """
@@ -394,7 +493,9 @@ class MosaicController:
             return []
         target_srs = _srs_from_wkt(target_wkt)
         result: List[Tuple[MosaicScene, ogr.Geometry]] = []
-        for scene in self._visible_scenes():
+        # Only live scenes: pending scenes have no footprint (non-georeferenced) or a
+        # CRS that cannot reach the target, so neither can be drawn on the common canvas.
+        for scene in self._live_scenes():
             src_srs = scene.dataset.get_spatial_ref()
             if src_srs is None or scene.footprint_wkt is None:
                 continue
@@ -419,21 +520,25 @@ class MosaicController:
         if not self._grid_dirty:
             return self._common_grid
 
-        scenes = self._visible_scenes()
+        # Only live (placeable) scenes participate in the grid. Pending scenes —
+        # non-georeferenced placeholders or scenes whose CRS can't reach the target —
+        # are excluded, so an all-pending mosaic yields an empty grid (blank preview)
+        # rather than an error.
+        scenes = self._live_scenes()
         if not scenes:
             self._common_grid = CommonGrid()
             self._grid_dirty = False
             return self._common_grid
 
-        # 1) Resolve the target CRS: an explicit choice wins, else the shared CRS.
-        target_wkt = self._target_crs_wkt or self.common_scene_crs_wkt()
+        # 1) Resolve the target CRS: an explicit choice wins, else the shared CRS of the
+        #    live scenes. Differing live CRSs with no explicit target need a choice.
+        target_wkt = self._target_crs_wkt or self._common_crs_wkt(scenes)
         if target_wkt is None:
             raise TargetCrsRequired(
                 "Scenes have differing coordinate reference systems; a target CRS "
                 "must be chosen before the common grid can be built."
             )
         self._target_crs_wkt = target_wkt
-        self.validate_target_crs(target_wkt)
         target_srs = _srs_from_wkt(target_wkt)
 
         # 2) Per-scene: extent (footprint envelope in target CRS) and the resolution

--- a/src/wiser/raster/mosaic_ingestion.py
+++ b/src/wiser/raster/mosaic_ingestion.py
@@ -84,40 +84,34 @@ def _is_identity_geo_transform(geo_transform: Tuple[float, ...]) -> bool:
     )
 
 
-def validate_scene(dataset: "RasterDataSet", existing_scenes: List["MosaicScene"]) -> None:
+def is_dataset_georeferenced(dataset: "RasterDataSet") -> bool:
     """
-    Validate a candidate ``dataset`` against the mosaic's existing scenes.
+    True if ``dataset`` is placeable on a mosaic grid: it has a real (non-identity)
+    geotransform **and** a non-empty spatial reference.
 
-    Raises :class:`SceneValidationError` with a specific reason for each rejected
-    case; returns ``None`` when the scene is acceptable.
-
-    Rejected:
-      * **Ungeoreferenced** — the geotransform is GDAL's identity sentinel. This is
-        a defensive gate against bad inputs. Note ``get_geo_transform()`` never
-        returns ``None`` (it returns the identity transform for ungeoreferenced
-        data), so the check is identity-based, not ``is None``.
-      * **No SRS** — ``get_wkt_spatial_reference()`` is empty/None.
-      * **Band-count mismatch** — the candidate's band count differs from the first
-        existing scene's. See ``# TODO(#640)`` for the future warn-but-allow path.
-
-    Deliberately NOT rejected:
-      * **No nodata value** — many valid datasets lack one. nodata only sharpens the
-        footprint; ``gdal.Footprint`` without it returns the full raster rectangle,
-        which is a valid (coarser) footprint.
-      * **Data-type mismatch across scenes** — no dtype consistency is required at
-        ingestion. The compositor (#635/#637) promotes to the widest common type at
-        warp time, so enforcing equal dtypes here would only cause false rejections.
+    This is the single definition of "georeferenced" shared by the strict
+    :func:`validate_scene` gate and the mosaic's live/pending classification (the
+    "pending scene" feature). A dataset that fails this cannot be materialized onto the
+    common grid and is carried as a pending placeholder until it is georeferenced.
+    Note ``get_geo_transform()`` never returns ``None`` (it returns the identity
+    transform for ungeoreferenced data), so the geotransform check is identity-based.
     """
-    if _is_identity_geo_transform(dataset.get_geo_transform()):
-        raise SceneValidationError(
-            "Scene is not georeferenced (no geotransform); it cannot be placed on the " "mosaic grid."
-        )
+    return not _is_identity_geo_transform(dataset.get_geo_transform()) and bool(
+        dataset.get_wkt_spatial_reference()
+    )
 
-    if not dataset.get_wkt_spatial_reference():
-        raise SceneValidationError(
-            "Scene has no spatial reference system (SRS); it cannot be placed on the " "mosaic grid."
-        )
 
+def validate_scene_addable(dataset: "RasterDataSet", existing_scenes: List["MosaicScene"]) -> None:
+    """
+    Enforce only the gates that make a candidate **fundamentally un-addable**, regardless
+    of whether it is georeferenced yet: a duplicate scene, or a band-count mismatch.
+
+    Unlike :func:`validate_scene`, this deliberately does *not* reject an
+    ungeoreferenced or CRS-incompatible dataset — those are added as disabled "pending"
+    scenes (the mosaic pane branches on :func:`is_dataset_georeferenced`) and fixed later
+    via the in-place georeferencer. Raises :class:`SceneValidationError` with a specific
+    reason for each rejected case; returns ``None`` when the scene may be added.
+    """
     if any(scene.dataset.get_id() == dataset.get_id() for scene in existing_scenes):
         raise SceneValidationError(f'"{dataset.get_name() or dataset.get_id()}" is already in the mosaic.')
 
@@ -131,6 +125,45 @@ def validate_scene(dataset: "RasterDataSet", existing_scenes: List["MosaicScene"
                 f"Scene has {candidate_bands} band(s) but the mosaic's scenes have "
                 f"{expected_bands}. All scenes must share a band count."
             )
+
+
+def validate_scene(dataset: "RasterDataSet", existing_scenes: List["MosaicScene"]) -> None:
+    """
+    Validate a candidate ``dataset`` against the mosaic's existing scenes (strict gate).
+
+    Raises :class:`SceneValidationError` with a specific reason for each rejected
+    case; returns ``None`` when the scene is acceptable.
+
+    Rejected:
+      * **Ungeoreferenced** — the geotransform is GDAL's identity sentinel. Note
+        ``get_geo_transform()`` never returns ``None`` (it returns the identity
+        transform for ungeoreferenced data), so the check is identity-based.
+      * **No SRS** — ``get_wkt_spatial_reference()`` is empty/None.
+      * **Duplicate / band-count mismatch** — see :func:`validate_scene_addable`.
+
+    Deliberately NOT rejected:
+      * **No nodata value** — many valid datasets lack one. nodata only sharpens the
+        footprint; ``gdal.Footprint`` without it returns the full raster rectangle,
+        which is a valid (coarser) footprint.
+      * **Data-type mismatch across scenes** — no dtype consistency is required at
+        ingestion. The compositor (#635/#637) promotes to the widest common type at
+        warp time, so enforcing equal dtypes here would only cause false rejections.
+
+    This remains the strict "must be immediately placeable" gate. The mosaic pane no
+    longer calls it directly (it splits the georef check off so ungeoreferenced scenes
+    can be added as pending), but it is kept as the canonical full check.
+    """
+    if _is_identity_geo_transform(dataset.get_geo_transform()):
+        raise SceneValidationError(
+            "Scene is not georeferenced (no geotransform); it cannot be placed on the " "mosaic grid."
+        )
+
+    if not dataset.get_wkt_spatial_reference():
+        raise SceneValidationError(
+            "Scene has no spatial reference system (SRS); it cannot be placed on the " "mosaic grid."
+        )
+
+    validate_scene_addable(dataset, existing_scenes)
 
 
 def build_overviews(gdal_path: str, progress: Optional[ProgressReporter] = None) -> None:


### PR DESCRIPTION
## What does this change do?
Add ability for mosaic pane to load scenes that don't have a CRS or don't have a compatible CRS with those already loaded.

Closes #707

## What type of PR is this? (check all applicable) 
- [X] Feature
- [ ] Bug Fix
- [X] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [X] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
Needed so people can load scenes into mosaic then geo reference as their workflow.

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed

## Desktop Screenshots/Recordings  
<!-- If applicable, add screenshots or video links showing changes. -->

## [optional] Are there any post-merge tasks we need to perform?  
<!-- List any tasks required after merge. -->