### PR TITLE
feat(mosaic): Zoom to a specific scene

### DIFF
--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -64,7 +64,7 @@ jobs:
     # If triggered by workflow_run, only run when upstream succeeded.
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     needs: [lint]
     defaults:
         run:

--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -18,10 +18,11 @@ method, and the band-metadata chooser), the **full-resolution export path**
 (streaming ENVI compositor on the common grid — see [The Export
 Path](#the-export-path)), and **in-place scene
 re-georeferencing** (right-click → warp → swap; see [Re-georeferencing a Scene In
-Place](#re-georeferencing-a-scene-in-place)), and **pending (disabled) scenes**
+Place](#re-georeferencing-a-scene-in-place)), **pending (disabled) scenes**
 (non-georeferenced or CRS-incompatible scenes carried in the list until georeferenced;
-see [Pending Scenes](#pending-scenes-disabled-scenes)) are implemented and wired into
-the GUI.
+see [Pending Scenes](#pending-scenes-disabled-scenes)), and **zoom-to-scene**
+(right-click a live scene → frame the camera on its footprint; see [Zoom to
+Scene](#zoom-to-scene)) are implemented and wired into the GUI.
 ```
 
 For the design rationale and full child-issue breakdown, see `EPIC_seamless_mosaic.md`
@@ -1090,9 +1091,19 @@ GCP, or CRS logic is added here.
 `_build_scene_list_group` gives `self._scene_list` a `Qt.CustomContextMenu` policy;
 `_on_scene_context_menu(pos)` resolves the clicked row to a **controller** index via
 `item.data(Qt.UserRole)` (the list is shown top-first but each item carries its real
-bottom-to-top index) and pops a one-action `QMenu` → `_on_georeference_scene(index)`. The
-menu is suppressed when the scheduler or the session materializer is absent, since the
-swap reingests (the same requirement Add Scene guards on).
+bottom-to-top index) and pops a `QMenu` whose actions are built **per-scene**:
+
+- **"Georeference…"** → `_on_georeference_scene(index)`. Offered only when the scheduler
+  **and** the session materializer are present, since the swap reingests (the same
+  requirement Add Scene guards on).
+- **"Zoom to Scene"** → `_on_zoom_to_scene(index)`. Offered only for **live** scenes
+  (`not controller.is_scene_pending(scene)`) — a pending scene has no placeable footprint
+  on the common canvas, so there is nothing to frame. See [Zoom to
+  Scene](#zoom-to-scene) below.
+
+The menu gates are **per-action**, not on the whole menu: the georeference guard no
+longer suppresses the entire menu, so a live scene on a materializer-less pane still gets
+"Zoom to Scene". If no action qualifies the menu is simply not shown (`menu.isEmpty()`).
 
 ### Opening the dialog (locked target + locked save path)
 
@@ -1201,6 +1212,41 @@ exactly why the design reingests rather than patching caches in place — one co
 rebuild, and the export path picks it up for free. (The correction lives only for the
 session; the mosaic export re-warps from the temp at full resolution, so the on-disk
 product is correct without persisting the single corrected scene separately.)
+
+---
+
+## Zoom to Scene
+
+**Files:** `src/wiser/raster/mosaic_controller.py` (the extent helper),
+`src/wiser/gui/mosaic_view.py` (the camera move), and `src/wiser/gui/mosaic_pane.py`
+(the menu action).
+
+Right-clicking a **live** scene offers **"Zoom to Scene"**, which frames the map camera
+on just that scene's footprint — the per-scene analogue of the one-time whole-mosaic
+auto-fit. It is a thin glue layer over three pieces that already existed; no new
+geometry, reprojection, or camera math is added.
+
+- **`MosaicController.scene_extent_in_common_crs(scene)`** (Qt-free) returns
+  `(min_x, min_y, max_x, max_y)` of the scene's footprint in the **resolved target CRS**,
+  reusing `_footprint_envelope` / `reprojected_footprint_geometry` (the same reprojection
+  the grid builder and overlay use). It returns `None` — so the action is a safe no-op —
+  when the scene is pending, has no footprint, or no target CRS is resolved yet. This
+  mirrors `build_common_grid`'s union extent, but for a single scene.
+- **`MosaicView.zoom_to_extent(extent, margin=0.05)`** pads the extent by a small margin
+  (so the footprint isn't flush against the viewport edges), calls the camera's existing
+  `MosaicViewTransform.fit_to_extent`, and repaints. It is a no-op until the widget has a
+  real size. It sets `_has_fitted = True` so the initial-fit branch in `paintEvent` can
+  never later snap the camera back to the whole-grid extent — a deliberate zoom is never
+  yanked away. A plain `self.update()` is enough: the moved camera makes `paintEvent`
+  schedule the debounced, off-thread tile read for the newly-visible cells (the same path
+  a pan/zoom gesture takes), so no `invalidate_pixels` full-cache clear is needed.
+- **`MosaicPane._on_zoom_to_scene(index)`** resolves the scene, asks the controller for
+  its extent, and (if not `None`) calls `zoom_to_extent`. The menu only shows the action
+  for live scenes, but the handler re-checks for `None` in case the scene went pending
+  between the menu opening and the click.
+
+The margin is symmetric, so the camera **center** lands exactly on the footprint's
+midpoint — which is what the GUI test asserts.
 
 ---
 
@@ -1330,7 +1376,10 @@ channels out.
   grid, an all-pending mosaic yields an empty grid, and an ingested-but-incompatible
   scene (built incrementally so the first scene auto-locks the target) is
   `INCOMPATIBLE_CRS`-pending — asserting `is_scene_pending`, `scene_pending_reason`,
-  `has_live_scenes`, `has_pending_scenes`, and `_live_scenes`.
+  `has_live_scenes`, `has_pending_scenes`, and `_live_scenes`. Zoom to Scene:
+  `scene_extent_in_common_crs` returns a live scene's footprint envelope (matching
+  `_footprint_envelope`, ordered `min_x/min_y/max_x/max_y`) and `None` for a pending
+  scene.
 - `src/tests/test_mosaic_view_transform.py` — `MosaicViewTransform` camera math:
   world↔screen round-trip, y-flip orientation, zoom-anchor invariance, aspect-ratio
   preservation (pure `QTransform` math, no widget shown).
@@ -1405,7 +1454,11 @@ channels out.
   warp output is **not** registered as a global dataset; Cancel restores the original at
   its slot while "Save to Mosaic" keeps the warped one. `test_add_non_georeferenced_scene_is_pending`
   loads a truly ungeoreferenced TIFF, adds it, and asserts it lands as a `NO_CRS`-pending
-  placeholder with the warning icon/tooltip and excluded from the grid.
+  placeholder with the warning icon/tooltip and excluded from the grid — and that its
+  context menu offers "Georeference…" but **not** "Zoom to Scene". Zoom to Scene: a live
+  scene's menu offers **both** actions and each routes to the right handler/index;
+  `_on_zoom_to_scene` moves the camera so its center lands on the scene footprint's
+  midpoint.
 
 GUI tests use `@pytest.mark.functional`/`@pytest.mark.smoke` with the
 `WiserTestModel` harness (`src/test_utils/test_model.py`), not pytest-qt/qtbot. Run

--- a/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/mosaic-internals.md
@@ -710,6 +710,11 @@ go live. If the change leaves no live scenes at all, the pane warns that the pre
 empty but still keeps the chosen CRS. Removal / visibility changes rebuild quietly as before
 (see [Removal and visibility changes](#removal-and-visibility-changes)).
 
+A CRS change also moves the world grid without moving the camera, so `_on_choose_target_crs`
+then calls `MosaicView.ensure_scenes_in_view()` to reframe the preview when the mosaic
+landed off-screen — see [Reframing after a target-CRS
+change](#reframing-after-a-target-crs-change).
+
 ### Export guard
 
 Export operates on `live_scenes()`. If `has_pending_scenes()` is `True`,
@@ -1248,6 +1253,24 @@ geometry, reprojection, or camera math is added.
 The margin is symmetric, so the camera **center** lands exactly on the footprint's
 midpoint — which is what the GUI test asserts.
 
+### Reframing after a target-CRS change
+
+The camera holds raw world coordinates (`center_x` / `center_y`) that are **not**
+transformed when the target CRS changes, so after a manual **"Choose Target CRS…"**
+switch the parked camera often points at a region the mosaic no longer occupies (e.g.
+switching UTM → geographic moves every footprint from eastings ~4×10⁵ to lon/lat ~−117/34)
+— the preview goes blank even though the scenes are fine.
+
+`MosaicView.ensure_scenes_in_view()`, called from `_on_choose_target_crs` right after the
+grid rebuild + view invalidation, fixes this **conservatively**: it reprojects the live
+footprints into the new CRS (`visible_scene_footprints_in_common_crs()`), tests each
+against the current viewport (`_visible_world_extent` + `_envelope_intersects`), and
+reframes to the union extent (`get_common_grid().extent`, via `zoom_to_extent`) **only
+when none is visible**. If any scene still intersects the viewport the user's pan/zoom is
+left untouched — the reframe rescues the off-screen case without yanking the camera on a
+CRS change that happened to keep the mosaic in view. It reuses the same `zoom_to_extent`
+(hence the same margin) as [Zoom to Scene](#zoom-to-scene).
+
 ---
 
 ## The Export Path
@@ -1442,7 +1465,10 @@ channels out.
   `wiser.gui.mosaic_pane.ReprojectPromptDialog` so nothing blocks the test. Also
   `test_manual_choose_target_crs_incompatible_marks_pending`: choosing an incompatible
   target CRS **commits** the choice, leaves no live scenes, marks the scenes pending, and
-  warns (rather than rejecting the change).
+  warns (rather than rejecting the change). Reframing: switching UTM → geographic pushes
+  the mosaic off the parked camera, and `_on_choose_target_crs` reframes to the new union
+  extent (`test_choose_target_crs_reframes_when_mosaic_off_screen`); when a scene is still
+  in view the camera is left untouched (`test_ensure_scenes_in_view_is_noop_when_a_scene_is_visible`).
 - `src/tests/test_mosaic_dialog_gui.py` — dialog shell, Add Scene ingestion flow,
   progress modal; asserts the ingested `MosaicScene.stretch_bounds` is populated
   (#675).

--- a/src/tests/test_mosaic_controller.py
+++ b/src/tests/test_mosaic_controller.py
@@ -390,6 +390,28 @@ def test_reprojected_footprint_same_crs_is_identity(tmp_path):
     assert geom.GetEnvelope() == pytest.approx(orig.GetEnvelope())
 
 
+def test_scene_extent_in_common_crs_live_and_pending(tmp_path):
+    # A live (ingested) scene plus a bare, non-georeferenced placeholder.
+    live = _make_scene(tmp_path, "live", epsg=32611, origin=(400000.0, 3800000.0), pixel=1.0)
+    ghost = _no_crs_scene("ghost")
+    c = MosaicController()
+    c.add_scene(live)
+    c.add_scene(ghost)
+    c.build_common_grid()  # auto-locks the target CRS to the live scene's CRS
+
+    # The live scene's extent equals its footprint envelope in the target CRS, ordered
+    # (min_x, min_y, max_x, max_y) -- the exact tuple fit_to_extent consumes.
+    src = live.dataset.get_spatial_ref()
+    target = _srs_from_wkt(c.get_target_crs())
+    expected = _footprint_envelope(live, src, target)
+    got = c.scene_extent_in_common_crs(live)
+    assert got == pytest.approx(expected)
+    assert got[0] < got[2] and got[1] < got[3]
+
+    # A pending (NO_CRS) scene has no placeable footprint -> no extent.
+    assert c.scene_extent_in_common_crs(ghost) is None
+
+
 def test_compute_union_overlaps_partial():
     # Bottom-to-top: A, B, C. B partly under C; A partly under B∪C. C is on top.
     a = _square(0, 0, 10, 10)

--- a/src/tests/test_mosaic_crs_gui.py
+++ b/src/tests/test_mosaic_crs_gui.py
@@ -249,6 +249,77 @@ class TestMosaicCrsGui(unittest.TestCase):
 
         self.test_model.close_seamless_mosaic_dialog()
 
+    # -- CRS change reframes the camera when the mosaic lands off-screen -------
+
+    def test_choose_target_crs_reframes_when_mosaic_off_screen(self):
+        # Two UTM (32611) scenes -> the camera is framed on eastings ~4e5. Switching the
+        # target to geographic (4326) reprojects the footprints to ~(-117, 34), far from
+        # the parked camera, so the mosaic lands off-screen and must be reframed.
+        ds_a = self._load("a_utm.tif", 32611)
+        ds_b = self._load("b_utm.tif", 32611)
+
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        view = pane._mosaic_view
+
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_a, 1)
+            self._ingest(pane, controller, ds_b, 2)
+
+        # Frame the camera on the UTM mosaic, as the user would be viewing it.
+        view.resize(300, 300)
+        view.zoom_to_extent(controller.get_common_grid().extent)
+        self.assertGreater(view._transform.center_x, 100000.0)  # parked over UTM easting
+
+        target_geo = osr.SpatialReference()
+        target_geo.ImportFromEPSG(4326)
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog") as Dlg:
+            inst = Dlg.return_value
+            inst.exec.return_value = QDialog.Accepted
+            inst.selected_target_wkt.return_value = target_geo.ExportToWkt()
+            pane._on_choose_target_crs()
+
+        self.assertTrue(_same_as_epsg(controller.get_target_crs(), 4326))
+        # The camera reframed to the new (geographic) union extent center.
+        geo_extent = controller.get_common_grid().extent
+        self.assertAlmostEqual(view._transform.center_x, (geo_extent[0] + geo_extent[2]) / 2.0, places=3)
+        self.assertAlmostEqual(view._transform.center_y, (geo_extent[1] + geo_extent[3]) / 2.0, places=3)
+
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_ensure_scenes_in_view_is_noop_when_a_scene_is_visible(self):
+        # No CRS change: the scene is already framed, so ensure_scenes_in_view must leave
+        # the user's pan/zoom untouched (only an off-screen mosaic gets reframed).
+        ds_a = self._load("a_utm.tif", 32611)
+
+        dlg = self.test_model.open_seamless_mosaic_dialog()
+        pane = dlg.get_mosaic_pane()
+        controller = pane.get_controller()
+        view = pane._mosaic_view
+
+        with mock.patch("wiser.gui.mosaic_pane.ReprojectPromptDialog"):
+            self._ingest(pane, controller, ds_a, 1)
+
+        view.resize(300, 300)
+        view.zoom_to_extent(controller.get_common_grid().extent)
+        before = (
+            view._transform.center_x,
+            view._transform.center_y,
+            view._transform.world_units_per_pixel,
+        )
+
+        view.ensure_scenes_in_view()
+
+        after = (
+            view._transform.center_x,
+            view._transform.center_y,
+            view._transform.world_units_per_pixel,
+        )
+        self.assertEqual(before, after)
+
+        self.test_model.close_seamless_mosaic_dialog()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/tests/test_mosaic_georeference_gui.py
+++ b/src/tests/test_mosaic_georeference_gui.py
@@ -108,6 +108,19 @@ class TestMosaicPendingScene(unittest.TestCase):
         self.assertFalse(item.icon().isNull())
         self.assertIn("no CRS", item.toolTip())
 
+        # A pending scene offers "Georeference…" (to fix it) but NOT "Zoom to Scene"
+        # (it has no placeable footprint on the common canvas).
+        with mock.patch("wiser.gui.mosaic_pane.QMenu") as MenuCls, mock.patch.object(
+            pane._scene_list, "itemAt", return_value=item
+        ):
+            menu = MenuCls.return_value
+            menu.addAction.side_effect = lambda *_a: mock.Mock()
+            menu.isEmpty.return_value = False
+            pane._on_scene_context_menu(QPoint(0, 0))
+            labels = [call.args[0] for call in menu.addAction.call_args_list]
+            self.assertTrue(any("Georeference" in label for label in labels))
+            self.assertFalse(any("Zoom to Scene" in label for label in labels))
+
         self.test_model.close_seamless_mosaic_dialog()
 
 
@@ -164,30 +177,57 @@ class TestMosaicRegeoreferenceEntryPoint(unittest.TestCase):
         self.assertEqual(pane._scene_list.contextMenuPolicy(), Qt.CustomContextMenu)
         self.test_model.close_seamless_mosaic_dialog()
 
-    def test_context_menu_offers_georeference(self):
+    def test_context_menu_offers_georeference_and_zoom_for_live(self):
         _dlg, pane, controller = self._open_with_two_scenes()
         # Row 0 is the top scene; it carries its real controller index in UserRole.
         item = pane._scene_list.item(0)
         index = item.data(Qt.UserRole)
 
-        # Patch QMenu so exec_ does not block, and _on_georeference_scene so we can
-        # confirm the action targets the right controller index.
+        # Patch QMenu so exec_ does not block, and the handlers so we can confirm each
+        # action targets the right controller index. A live scene gets both actions.
         with mock.patch("wiser.gui.mosaic_pane.QMenu") as MenuCls, mock.patch.object(
             pane._scene_list, "itemAt", return_value=item
-        ), mock.patch.object(pane, "_on_georeference_scene") as geo:
+        ), mock.patch.object(pane, "_on_georeference_scene") as geo, mock.patch.object(
+            pane, "_on_zoom_to_scene"
+        ) as zoom:
             menu = MenuCls.return_value
-            action = menu.addAction.return_value
+            georef_action, zoom_action = mock.Mock(), mock.Mock()
+            menu.addAction.side_effect = [georef_action, zoom_action]
+            menu.isEmpty.return_value = False
             pane._on_scene_context_menu(QPoint(0, 0))
 
-            menu.addAction.assert_called_once()
-            (label,), _ = menu.addAction.call_args
-            self.assertIn("Georeference", label)
+            labels = [call.args[0] for call in menu.addAction.call_args_list]
+            self.assertEqual(len(labels), 2)
+            self.assertIn("Georeference", labels[0])
+            self.assertIn("Zoom to Scene", labels[1])
             menu.exec_.assert_called_once()
 
-            # Firing the action re-georeferences the clicked row's scene.
-            (slot,), _ = action.triggered.connect.call_args
-            slot()
+            # Firing each action routes to the right handler with the clicked index.
+            (geo_slot,), _ = georef_action.triggered.connect.call_args
+            geo_slot()
             geo.assert_called_once_with(index)
+            (zoom_slot,), _ = zoom_action.triggered.connect.call_args
+            zoom_slot()
+            zoom.assert_called_once_with(index)
+        self.test_model.close_seamless_mosaic_dialog()
+
+    def test_zoom_to_scene_reframes_view_on_the_scene(self):
+        _dlg, pane, controller = self._open_with_two_scenes()
+        view = pane._mosaic_view
+        view.resize(300, 300)  # give the canvas a real size so the camera math runs
+        index = 0
+        scene = controller.get_scenes()[index]
+        extent = controller.scene_extent_in_common_crs(scene)
+        self.assertIsNotNone(extent)
+        min_x, min_y, max_x, max_y = extent
+
+        pane._on_zoom_to_scene(index)
+
+        # The camera centers on the scene's footprint (padding is symmetric, so the
+        # center is unshifted) and zooms in to frame it.
+        self.assertAlmostEqual(view._transform.center_x, (min_x + max_x) / 2.0, places=3)
+        self.assertAlmostEqual(view._transform.center_y, (min_y + max_y) / 2.0, places=3)
+        self.assertGreater(view._transform.world_units_per_pixel, 0.0)
         self.test_model.close_seamless_mosaic_dialog()
 
     def test_context_menu_no_op_without_item(self):

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -668,24 +668,38 @@ class MosaicPane(QWidget):
 
     def _on_scene_context_menu(self, pos) -> None:
         """
-        Right-click on a scene row: offer "Georeference…" for that scene.
+        Right-click on a scene row: offer per-scene actions.
 
-        Re-georeferencing reingests the warped result, which needs the scheduler and
-        the session materializer -- the same requirement Add Scene guards on -- so the
-        menu is suppressed when either is absent (e.g. a display-only pane).
+        "Georeference…" reingests the warped result, which needs the scheduler and the
+        session materializer -- the same requirement Add Scene guards on -- so that
+        action is offered only when both are present (e.g. not on a display-only pane).
+        "Zoom to Scene" frames the map on the scene's footprint and is offered only for
+        live scenes: a pending scene has no placeable footprint on the common canvas.
         """
-        if self._app_services is None or self._materializer is None:
-            return
         item = self._scene_list.itemAt(pos)
         if item is None:
             return
         index = item.data(Qt.UserRole)
         if index is None:
             return
+        scene = self._controller.get_scenes()[index]
         menu = QMenu(self._scene_list)
-        action = menu.addAction(self.tr("Georeference…"))
-        action.triggered.connect(lambda *_a, i=index: self._on_georeference_scene(i))
-        menu.exec_(self._scene_list.mapToGlobal(pos))
+        if self._app_services is not None and self._materializer is not None:
+            georef = menu.addAction(self.tr("Georeference…"))
+            georef.triggered.connect(lambda *_a, i=index: self._on_georeference_scene(i))
+        if not self._controller.is_scene_pending(scene):
+            zoom = menu.addAction(self.tr("Zoom to Scene"))
+            zoom.triggered.connect(lambda *_a, i=index: self._on_zoom_to_scene(i))
+        if not menu.isEmpty():
+            menu.exec_(self._scene_list.mapToGlobal(pos))
+
+    def _on_zoom_to_scene(self, index: int) -> None:
+        """Frame the map view on the scene at controller ``index``'s footprint."""
+        scene = self._controller.get_scenes()[index]
+        extent = self._controller.scene_extent_in_common_crs(scene)
+        if extent is None:  # became pending / lost its target CRS since the menu opened
+            return
+        self._mosaic_view.zoom_to_extent(extent)
 
     def _regeoref_save_path(self, scene: MosaicScene) -> str:
         """

--- a/src/wiser/gui/mosaic_pane.py
+++ b/src/wiser/gui/mosaic_pane.py
@@ -1120,6 +1120,9 @@ class MosaicPane(QWidget):
         self._refresh_scene_list()
         self._mosaic_view.invalidate_overlay()
         self._mosaic_view.invalidate_pixels()
+        # A CRS change moves the world grid but not the parked camera, so the mosaic can
+        # land entirely off-screen; reframe to show every scene when none is left in view.
+        self._mosaic_view.ensure_scenes_in_view()
         if not self._controller.has_live_scenes():
             QMessageBox.warning(
                 self,

--- a/src/wiser/gui/mosaic_view.py
+++ b/src/wiser/gui/mosaic_view.py
@@ -461,6 +461,33 @@ class MosaicView(QWidget):
         self._has_fitted = True
         self.update()
 
+    def ensure_scenes_in_view(self) -> None:
+        """
+        Reframe to the whole-mosaic extent **iff** no live scene is currently visible.
+
+        The camera stores raw world coordinates (``center_x`` / ``center_y``) that are
+        *not* transformed when the target CRS changes, so after a reprojection the
+        parked camera often points at a region the mosaic no longer occupies — a blank
+        canvas. Called after such a move (see
+        :meth:`~wiser.gui.mosaic_pane.MosaicPane._on_choose_target_crs`), this checks
+        whether any live scene footprint (already reprojected into the new target CRS)
+        still intersects the viewport; if one does, the user's pan/zoom is left alone,
+        and only when **none** do is the camera reframed to the union extent so every
+        scene is visible again. No-op until the widget has a real size or while the
+        mosaic has no resolved footprints.
+        """
+        if self.width() <= 1 or self.height() <= 1:
+            return
+        footprints = self._controller.visible_scene_footprints_in_common_crs()
+        if not footprints:
+            return
+        viewport = self._visible_world_extent()
+        if any(self._envelope_intersects(geom, viewport) for _scene, geom in footprints):
+            return
+        grid = self._controller.get_common_grid()
+        if grid.extent is not None:
+            self.zoom_to_extent(grid.extent)
+
     def _visible_world_extent(self) -> Tuple[float, float, float, float]:
         """The camera's visible rectangle as ``(min_x, min_y, max_x, max_y)`` in world."""
         size = self.size()

--- a/src/wiser/gui/mosaic_view.py
+++ b/src/wiser/gui/mosaic_view.py
@@ -436,6 +436,31 @@ class MosaicView(QWidget):
         self._schedule_pixel_read()
         self.update()
 
+    def zoom_to_extent(self, extent: Tuple[float, float, float, float], margin: float = 0.05) -> None:
+        """
+        Frame a world-coordinate ``(min_x, min_y, max_x, max_y)`` extent, padded by
+        ``margin`` (a fraction of each side) so the target is not flush against the
+        viewport edges, then repaint.
+
+        This is the per-scene analogue of the one-time whole-mosaic auto-fit in
+        :meth:`paintEvent`. It is a no-op until the widget has a real size (the camera
+        math needs a non-degenerate viewport). Setting ``_has_fitted`` keeps the
+        auto-fit branch from later snapping the camera back to the whole-grid extent,
+        so a deliberate zoom is never yanked away. ``update()`` is enough: the moved
+        camera makes ``paintEvent`` schedule the debounced, off-thread read for the
+        newly-visible tiles (the same path as a pan/zoom gesture).
+        """
+        if self.width() <= 1 or self.height() <= 1:
+            return
+        min_x, min_y, max_x, max_y = extent
+        pad_x = (max_x - min_x) * margin
+        pad_y = (max_y - min_y) * margin
+        self._transform.fit_to_extent(
+            (min_x - pad_x, min_y - pad_y, max_x + pad_x, max_y + pad_y), self.size()
+        )
+        self._has_fitted = True
+        self.update()
+
     def _visible_world_extent(self) -> Tuple[float, float, float, float]:
         """The camera's visible rectangle as ``(min_x, min_y, max_x, max_y)`` in world."""
         size = self.size()

--- a/src/wiser/raster/mosaic_controller.py
+++ b/src/wiser/raster/mosaic_controller.py
@@ -578,6 +578,24 @@ class MosaicController:
 
     # -- geometry overlay (#636) ---------------------------------------------
 
+    def scene_extent_in_common_crs(self, scene: MosaicScene) -> Optional[Tuple[float, float, float, float]]:
+        """
+        Return ``(min_x, min_y, max_x, max_y)`` of ``scene``'s footprint in the
+        resolved target CRS, or ``None`` when the scene cannot be placed on the
+        common canvas: it is pending, has no footprint, or no target CRS is resolved
+        yet. This is a single-scene analogue of the union extent
+        :meth:`build_common_grid` computes, reused by the view's "zoom to scene".
+        """
+        if self.is_scene_pending(scene):
+            return None
+        target_wkt = self._resolved_target_wkt()
+        if target_wkt is None:
+            return None
+        src_srs = scene.dataset.get_spatial_ref()
+        if src_srs is None or scene.footprint_wkt is None:
+            return None
+        return _footprint_envelope(scene, src_srs, _srs_from_wkt(target_wkt))
+
     def visible_scene_footprints_in_common_crs(
         self,
     ) -> List[Tuple[MosaicScene, ogr.Geometry]]:


### PR DESCRIPTION
## What does this change do?
Add ability for mosaic to zoom to a specific scene. Also adds if the target crs change does not have any scenes in the window, we zoom to show all scenes.

Closes #706

## What type of PR is this? (check all applicable) 
- [x] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
If the user changes their target crs or loses where they are, this will help them find it again. 

## Added tests?
- [X] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [X] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed