### PR TITLE
 Save and open projects behind a progress dialog: cancellable, and crash-safe

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/user-content/projects.md
+++ b/doc/sphinx-general-wiser-docs/source/user-content/projects.md
@@ -131,6 +131,12 @@ a different selection.
 Choose **File ▸ Open Project...**. Opening a project replaces your current session,
 so WISER asks you to confirm first — save your work beforehand if you need it.
 
+A self-contained project has to be unpacked before it can be opened, which takes a
+moment for a large one, so WISER shows the same progress dialog it shows when
+saving. You can cancel it: your current session is only replaced once the project has
+been unpacked successfully, so cancelling an open leaves the session you already had
+exactly as it was, rather than half-replaced.
+
 If anything in the project cannot be restored, WISER still opens it and tells you
 what was left out. The usual cause is a **referenced** data file that has since been
 moved, renamed, or deleted; a self-contained project is immune to this, since it

--- a/doc/sphinx-general-wiser-docs/source/user-content/projects.md
+++ b/doc/sphinx-general-wiser-docs/source/user-content/projects.md
@@ -95,6 +95,19 @@ it with a colleague.
 Datasets that only exist inside WISER — a band math result, a PCA output — have no
 file on disk to point at, so they are always stored inside the project either way.
 
+### While the project is being written
+
+Writing a project is quick when the data is only referenced, but a self-contained save
+copies and compresses every image into the project file, which can take a while for a
+large scene. WISER shows a progress dialog while it works and leaves the main window
+disabled until it finishes, so the save cannot be disturbed halfway through. Progress
+is also mirrored in the Activity Monitor.
+
+You can **cancel** from that dialog. Cancelling means nothing happened: WISER builds
+the new project alongside the destination and only puts it in place once it is
+complete, so a cancelled save — like one interrupted by a crash or a full disk —
+leaves any project already saved at that location exactly as it was.
+
 ---
 
 ## Saving again

--- a/src/tests/test_project_orchestrate.py
+++ b/src/tests/test_project_orchestrate.py
@@ -21,7 +21,13 @@ from osgeo import osr
 
 from wiser.gui.permanent_plugins.pca_plugin import PCARunRecord
 from wiser.gui.reference_creator_dialog import CrsCreatorState
-from wiser.project.orchestrate import load_project, project_embeds_datasets, save_project
+from wiser.project.orchestrate import (
+    load_project,
+    open_bundle,
+    project_embeds_datasets,
+    restore_bundle,
+    save_project,
+)
 from wiser.utils.progress import ProgressCancelled, ProgressReporter
 from wiser.raster.loader import RasterDataLoader
 from wiser.raster.roi import RegionOfInterest
@@ -362,6 +368,40 @@ def test_a_cancelled_save_leaves_the_existing_project_untouched(tmp_path):
     report = load_project(proj, dst, extract_dir=tmp_path / "unpacked")
     assert report["datasets"] == []  # still opens
     assert len(dst.get_datasets()) == 1  # holding what it held before the cancel
+
+
+def test_a_cancelled_open_leaves_the_current_session_alone(tmp_path):
+    # Unpacking is the slow half of an open and is what gets cancelled; the session is
+    # only cleared by the restore.  So abandoning an open costs the user nothing -- they
+    # keep the session they had, rather than half of the one they asked for.
+    app, _ = _populated_session()
+    proj = tmp_path / "session.wiserproj"
+    save_project(app, proj)
+
+    working = _FakeAppState()
+    kept = working.get_loader().dataset_from_numpy_array(_sample_array(), None)
+    working.add_dataset(kept)
+
+    cancel = ProgressReporter(is_cancelled=lambda: True)
+    with pytest.raises(ProgressCancelled):
+        open_bundle(proj, tmp_path / "unpacked", progress=cancel)
+
+    assert [ds.get_id() for ds in working.get_datasets()] == [kept.get_id()]
+
+
+def test_open_reports_progress_to_completion(tmp_path):
+    app, _ = _populated_session()
+    proj = tmp_path / "session.wiserproj"
+    save_project(app, proj)
+
+    seen = []
+    reporter = ProgressReporter(sink=lambda fraction, message: seen.append(fraction))
+    bundle = open_bundle(proj, tmp_path / "unpacked", progress=reporter)
+
+    assert seen == sorted(seen)
+    assert seen[-1] == 1.0
+    dst = _FakeAppState()
+    assert restore_bundle(bundle, dst)["datasets"] == []  # and the bundle it gives back works
 
 
 def test_save_reports_progress_to_completion(tmp_path):

--- a/src/tests/test_project_orchestrate.py
+++ b/src/tests/test_project_orchestrate.py
@@ -370,6 +370,30 @@ def test_a_cancelled_save_leaves_the_existing_project_untouched(tmp_path):
     assert len(dst.get_datasets()) == 1  # holding what it held before the cancel
 
 
+def test_a_cancelled_directory_save_leaves_the_existing_bundle_untouched(tmp_path):
+    # The same guarantee as the zip form, which the bundle-directory form did not have:
+    # _write_bundle clears the bundle before writing it, so saving straight into the
+    # destination destroyed the project already there the instant the save began.
+    app = _FakeAppState()
+    app.add_dataset(app.get_loader().dataset_from_numpy_array(_sample_array(), None))
+    bundle_dir = tmp_path / "session"
+    save_project(app, bundle_dir)
+    manifest_before = (bundle_dir / "manifest.json").read_text()
+
+    app.add_dataset(app.get_loader().dataset_from_numpy_array(_sample_array(), None))
+    cancel = ProgressReporter(is_cancelled=lambda: True)
+    with pytest.raises(ProgressCancelled):
+        save_project(app, bundle_dir, progress=cancel)
+
+    assert (bundle_dir / "manifest.json").read_text() == manifest_before
+    assert not (tmp_path / "session.part").exists()  # the abandoned bundle is gone
+    assert not (tmp_path / "session.bak").exists()  # and so is the backup
+
+    dst = _FakeAppState()
+    load_project(bundle_dir, dst)
+    assert len(dst.get_datasets()) == 1  # still the project it was
+
+
 def test_a_cancelled_open_leaves_the_current_session_alone(tmp_path):
     # Unpacking is the slow half of an open and is what gets cancelled; the session is
     # only cleared by the restore.  So abandoning an open costs the user nothing -- they

--- a/src/tests/test_project_orchestrate.py
+++ b/src/tests/test_project_orchestrate.py
@@ -394,6 +394,43 @@ def test_a_cancelled_directory_save_leaves_the_existing_bundle_untouched(tmp_pat
     assert len(dst.get_datasets()) == 1  # still the project it was
 
 
+def test_a_save_clears_a_stale_staging_path_of_either_kind(tmp_path):
+    # A crash can leave a ".part" behind, and not necessarily as the kind we expect: the
+    # zip form leaves a file, the directory form a directory.  Cleanup that assumed one
+    # or the other would either fail outright or mask the failure it was cleaning up.
+    zipped = tmp_path / "zipped.wiserproj"
+    (tmp_path / "zipped.wiserproj.part").mkdir()  # a directory where a file is expected
+    bundle_dir = tmp_path / "dir"
+    (tmp_path / "dir.part").write_text("junk")  # a file where a directory is expected
+
+    app = _FakeAppState()
+    app.add_dataset(app.get_loader().dataset_from_numpy_array(_sample_array(), None))
+    save_project(app, zipped)
+    save_project(app, bundle_dir)
+
+    assert not (tmp_path / "zipped.wiserproj.part").exists()
+    assert not (tmp_path / "dir.part").exists()
+    for dest in (zipped, bundle_dir):
+        dst = _FakeAppState()
+        load_project(dest, dst, extract_dir=tmp_path / f"unpacked-{dest.name}")
+        assert len(dst.get_datasets()) == 1
+
+
+def test_a_cancelled_open_removes_what_it_extracted(tmp_path):
+    # Abandoning the unpack of a large self-contained project would otherwise strand
+    # gigabytes in the temp directory it was being unpacked into.
+    app, _ = _populated_session()
+    proj = tmp_path / "session.wiserproj"
+    save_project(app, proj, self_contained=True)
+
+    extract_dir = tmp_path / "unpacked"
+    cancel = ProgressReporter(is_cancelled=lambda: True)
+    with pytest.raises(ProgressCancelled):
+        open_bundle(proj, extract_dir, progress=cancel)
+
+    assert not extract_dir.exists()
+
+
 def test_a_cancelled_open_leaves_the_current_session_alone(tmp_path):
     # Unpacking is the slow half of an open and is what gets cancelled; the session is
     # only cleared by the restore.  So abandoning an open costs the user nothing -- they

--- a/src/tests/test_project_orchestrate.py
+++ b/src/tests/test_project_orchestrate.py
@@ -12,6 +12,7 @@ import os
 import shutil
 
 import numpy as np
+import pytest
 
 import tests.context  # noqa: F401
 
@@ -21,6 +22,7 @@ from osgeo import osr
 from wiser.gui.permanent_plugins.pca_plugin import PCARunRecord
 from wiser.gui.reference_creator_dialog import CrsCreatorState
 from wiser.project.orchestrate import load_project, project_embeds_datasets, save_project
+from wiser.utils.progress import ProgressCancelled, ProgressReporter
 from wiser.raster.loader import RasterDataLoader
 from wiser.raster.roi import RegionOfInterest
 from wiser.raster.selection import RectangleSelection
@@ -335,6 +337,45 @@ def test_roi_average_survives_round_trip_when_ids_gap(tmp_path):
     restored_roi = dst.get_roi(id=roi.get_id())
     assert restored_roi is not None
     assert restored_roi.get_id() == roi.get_id()
+
+
+def test_a_cancelled_save_leaves_the_existing_project_untouched(tmp_path):
+    # Cancelling means nothing happened.  The archive is built beside the destination
+    # and moved into place only when complete, so the project already saved there is
+    # still openable -- writing into it directly would truncate it at the first byte.
+    app = _FakeAppState()
+    app.add_dataset(app.get_loader().dataset_from_numpy_array(_sample_array(), None))
+    proj = tmp_path / "session.wiserproj"
+    save_project(app, proj)
+    original = proj.read_bytes()
+
+    # A second dataset, so the cancelled save would have written a different project.
+    app.add_dataset(app.get_loader().dataset_from_numpy_array(_sample_array(), None))
+    cancel = ProgressReporter(is_cancelled=lambda: True)
+    with pytest.raises(ProgressCancelled):
+        save_project(app, proj, progress=cancel)
+
+    assert proj.read_bytes() == original  # the previous save survived
+    assert not list(tmp_path.glob("*.part"))  # and the abandoned archive is gone
+
+    dst = _FakeAppState()
+    report = load_project(proj, dst, extract_dir=tmp_path / "unpacked")
+    assert report["datasets"] == []  # still opens
+    assert len(dst.get_datasets()) == 1  # holding what it held before the cancel
+
+
+def test_save_reports_progress_to_completion(tmp_path):
+    app = _FakeAppState()
+    app.add_dataset(app.get_loader().dataset_from_numpy_array(_sample_array(), None))
+    app.add_dataset(app.get_loader().dataset_from_numpy_array(_sample_array(), None))
+
+    seen = []
+    reporter = ProgressReporter(sink=lambda fraction, message: seen.append(fraction))
+    save_project(app, tmp_path / "session.wiserproj", progress=reporter)
+
+    assert seen, "the save reported no progress at all"
+    assert seen == sorted(seen)  # never runs backwards
+    assert seen[-1] == 1.0  # and it finishes
 
 
 def test_self_contained_save_embeds_file_backed_dataset(tmp_path):

--- a/src/tests/test_project_save_gui.py
+++ b/src/tests/test_project_save_gui.py
@@ -22,6 +22,7 @@ import pytest
 import tests.context  # noqa: F401
 
 from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QDialog, QMessageBox
 
 from test_utils.test_model import WiserTestModel
@@ -63,6 +64,23 @@ class TestProjectSaveGui(unittest.TestCase):
             )
         return src_dir, self.test_model.load_dataset(os.path.join(src_dir, "scene"))
 
+    def _wait_for(self, predicate, timeout_ms: int = 60000, step_ms: int = 20) -> bool:
+        """Pump the Qt event loop until ``predicate()`` is true or the timeout elapses."""
+        waited = 0
+        while waited < timeout_ms:
+            if predicate():
+                return True
+            QTest.qWait(step_ms)
+            waited += step_ms
+        return predicate()
+
+    def _await_save(self, runner):
+        """The save runs on the scheduler behind a progress dialog; wait it out."""
+        self.assertIsNotNone(runner, "no save was started")
+        completed = self._wait_for(lambda: getattr(runner, "_done", False))
+        self.test_model.app.processEvents()  # let on_success run on the GUI thread
+        self.assertTrue(completed, "the save did not finish within the timeout")
+
     def _save_as(self, path, self_contained=False, excluded=()):
         """Drive File > Save Project As, standing in for the dialog and the file picker."""
         dialog = mock.MagicMock()
@@ -74,7 +92,12 @@ class TestProjectSaveGui(unittest.TestCase):
             mock.patch("wiser.gui.app.SaveProjectDialog", return_value=dialog),
             mock.patch("wiser.gui.app.QFileDialog.getSaveFileName", return_value=(path, "")),
         ):
-            self.main_window.on_save_project_as()
+            runner = self.main_window.on_save_project_as()
+        self._await_save(runner)
+
+    def _save(self):
+        """Drive File > Save (in place) and wait for it."""
+        self._await_save(self.main_window.on_save_project())
 
     def _open(self, path):
         """Drive File > Open Project, confirming the discard prompt."""
@@ -125,7 +148,7 @@ class TestProjectSaveGui(unittest.TestCase):
         self._save_as(project, excluded=[("dataset", extra.get_id())])
         self.assertEqual(len(self._manifest(project)["datasets"]), 1)
 
-        self.main_window.on_save_project()  # File > Save, in place
+        self._save()  # File > Save, in place
 
         self.assertEqual(len(self._manifest(project)["datasets"]), 1)
 
@@ -142,7 +165,7 @@ class TestProjectSaveGui(unittest.TestCase):
         self._open(project)
 
         self.assertEqual(self.main_window._current_excluded, set())
-        self.main_window.on_save_project()
+        self._save()
         self.assertEqual(len(self._manifest(project)["datasets"]), 1)  # the one it holds
 
     # -- save mode across an open ------------------------------------------
@@ -162,7 +185,7 @@ class TestProjectSaveGui(unittest.TestCase):
         (restored,) = self.app_state.get_datasets()
         self.assertEqual(restored.get_name(), dataset.get_name())
 
-        self.main_window.on_save_project()  # File > Save, in place
+        self._save()  # File > Save, in place
         entry = self._manifest(project)["datasets"][0]
         self.assertEqual(entry["storage"], STORAGE_SIDECAR)
 
@@ -184,6 +207,6 @@ class TestProjectSaveGui(unittest.TestCase):
         self._open(referenced)
 
         self.assertFalse(self.main_window._current_self_contained)
-        self.main_window.on_save_project()
+        self._save()
         entry = self._manifest(referenced)["datasets"][0]
         self.assertEqual(entry["storage"], STORAGE_REFERENCE)

--- a/src/tests/test_project_save_gui.py
+++ b/src/tests/test_project_save_gui.py
@@ -176,6 +176,37 @@ class TestProjectSaveGui(unittest.TestCase):
         self._save()
         self.assertEqual(len(self._manifest(project)["datasets"]), 1)  # the one it holds
 
+    def test_a_failed_open_leaves_the_open_session_and_its_data_alone(self):
+        # An open that fails must not take the session down with it.  The session's
+        # datasets may be sidecars living in the extract directory of the project it was
+        # opened from, so that directory has to outlive a failed attempt at another one.
+        src_dir, _ = self._file_backed_dataset("sources")
+        project = os.path.join(self.tmp_path, "portable.wiserproj")
+        self._save_as(project, self_contained=True)
+        shutil.rmtree(src_dir)  # only the bundle has the pixels now
+        self._open(project)
+        (restored,) = self.app_state.get_datasets()
+
+        junk = os.path.join(self.tmp_path, "not-a-project.wiserproj")
+        with open(junk, "w") as handle:
+            handle.write("this is not a project")
+
+        with (
+            mock.patch("wiser.gui.app.QMessageBox.question", return_value=QMessageBox.Yes),
+            mock.patch("wiser.gui.app.QFileDialog.getOpenFileName", return_value=(junk, "")),
+            mock.patch("wiser.gui.app.QMessageBox.critical") as complained,
+        ):
+            runner = self.main_window.on_open_project()
+            self._wait_for(lambda: getattr(runner, "_done", False))
+            self.test_model.app.processEvents()
+
+        self.assertTrue(complained.called, "the failed open was not reported")
+        (still_there,) = self.app_state.get_datasets()
+        self.assertEqual(still_there.get_id(), restored.get_id())
+        # And its pixels are still readable: the extract dir it reads from survived.
+        self.assertEqual(still_there.num_bands(), restored.num_bands())
+        np.asarray(still_there.get_image_data(filter_data_ignore_value=False))
+
     # -- save mode across an open ------------------------------------------
 
     def test_opening_a_self_contained_project_keeps_saving_it_self_contained(self):

--- a/src/tests/test_project_save_gui.py
+++ b/src/tests/test_project_save_gui.py
@@ -100,13 +100,21 @@ class TestProjectSaveGui(unittest.TestCase):
         self._await_save(self.main_window.on_save_project())
 
     def _open(self, path):
-        """Drive File > Open Project, confirming the discard prompt."""
+        """Drive File > Open Project, confirming the discard prompt, and wait for it.
+
+        The unpack runs on the scheduler; the restore then happens on the GUI thread in
+        the success callback, so the event loop must be pumped for both.
+        """
         with (
             mock.patch("wiser.gui.app.QMessageBox.question", return_value=QMessageBox.Yes),
             mock.patch("wiser.gui.app.QFileDialog.getOpenFileName", return_value=(path, "")),
             mock.patch("wiser.gui.app.QMessageBox.warning") as warned,
         ):
-            self.main_window.on_open_project()
+            runner = self.main_window.on_open_project()
+            self.assertIsNotNone(runner, "no open was started")
+            completed = self._wait_for(lambda: getattr(runner, "_done", False))
+            self.test_model.app.processEvents()  # let the restore run on the GUI thread
+            self.assertTrue(completed, "the open did not finish within the timeout")
         self.assertFalse(warned.called, "the project reported items it could not restore")
 
     def _manifest(self, project_path):

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -789,10 +789,11 @@ class DataVisualizerApp(QMainWindow):
             return None
 
         # A zipped project extracts to a directory that must outlive the load, since
-        # sidecar datasets are read from it lazily.  The app owns it: clear the previous
-        # session's directory and hand the open a fresh one.
-        self._clear_project_extract_dir()
-        self._project_extract_dir = tempfile.mkdtemp(prefix="wiser-project-")
+        # sidecar datasets are read from it lazily.  The *current* session may still be
+        # reading from the one it was opened from, so it is kept until this open has
+        # actually replaced the session -- an open that fails or is cancelled must not
+        # pull the data out from under the session the user still has.
+        extract_dir = tempfile.mkdtemp(prefix="wiser-project-")
 
         # Unpacking a self-contained project copies out every image it holds, so it runs
         # on the scheduler behind a progress dialog.  Only the *restore* touches the
@@ -804,22 +805,22 @@ class DataVisualizerApp(QMainWindow):
             self.tr("Opening Project"),
             open_bundle,
             path,
-            self._project_extract_dir,
-            on_success=lambda bundle: self._restore_project(bundle, path),
-            on_error=self._on_open_failed,
+            extract_dir,
+            on_success=lambda bundle: self._restore_project(bundle, path, extract_dir),
+            on_error=lambda message: self._on_open_failed(message, extract_dir),
             description=self.tr("Unpacking project file…"),
         )
 
-    def _restore_project(self, bundle, path):
+    def _restore_project(self, bundle, path, extract_dir):
         """Restore an unpacked bundle into the session (GUI thread: this fires reloads)."""
         try:
             report = restore_bundle(bundle, self._app_state)
         except ProjectTooNewError as e:
-            self._clear_project_extract_dir()
+            shutil.rmtree(extract_dir, ignore_errors=True)
             QMessageBox.critical(self, self.tr("Cannot Open Project"), str(e))
             return
         except Exception as e:
-            self._clear_project_extract_dir()
+            shutil.rmtree(extract_dir, ignore_errors=True)
             logger.exception("Failed to open project")
             QMessageBox.critical(
                 self,
@@ -828,6 +829,10 @@ class DataVisualizerApp(QMainWindow):
             )
             return
 
+        # The session is the new project now, so nothing reads from the old extract
+        # directory any more and it can go.
+        self._clear_project_extract_dir()
+        self._project_extract_dir = extract_dir
         self._current_project_path = path
         # The session now *is* the project, so a re-save writes all of it; the exclusions
         # that produced the file were applied when it was written.
@@ -841,8 +846,9 @@ class DataVisualizerApp(QMainWindow):
         self._app_state.update_cwd_from_path(path)
         self._warn_dropped_on_load(report)
 
-    def _on_open_failed(self, message):
-        self._clear_project_extract_dir()
+    def _on_open_failed(self, message, extract_dir):
+        # Only this open's directory goes; the session still has the one it is using.
+        shutil.rmtree(extract_dir, ignore_errors=True)
         logger.error("Failed to open project: %s", message)
         QMessageBox.critical(
             self,

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -690,22 +690,13 @@ class DataVisualizerApp(QMainWindow):
     def on_save_project(self, checked=False):
         """Save the session to its current project file, or prompt if there is none."""
         if self._current_project_path is None:
-            self.on_save_project_as()
-            return
-        try:
-            save_project(
-                self._app_state,
-                self._current_project_path,
-                resolver_for_excluded(self._app_state, self._current_excluded),
-                self_contained=self._current_self_contained,
-            )
-        except Exception as e:
-            logger.exception("Failed to save project")
-            QMessageBox.critical(
-                self,
-                self.tr("Save Failed"),
-                self.tr("Could not save the project:\n\n{0}").format(e),
-            )
+            return self.on_save_project_as()
+        return self._save_project(
+            self._current_project_path,
+            resolver_for_excluded(self._app_state, self._current_excluded),
+            self._current_excluded,
+            self._current_self_contained,
+        )
 
     def on_save_project_as(self, checked=False):
         """Prompt for what to include and where, then save a new project file."""
@@ -716,7 +707,7 @@ class DataVisualizerApp(QMainWindow):
             self_contained=self._current_self_contained,
         )
         if dialog.exec() != QDialog.Accepted:
-            return
+            return None
         resolver = dialog.get_resolver()
         excluded = dialog.get_excluded()
         self_contained = dialog.get_self_contained()
@@ -728,24 +719,50 @@ class DataVisualizerApp(QMainWindow):
             self.tr("WISER project files (*{0})").format(ProjectBundle.EXTENSION),
         )
         if not path:
-            return
+            return None
         if not path.lower().endswith(ProjectBundle.EXTENSION):
             path += ProjectBundle.EXTENSION
 
-        try:
-            save_project(self._app_state, path, resolver, self_contained=self_contained)
-        except Exception as e:
-            logger.exception("Failed to save project")
+        return self._save_project(path, resolver, excluded, self_contained)
+
+    def _save_project(self, path, resolver, excluded, self_contained):
+        """Write the project on the scheduler, behind a progress dialog.
+
+        Copying and compressing a dataset's pixels is slow enough to freeze the window
+        for a noticeable time -- a self-contained save of a large cube for much longer --
+        so the work runs off the GUI thread with the main window disabled until it
+        finishes.  Cancelling abandons the save: the destination is only replaced once
+        the archive is complete, so the project that was there is still there.
+        """
+
+        def on_saved(_result):
+            self._current_project_path = path
+            self._current_excluded = set(excluded)
+            self._current_self_contained = self_contained
+            self._app_state.update_cwd_from_path(path)
+            self.statusBar().showMessage(self.tr("Saved project to {0}").format(path), 5000)
+
+        def on_failed(message):
+            logger.error("Failed to save project: %s", message)
             QMessageBox.critical(
                 self,
                 self.tr("Save Failed"),
-                self.tr("Could not save the project:\n\n{0}").format(e),
+                self.tr("Could not save the project:\n\n{0}").format(message),
             )
-            return
-        self._current_project_path = path
-        self._current_excluded = excluded
-        self._current_self_contained = self_contained
-        self._app_state.update_cwd_from_path(path)
+
+        return run_with_progress(
+            self._app_services,
+            self,
+            self.tr("Saving Project"),
+            save_project,
+            self._app_state,
+            path,
+            resolver,
+            self_contained,
+            on_success=on_saved,
+            on_error=on_failed,
+            description=self.tr("Writing project file…"),
+        )
 
     def on_open_project(self, checked=False):
         """Open a project file, replacing the current session after confirmation."""

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -41,7 +41,12 @@ from wiser.raster.spectrum import (
 )
 from wiser.project.bundle import ProjectBundle
 from wiser.project.migrate import ProjectTooNewError
-from wiser.project.orchestrate import load_project, project_embeds_datasets, save_project
+from wiser.project.orchestrate import (
+    open_bundle,
+    project_embeds_datasets,
+    restore_bundle,
+    save_project,
+)
 from wiser.project.save_plan import resolver_for_excluded
 from wiser.utils.primitives import PriorityClass
 from wiser.utils.task_stage_utils import get_save_external_dataset_pipeline
@@ -772,7 +777,7 @@ class DataVisualizerApp(QMainWindow):
             self.tr("Opening a project discards the current session.  Continue?"),
         )
         if reply != QMessageBox.Yes:
-            return
+            return None
 
         (path, _) = QFileDialog.getOpenFileName(
             self,
@@ -781,16 +786,34 @@ class DataVisualizerApp(QMainWindow):
             self.tr("WISER project files (*{0})").format(ProjectBundle.EXTENSION),
         )
         if not path:
-            return
+            return None
 
-        # A zipped project extracts to a directory that must outlive the load,
-        # since sidecar datasets are read from it lazily.  The app owns it: clear
-        # the previous session's directory and hand load_project a fresh one.
+        # A zipped project extracts to a directory that must outlive the load, since
+        # sidecar datasets are read from it lazily.  The app owns it: clear the previous
+        # session's directory and hand the open a fresh one.
         self._clear_project_extract_dir()
         self._project_extract_dir = tempfile.mkdtemp(prefix="wiser-project-")
 
+        # Unpacking a self-contained project copies out every image it holds, so it runs
+        # on the scheduler behind a progress dialog.  Only the *restore* touches the
+        # session, and that happens below on the GUI thread -- so a cancelled or failed
+        # open leaves the current session exactly as it was, nothing half-replaced.
+        return run_with_progress(
+            self._app_services,
+            self,
+            self.tr("Opening Project"),
+            open_bundle,
+            path,
+            self._project_extract_dir,
+            on_success=lambda bundle: self._restore_project(bundle, path),
+            on_error=self._on_open_failed,
+            description=self.tr("Unpacking project file…"),
+        )
+
+    def _restore_project(self, bundle, path):
+        """Restore an unpacked bundle into the session (GUI thread: this fires reloads)."""
         try:
-            report = load_project(path, self._app_state, extract_dir=self._project_extract_dir)
+            report = restore_bundle(bundle, self._app_state)
         except ProjectTooNewError as e:
             self._clear_project_extract_dir()
             QMessageBox.critical(self, self.tr("Cannot Open Project"), str(e))
@@ -817,6 +840,15 @@ class DataVisualizerApp(QMainWindow):
         )
         self._app_state.update_cwd_from_path(path)
         self._warn_dropped_on_load(report)
+
+    def _on_open_failed(self, message):
+        self._clear_project_extract_dir()
+        logger.error("Failed to open project: %s", message)
+        QMessageBox.critical(
+            self,
+            self.tr("Open Failed"),
+            self.tr("Could not open the project:\n\n{0}").format(message),
+        )
 
     def _clear_project_extract_dir(self):
         """Remove the temp directory a zipped project was extracted into, if any."""

--- a/src/wiser/gui/progress_task.py
+++ b/src/wiser/gui/progress_task.py
@@ -18,6 +18,7 @@ This is the thread-scoped path (see ``FOLLOWUP_io_work_units.md``); it does not 
 the work-unit RAM accounting.
 """
 
+import logging
 from concurrent.futures import Future
 from threading import Event
 from typing import Any, Callable, Dict, Optional
@@ -26,10 +27,12 @@ from PySide6.QtCore import QObject, Signal
 from PySide6.QtWidgets import QWidget
 
 from wiser.utils.primitives import PriorityClass
-from wiser.utils.progress import ProgressReporter
+from wiser.utils.progress import ProgressCancelled, ProgressReporter
 from wiser.utils.task_system import ProgressUpdate
 
 from .progress_dialog import PROGRESS_RESOLUTION, ProgressDialog
+
+logger = logging.getLogger(__name__)
 
 
 class _ProgressTaskRunner(QObject):
@@ -55,10 +58,13 @@ class _ProgressTaskRunner(QObject):
         on_error: Optional[Callable[[str], None]],
         cancel_event: Event,
         block_window: Optional[QWidget] = None,
+        title: str = "",
     ) -> None:
         super().__init__(parent)
         self._app_services = app_services
         self._dialog = dialog
+        # Kept for the failure log: the dialog is a widget the worker thread must not touch.
+        self._title = title
         self._activity_id: Optional[int] = None
         self._on_success = on_success
         self._on_error = on_error
@@ -90,7 +96,14 @@ class _ProgressTaskRunner(QObject):
         """Future done-callback (worker/pool thread): funnel result to the GUI thread."""
         try:
             result = future.result()
+        except ProgressCancelled as exc:
+            # The user asked to stop; not a failure worth a traceback.
+            self.failed.emit(str(exc))
         except Exception as exc:  # noqa: BLE001 - surfaced to the user via `failed`
+            # Only the message crosses to the GUI thread, so log the traceback here,
+            # where the exception still has one -- otherwise a failed task leaves
+            # nothing in the log to diagnose it with.
+            logger.exception("Task failed: %s", self._title)
             self.failed.emit(str(exc))
         else:
             self.succeeded.emit(result)
@@ -203,7 +216,7 @@ def run_with_progress(
     # on the GUI thread when the user cancels.
     cancel_event = Event()
     runner = _ProgressTaskRunner(
-        dialog_parent, app_services, dialog, on_success, on_error, cancel_event, target
+        dialog_parent, app_services, dialog, on_success, on_error, cancel_event, target, title
     )
     # Register the row with the runner as its cancel handler so the Activity Monitor's
     # Cancel button cancels this task too; then hand the runner its row id.

--- a/src/wiser/project/bundle.py
+++ b/src/wiser/project/bundle.py
@@ -23,6 +23,23 @@ from .pyrep import array_ref, array_ref_key, is_array_ref
 PathLike = Union[str, Path]
 
 
+def remove_path(path: PathLike) -> None:
+    """Remove ``path`` whether it is a file or a directory tree, and never raise.
+
+    A stray ``.part`` or ``.bak`` left behind by a crash may be either kind, and this
+    runs in the cleanup arm of an ``except`` block -- where raising would mask the very
+    failure being cleaned up after.
+    """
+    path = Path(path)
+    try:
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
 def _resolve_within(root: PathLike, rel: str) -> Path:
     """Resolve ``rel`` under ``root``, refusing paths that escape the bundle.
 
@@ -163,6 +180,7 @@ def zip_bundle(
     root = bundle.root
     files = [path for path in sorted(root.rglob("*")) if path.is_file()]
     partial = zip_path.with_name(zip_path.name + ".part")
+    remove_path(partial)  # a crash may have left one, of either kind
     try:
         with zipfile.ZipFile(partial, "w", zipfile.ZIP_DEFLATED) as zf:
             for index, path in enumerate(files):
@@ -172,7 +190,7 @@ def zip_bundle(
                 zf.write(path, path.relative_to(root))
         os.replace(partial, zip_path)
     except BaseException:
-        partial.unlink(missing_ok=True)
+        remove_path(partial)
         raise
     if progress is not None:
         progress.report_fraction(1.0)

--- a/src/wiser/project/bundle.py
+++ b/src/wiser/project/bundle.py
@@ -179,16 +179,30 @@ def zip_bundle(
     return zip_path
 
 
-def unzip_bundle(zip_path: PathLike, dest_dir: PathLike) -> ProjectBundle:
+def unzip_bundle(
+    zip_path: PathLike, dest_dir: PathLike, progress: Optional[ProgressReporter] = None
+) -> ProjectBundle:
     """Extract a ``.wiserproj`` zip into ``dest_dir`` and open it as a bundle.
 
     Guards against zip-slip: a member whose path escapes ``dest_dir`` (via
     ``../`` or an absolute path) is refused before anything is extracted, since
-    a project file may come from an untrusted source."""
+    a project file may come from an untrusted source.
+
+    ``progress`` reports per member and is checked for cancellation between them, so
+    unpacking a large self-contained project can be abandoned.  Members are extracted
+    one at a time rather than with ``extractall`` so there is somewhere to check.
+    """
     dest_dir = Path(dest_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(zip_path, "r") as zf:
-        for name in zf.namelist():
+        names = zf.namelist()
+        for name in names:
             _resolve_within(dest_dir, name)
-        zf.extractall(dest_dir)
+        for index, name in enumerate(names):
+            if progress is not None:
+                progress.raise_if_cancelled()
+                progress.report(index, len(names))
+            zf.extract(name, dest_dir)
+    if progress is not None:
+        progress.report_fraction(1.0)
     return ProjectBundle.open(dest_dir)

--- a/src/wiser/project/bundle.py
+++ b/src/wiser/project/bundle.py
@@ -7,12 +7,15 @@ two.  Bulk data never goes in the manifest: large arrays are written to
 """
 
 import json
+import os
 import shutil
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
+
+from wiser.utils.progress import ProgressReporter
 
 from .migrate import CURRENT_FORMAT_VERSION, ProjectFormatError, migrate_up
 from .pyrep import array_ref, array_ref_key, is_array_ref
@@ -143,14 +146,36 @@ class ProjectBundle:
         return dest / filename
 
 
-def zip_bundle(bundle: ProjectBundle, zip_path: PathLike) -> Path:
-    """Package a bundle directory into a single ``.wiserproj`` zip file."""
+def zip_bundle(
+    bundle: ProjectBundle, zip_path: PathLike, progress: Optional[ProgressReporter] = None
+) -> Path:
+    """Package a bundle directory into a single ``.wiserproj`` zip file.
+
+    The archive is built beside ``zip_path`` and moved into place only once it is
+    complete, so a save that fails, runs out of disk, or is cancelled leaves the
+    project file that was already there untouched.  Opening the destination for
+    writing directly would truncate it at the first byte -- destroying the user's
+    previous save to write the one they abandoned.
+
+    ``progress`` reports per-file and is checked for cancellation between files.
+    """
     zip_path = Path(zip_path)
     root = bundle.root
-    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for path in sorted(root.rglob("*")):
-            if path.is_file():
+    files = [path for path in sorted(root.rglob("*")) if path.is_file()]
+    partial = zip_path.with_name(zip_path.name + ".part")
+    try:
+        with zipfile.ZipFile(partial, "w", zipfile.ZIP_DEFLATED) as zf:
+            for index, path in enumerate(files):
+                if progress is not None:
+                    progress.raise_if_cancelled()
+                    progress.report(index, len(files))
                 zf.write(path, path.relative_to(root))
+        os.replace(partial, zip_path)
+    except BaseException:
+        partial.unlink(missing_ok=True)
+        raise
+    if progress is not None:
+        progress.report_fraction(1.0)
     return zip_path
 
 

--- a/src/wiser/project/orchestrate.py
+++ b/src/wiser/project/orchestrate.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from wiser.utils.progress import ProgressReporter
 
-from .bundle import ProjectBundle, unzip_bundle, zip_bundle
+from .bundle import ProjectBundle, remove_path, unzip_bundle, zip_bundle
 from .persisters.bandmath import load_bandmath, save_bandmath
 from .persisters.crs import load_user_crs, save_user_crs
 from .persisters.datasets import load_datasets, save_datasets
@@ -101,14 +101,16 @@ def _write_bundle_directory(
     """
     staging = dest.with_name(dest.name + ".part")
     previous = dest.with_name(dest.name + ".bak")
-    shutil.rmtree(staging, ignore_errors=True)
+    # Either may be left over from a crash, and as a file rather than a directory, so
+    # clear whatever is actually there rather than assuming its kind.
+    remove_path(staging)
     try:
         _write_bundle(app_state, ProjectBundle.create(staging), resolver, self_contained, progress)
     except BaseException:
-        shutil.rmtree(staging, ignore_errors=True)
+        remove_path(staging)
         raise
 
-    shutil.rmtree(previous, ignore_errors=True)
+    remove_path(previous)
     replacing = dest.exists()
     if replacing:
         os.replace(dest, previous)
@@ -117,9 +119,9 @@ def _write_bundle_directory(
     except BaseException:
         if replacing:
             os.replace(previous, dest)  # put the old bundle back
-        shutil.rmtree(staging, ignore_errors=True)
+        remove_path(staging)
         raise
-    shutil.rmtree(previous, ignore_errors=True)
+    remove_path(previous)
 
 
 def open_bundle(
@@ -141,6 +143,10 @@ def open_bundle(
     a caller can extract with progress and cancellation in the background and then
     restore on the GUI thread -- and a cancelled open leaves the current session
     untouched, since nothing has been cleared yet.
+
+    ``extract_dir`` must be used for this load alone: if the extraction is cancelled or
+    fails, what was unpacked into it is removed rather than left behind, which for a
+    large self-contained project would otherwise strand gigabytes in a temp directory.
     """
     src = Path(src)
     if src.is_file() and zipfile.is_zipfile(src):
@@ -150,7 +156,11 @@ def open_bundle(
                 "and keeps alive for the session, since sidecar datasets are read from "
                 "it lazily."
             )
-        return unzip_bundle(src, extract_dir, progress)
+        try:
+            return unzip_bundle(src, extract_dir, progress)
+        except BaseException:
+            remove_path(extract_dir)
+            raise
     return ProjectBundle.open(src)
 
 

--- a/src/wiser/project/orchestrate.py
+++ b/src/wiser/project/orchestrate.py
@@ -16,6 +16,8 @@ resolver in place of the default here; the golden-file version gate (#628) build
 on the migrate step already performed by :meth:`ProjectBundle.read_manifest`.
 """
 
+import os
+import shutil
 import tempfile
 import zipfile
 from pathlib import Path
@@ -59,8 +61,9 @@ def save_project(
     ``progress`` (a :class:`~wiser.utils.progress.ProgressReporter`) reports the save
     and is checked for cancellation at each dataset and each file added to the
     archive; cancelling raises
-    :class:`~wiser.utils.progress.ProgressCancelled` and writes nothing, so any
-    project already at ``dest`` survives intact.
+    :class:`~wiser.utils.progress.ProgressCancelled`.  Either form of ``dest`` is
+    written aside and moved into place only once it is complete, so a cancelled or
+    failed save leaves whatever was already at ``dest`` intact.
     """
     dest = Path(dest)
     if resolver is None:
@@ -77,8 +80,46 @@ def save_project(
             _write_bundle(app_state, bundle, resolver, self_contained, collect)
             zip_bundle(bundle, dest, package)
     else:
-        _write_bundle(app_state, ProjectBundle.create(dest), resolver, self_contained, progress)
+        _write_bundle_directory(app_state, dest, resolver, self_contained, progress)
     return dest
+
+
+def _write_bundle_directory(
+    app_state: "ApplicationState",
+    dest: Path,
+    resolver: DependencyResolver,
+    self_contained: bool,
+    progress: ProgressReporter,
+) -> None:
+    """Write a bundle *directory*, swapping it into place only once it is complete.
+
+    :func:`_write_bundle` clears the bundle before writing it, so writing straight into
+    ``dest`` would destroy the project already there the instant the save began -- the
+    same hazard :func:`~wiser.project.bundle.zip_bundle` avoids by building a ``.part``
+    file.  The new bundle is staged beside ``dest`` and the old one kept until the new
+    one is in place, so a cancelled or failed save costs the user nothing.
+    """
+    staging = dest.with_name(dest.name + ".part")
+    previous = dest.with_name(dest.name + ".bak")
+    shutil.rmtree(staging, ignore_errors=True)
+    try:
+        _write_bundle(app_state, ProjectBundle.create(staging), resolver, self_contained, progress)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    shutil.rmtree(previous, ignore_errors=True)
+    replacing = dest.exists()
+    if replacing:
+        os.replace(dest, previous)
+    try:
+        os.replace(staging, dest)
+    except BaseException:
+        if replacing:
+            os.replace(previous, dest)  # put the old bundle back
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    shutil.rmtree(previous, ignore_errors=True)
 
 
 def open_bundle(

--- a/src/wiser/project/orchestrate.py
+++ b/src/wiser/project/orchestrate.py
@@ -21,6 +21,8 @@ import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from wiser.utils.progress import ProgressReporter
+
 from .bundle import ProjectBundle, unzip_bundle, zip_bundle
 from .persisters.bandmath import load_bandmath, save_bandmath
 from .persisters.crs import load_user_crs, save_user_crs
@@ -43,6 +45,7 @@ def save_project(
     dest: PathLike,
     resolver: Optional[DependencyResolver] = None,
     self_contained: bool = False,
+    progress: Optional[ProgressReporter] = None,
 ) -> Path:
     """Save the current session to ``dest``.
 
@@ -52,18 +55,29 @@ def save_project(
     When ``self_contained`` is set, file-backed datasets are copied into the bundle
     (rather than referenced by path) so the project is portable/shareable.
     Returns the path written.
+
+    ``progress`` (a :class:`~wiser.utils.progress.ProgressReporter`) reports the save
+    and is checked for cancellation at each dataset and each file added to the
+    archive; cancelling raises
+    :class:`~wiser.utils.progress.ProgressCancelled` and writes nothing, so any
+    project already at ``dest`` survives intact.
     """
     dest = Path(dest)
     if resolver is None:
         resolver = resolver_for_all_datasets(app_state)
+    if progress is None:
+        progress = ProgressReporter()
 
     if dest.suffix == ProjectBundle.EXTENSION:
+        # Copying pixels into the bundle dominates a self-contained save, and
+        # compressing them dominates the rest; a referenced save is quick in both.
+        collect, package = progress.split((0.7, "Collecting project data"), (0.3, "Writing project file"))
         with tempfile.TemporaryDirectory(prefix="wiserproj-save-") as work:
             bundle = ProjectBundle.create(work)
-            _write_bundle(app_state, bundle, resolver, self_contained)
-            zip_bundle(bundle, dest)
+            _write_bundle(app_state, bundle, resolver, self_contained, collect)
+            zip_bundle(bundle, dest, package)
     else:
-        _write_bundle(app_state, ProjectBundle.create(dest), resolver, self_contained)
+        _write_bundle(app_state, ProjectBundle.create(dest), resolver, self_contained, progress)
     return dest
 
 
@@ -128,10 +142,18 @@ def _write_bundle(
     bundle: ProjectBundle,
     resolver: DependencyResolver,
     self_contained: bool = False,
+    progress: Optional[ProgressReporter] = None,
 ) -> None:
     # Clear any prior contents so re-saving over an existing bundle directory does
     # not leave stale sidecars the new manifest no longer references.
     bundle.clear_contents()
+    if progress is None:
+        progress = ProgressReporter()
+    # The datasets carry the pixels; every other section is a few dictionaries, so
+    # the bar would otherwise sit still through the only part that takes any time.
+    datasets_progress, session_progress = progress.split(
+        (0.9, "Saving datasets"), (0.1, "Saving session state")
+    )
     manifest: Dict[str, Any] = {}
     # Datasets first: they are the roots the rest of the manifest references by
     # id, and they own the sidecar I/O through the bundle.  A dataset the resolver
@@ -142,7 +164,15 @@ def _write_bundle(
         for ds in app_state.get_datasets()
         if not resolver.is_saved(Dependency("dataset", ds.get_id()))
     )
-    save_datasets(app_state, manifest, bundle, excluded_ids, embed_file_backed=self_contained)
+    save_datasets(
+        app_state,
+        manifest,
+        bundle,
+        excluded_ids,
+        embed_file_backed=self_contained,
+        progress=datasets_progress,
+    )
+    session_progress.raise_if_cancelled()
     save_user_crs(app_state, manifest, resolver)
     save_bandmath(app_state, manifest, resolver)
     save_rois(app_state, manifest, resolver)
@@ -151,6 +181,7 @@ def _write_bundle(
     save_libraries(app_state, manifest, resolver)
     save_runs(app_state, manifest, resolver)
     bundle.write_manifest(manifest)
+    session_progress.report_fraction(1.0)
 
 
 def _restore(bundle: ProjectBundle, app_state: "ApplicationState") -> Dict[str, List[Any]]:

--- a/src/wiser/project/orchestrate.py
+++ b/src/wiser/project/orchestrate.py
@@ -81,22 +81,25 @@ def save_project(
     return dest
 
 
-def load_project(
+def open_bundle(
     src: PathLike,
-    app_state: "ApplicationState",
     extract_dir: Optional[PathLike] = None,
-) -> Dict[str, List[Any]]:
-    """Open a project bundle at ``src`` and restore it into a cleared session.
+    progress: Optional[ProgressReporter] = None,
+) -> ProjectBundle:
+    """Unpack ``src`` and return the bundle, without touching the session.
 
     ``src`` may be a bundle directory or a ``.wiserproj`` zip.  A zip is extracted
-    into ``extract_dir``, which is **required** for a zip and must outlive the
-    loaded session, since sidecar datasets are read from it lazily -- the caller
-    owns it and its cleanup.  Raises :class:`ValueError` if a zip is opened without
-    an ``extract_dir``, and
-    :class:`~wiser.project.migrate.ProjectTooNewError` for a too-new file.
+    into ``extract_dir``, which is **required** for a zip and must outlive the loaded
+    session, since sidecar datasets are read from it lazily -- the caller owns it and
+    its cleanup.  Raises :class:`ValueError` if a zip is opened without an
+    ``extract_dir``.
 
-    Returns a load report: a dict mapping each section to the entries that could
-    not be restored (a moved file, an unknown kind, a malformed record).
+    This is the half of a load that is slow and safe to run off the GUI thread:
+    unpacking a self-contained project copies out every image it holds.  It is
+    separate from :func:`restore_bundle` because restoring *mutates the session*, so
+    a caller can extract with progress and cancellation in the background and then
+    restore on the GUI thread -- and a cancelled open leaves the current session
+    untouched, since nothing has been cleared yet.
     """
     src = Path(src)
     if src.is_file() and zipfile.is_zipfile(src):
@@ -106,10 +109,34 @@ def load_project(
                 "and keeps alive for the session, since sidecar datasets are read from "
                 "it lazily."
             )
-        bundle = unzip_bundle(src, extract_dir)
-    else:
-        bundle = ProjectBundle.open(src)
+        return unzip_bundle(src, extract_dir, progress)
+    return ProjectBundle.open(src)
+
+
+def restore_bundle(bundle: ProjectBundle, app_state: "ApplicationState") -> Dict[str, List[Any]]:
+    """Clear the session and restore ``bundle`` into it, returning the load report.
+
+    Mutates ``app_state`` and fires its reload signals, so it must run on the GUI
+    thread.  Raises :class:`~wiser.project.migrate.ProjectTooNewError` for a project
+    written by a newer WISER.
+    """
     return _restore(bundle, app_state)
+
+
+def load_project(
+    src: PathLike,
+    app_state: "ApplicationState",
+    extract_dir: Optional[PathLike] = None,
+    progress: Optional[ProgressReporter] = None,
+) -> Dict[str, List[Any]]:
+    """Open a project bundle at ``src`` and restore it into a cleared session.
+
+    The one-shot form of :func:`open_bundle` + :func:`restore_bundle`, for callers
+    with no GUI thread to keep free.  Returns a load report: a dict mapping each
+    section to the entries that could not be restored (a moved file, an unknown kind,
+    a malformed record).
+    """
+    return restore_bundle(open_bundle(src, extract_dir, progress), app_state)
 
 
 def project_embeds_datasets(app_state: "ApplicationState", bundle_root: PathLike) -> bool:

--- a/src/wiser/project/persisters/datasets.py
+++ b/src/wiser/project/persisters/datasets.py
@@ -29,6 +29,8 @@ application's raster loader directly.
 import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from wiser.utils.progress import ProgressReporter
+
 from ..bundle import ProjectBundle
 
 if TYPE_CHECKING:
@@ -105,6 +107,7 @@ def save_datasets(
     bundle: ProjectBundle,
     excluded_ids: "frozenset[int]" = frozenset(),
     embed_file_backed: bool = False,
+    progress: Optional[ProgressReporter] = None,
 ) -> None:
     """Write every dataset in ``app_state`` into ``manifest['datasets']``.
 
@@ -116,13 +119,21 @@ def save_datasets(
     When ``embed_file_backed`` is set (a self-contained save) file-backed datasets
     are copied into the bundle as ENVI sidecars rather than referenced by path, so
     the project is portable.
+
+    Writing a dataset's pixels is the one slow step of a save, so ``progress`` reports
+    per dataset and cancellation is checked before each one.
     """
     loader = app_state.get_loader()
-    manifest["datasets"] = [
-        dataset_to_pyrep(ds, bundle, loader, embed=embed_file_backed)
-        for ds in app_state.get_datasets()
-        if ds.get_id() not in excluded_ids
-    ]
+    if progress is None:
+        progress = ProgressReporter()
+    datasets = [ds for ds in app_state.get_datasets() if ds.get_id() not in excluded_ids]
+    entries = []
+    for index, dataset in enumerate(datasets):
+        progress.raise_if_cancelled()
+        progress.report(index, len(datasets), dataset.get_name() or "")
+        entries.append(dataset_to_pyrep(dataset, bundle, loader, embed=embed_file_backed))
+    progress.report_fraction(1.0)
+    manifest["datasets"] = entries
 
 
 def load_datasets(


### PR DESCRIPTION
What does this change do?

Project saving & opening now runs off the GUI thread behind a blocking progress dialog, can be cancelled, and can no longer destroy an existing project file if it is interrupted.

What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix
- [x] Documentation Update
- [x] Test

Why is this change needed?

Saving ran synchronously on the GUI thread with no feedback of any kind. WISER simply froze until it was done — and a self-contained save copies and compresses every band of every dataset, so for a large scene that is a long, silent freeze with nothing to tell the user it is working, or that they should wait.

Adding a progress dialog surfaced a second, worse probleestination with ZipFile(dest, "w"), which truncates it atthe first byte. Any interrupted save — a crash, a full disk, and now a cancel — left a corrupt, unopenable file where the user's workingproject used to be. Offering a cancel button on top of tre hazard into a one-click one, so both are fixedtogether.                                                                                                                               
How did you implement the change?                                                                                                       
- Crash-safe write (bundle.py): the archive is built as a .part file beside the destination and os.replace()d into position only once   complete. Any failure removes the partial and leaves thed. This is what lets "cancel" honestly mean nothinghappened.                                                                                                                               - Progress (orchestrate.py, persisters/datasets.py): an is threaded through save_project → _write_bundle →save_datasets, weighted so the bar tracks where the time actually goes — 70% collecting (90% of which is the dataset pixel writes, reporper dataset by name) and 30% packaging (reported per filve is fast through both.
- Cancellation: raise_if_cancelled() before each dataset and each file added to the archive; ProgressCancelled is already understood by run_with_progress and dropped rather than surfaced as an
- GUI (app.py): Save and Save As both route through one _save_project() helper calling run_with_progress(...) with the main window as the block target. The project path, selection, and save modes, so a cancelled or failed save doesn't leave the appbelieving it saved.

Added tests?

- [x] yes — a cancelled save leaves the previous file byte-identical, still openable, with no .part left behind; progress is monotonic and
reaches exactly 1.0. The existing real-app GUI tests now exercise the threaded path.

Added to documentation?

- [x] yes — the Projects manual page gains a "While the section covering the progress dialog, cancelling, and theguarantee about the previous file.

Checklist

- [ ] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced (ruff clean)
- [ ] Branch is up-to-date with main — stacked on feat/p)
- [ ] All CI checks passed — note the tests job won't run until the base is main

[optional] Are there any post-merge tasks we need to perform?

- Merges after #709. 