### PR TITLE
fix: multiprocess logging error

### DIFF
--- a/src/tests/test_logging_setup.py
+++ b/src/tests/test_logging_setup.py
@@ -1,0 +1,270 @@
+"""Regression tests for the wiser.log rotation crash on Windows (#502).
+
+The failure in the wild: the scheduler's pool workers each opened their own
+handle on ``wiser.log``, and when one of them tried to roll the file over,
+Windows refused to rename a file the other processes still had open:
+
+    PermissionError: [WinError 32] The process cannot access the file because
+    it is being used by another process:
+    '...\\wiser.log' -> '...\\wiser.log.1'
+
+``TestWorkerDoesNotOpenTheLogFile`` is the regression test: it runs the real
+``wiser/__main__.py`` in a subprocess set up exactly as a spawned worker is, and
+asserts the worker opens no handle on the log file.  It fails against the guard
+that shipped on main.
+
+``TestRolloverWithForeignHandle`` covers the second-handle cases we cannot
+prevent (antivirus, an editor tailing the log, a second copy of WISER), where
+rotation must degrade instead of melting down.
+"""
+
+import json
+import logging
+import logging.handlers
+import os
+import subprocess
+import sys
+
+import pytest
+
+import wiser
+from wiser.logging_setup import SafeRotatingFileHandler
+from wiser.utils.multiprocessing_context import CTX
+
+pytestmark = pytest.mark.functional
+
+WINDOWS_ONLY = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Only Windows refuses to rename a file that another process holds open.",
+)
+
+# Runs wiser/__main__.py's top-level code -- the logging configuration under test --
+# without calling main(), then reports what that left behind. importlib is used
+# rather than `python -m wiser` precisely so the `if __name__ == "__main__"` block
+# (which starts Qt) does not run.
+PROBE_SOURCE = """
+import importlib, json, logging, os, sys
+
+importlib.import_module("wiser.__main__")
+
+from wiser.gui.app_config import get_wiser_config_dir
+
+logfile = os.path.join(get_wiser_config_dir(), "wiser.log")
+print("WISER_PROBE " + json.dumps({
+    "argv": sys.argv,
+    "log_file_handlers": [
+        os.path.basename(h.baseFilename)
+        for h in logging.getLogger().handlers
+        if isinstance(h, logging.FileHandler)
+    ],
+    "log_file_exists": os.path.exists(logfile),
+    "numba_debug_enabled": logging.getLogger("numba.core.ssa").isEnabledFor(logging.DEBUG),
+    "wiser_debug_enabled": logging.getLogger("wiser.gui").isEnabledFor(logging.DEBUG),
+}))
+"""
+
+
+def _run_probe(tmp_path, *extra_argv: str) -> dict:
+    """Run PROBE_SOURCE in a fresh interpreter, with WISER's config dir in tmp_path.
+
+    `extra_argv` lands in the child's sys.argv after the `-c`, which is how we
+    reproduce a spawned worker: the frozen bootloader launches
+    `WISER.exe --multiprocessing-fork pipe_handle=...`, and the entry script runs
+    top-to-bottom with that argv long before multiprocessing takes control.
+    """
+    env = dict(os.environ)
+    # get_app_data_dir() builds the config dir from these (LOCALAPPDATA on
+    # Windows, HOME elsewhere), so the probe writes any log into tmp_path.
+    env["LOCALAPPDATA"] = str(tmp_path)
+    env["HOME"] = str(tmp_path)
+    env["USERPROFILE"] = str(tmp_path)
+    env["PYTHONPATH"] = os.path.dirname(os.path.dirname(os.path.abspath(wiser.__file__)))
+    env.pop("QT_QPA_PLATFORM", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", PROBE_SOURCE, *extra_argv],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=env,
+    )
+    for line in result.stdout.splitlines():
+        if line.startswith("WISER_PROBE "):
+            return json.loads(line[len("WISER_PROBE ") :])
+    raise AssertionError(
+        f"probe did not report a result (exit {result.returncode})\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+
+
+@pytest.mark.skipif(
+    getattr(sys, "frozen", False),
+    reason="The probe needs `python -c`; sys.executable is WISER.exe in a frozen run.",
+)
+class TestWorkerDoesNotOpenTheLogFile:
+    """Only one process may hold wiser.log open, or rotation cannot rename it."""
+
+    def test_worker_opens_no_handle_on_the_log_file(self, tmp_path):
+        """The regression test for #502.
+
+        This is the state a scheduler pool worker is really in: in the frozen
+        build it is a fresh WISER.exe launched with --multiprocessing-fork, whose
+        bootloader executes wiser/__main__.py from the top and only reaches the
+        freeze_support() call at the bottom afterwards.
+
+        The guard that shipped on main asked `multiprocessing.parent_process() is
+        None` to detect this, but that global is not assigned until
+        BaseProcess._bootstrap() -- which the worker reaches *through* the bottom
+        of __main__.py. So the worker reported no parent, believed it was the app,
+        and opened wiser.log. This test fails against that guard.
+        """
+        probe = _run_probe(tmp_path, "--multiprocessing-fork", "pipe_handle=123", "parent_pid=456")
+
+        assert probe["log_file_handlers"] == [], (
+            "a worker process opened a handle on the log file; when the app "
+            "rotates wiser.log, Windows will refuse the rename (WinError 32)"
+        )
+        assert not probe["log_file_exists"], "a worker created the log file it must not touch"
+
+    def test_app_still_opens_exactly_one_log_file_handle(self, tmp_path):
+        """Control: the same probe without a worker's argv must still log to file.
+
+        Without this, `test_worker_opens_no_handle_on_the_log_file` would also
+        pass if logging were simply broken everywhere.
+        """
+        probe = _run_probe(tmp_path)
+
+        assert probe["log_file_handlers"] == ["wiser.log"]
+        assert probe["log_file_exists"]
+
+    def test_numba_debug_logging_is_capped_in_the_app(self, tmp_path):
+        """The other half of #502: what drives wiser.log to the rotation threshold.
+
+        Numba emits a DEBUG record per bytecode instruction and per SSA block while
+        it compiles. With the root logger at DEBUG and no cap on the numba logger,
+        one spectral-feature-fitting run writes megabytes into wiser.log -- which is
+        what forces the rollover that then fails. WISER's own loggers must keep
+        their DEBUG output.
+        """
+        probe = _run_probe(tmp_path)
+
+        assert not probe["numba_debug_enabled"], "numba's per-instruction DEBUG log is filling wiser.log"
+        assert probe["wiser_debug_enabled"], "WISER's own DEBUG logging was lost"
+
+
+def _record(message: str) -> logging.LogRecord:
+    return logging.LogRecord("test", logging.INFO, __file__, 1, message, None, None)
+
+
+def _hold_file_open(path: str, opened, release) -> None:
+    """Child process: hold an OS handle on `path` until told to let go."""
+    with open(path, "a", encoding="utf-8"):
+        opened.set()
+        release.wait(timeout=30)
+
+
+@pytest.mark.multiprocessing
+class TestRolloverWithForeignHandle:
+    """Rotation while another *process* holds the log file open."""
+
+    @pytest.fixture
+    def logfile(self, tmp_path):
+        return str(tmp_path / "wiser.log")
+
+    @pytest.fixture
+    def foreign_handle(self, logfile):
+        """Run a real child process that keeps an OS handle on the log file."""
+        open(logfile, "w", encoding="utf-8").close()
+
+        opened = CTX.Event()
+        release = CTX.Event()
+        child = CTX.Process(target=_hold_file_open, args=(logfile, opened, release), daemon=True)
+        child.start()
+        try:
+            assert opened.wait(timeout=30), "child never opened the log file"
+            yield release
+        finally:
+            release.set()
+            child.join(timeout=30)
+
+    @staticmethod
+    def _fill_past_max_bytes(handler: logging.handlers.RotatingFileHandler) -> None:
+        handler.stream.write("x" * (handler.maxBytes + 1))
+        handler.stream.flush()
+
+    @WINDOWS_ONLY
+    def test_stock_handler_raises_winerror_32(self, logfile, foreign_handle):
+        """Characterization of the OS behaviour this whole module works around.
+
+        Not a regression test -- it pins down stdlib/Windows, which our change does
+        not alter. It documents that the rename in doRollover() is genuinely
+        refused while another process holds the file, which is the mechanism behind
+        the repeating "--- Logging error --- ... PermissionError" wall users saw.
+        """
+        handler = logging.handlers.RotatingFileHandler(logfile, maxBytes=100, backupCount=5)
+        try:
+            self._fill_past_max_bytes(handler)
+
+            with pytest.raises(PermissionError) as exc_info:
+                handler.doRollover()
+
+            assert exc_info.value.winerror == 32
+        finally:
+            handler.close()
+
+    def test_safe_handler_keeps_logging_through_a_blocked_rollover(self, logfile, foreign_handle):
+        """A blocked rename must not raise, and must not lose records."""
+        handler = SafeRotatingFileHandler(logfile, maxBytes=100, backupCount=5)
+        try:
+            self._fill_past_max_bytes(handler)
+
+            handler.doRollover()  # PermissionError on Windows; absorbed
+
+            assert handler.stream is not None, "handler was left with no stream to write to"
+            handler.emit(_record("survived the blocked rollover"))
+            handler.flush()
+        finally:
+            handler.close()
+
+        assert "survived the blocked rollover" in open(logfile, encoding="utf-8").read()
+
+    @WINDOWS_ONLY
+    def test_safe_handler_does_not_retry_the_rollover_on_every_record(self, logfile, foreign_handle):
+        """No retry storm.
+
+        The file stays over maxBytes after a failed rollover, so a naive handler
+        re-attempts (and re-fails) the rename for every single record -- which is
+        why the console spam lasted minutes rather than printing once.
+        """
+        handler = SafeRotatingFileHandler(logfile, maxBytes=100, backupCount=5, retry_seconds=60.0)
+        try:
+            self._fill_past_max_bytes(handler)
+            handler.doRollover()
+
+            assert handler.shouldRollover(_record("next")) == 0, "handler is still trying to roll over"
+
+            for i in range(50):
+                handler.emit(_record(f"record {i}"))
+            handler.flush()
+        finally:
+            handler.close()
+
+        assert "record 49" in open(logfile, encoding="utf-8").read()
+
+    def test_safe_handler_rotates_once_the_other_handle_is_released(self, logfile, foreign_handle):
+        """Degradation is temporary: normal rotation resumes when the file frees up."""
+        handler = SafeRotatingFileHandler(logfile, maxBytes=100, backupCount=5, retry_seconds=0.0)
+        try:
+            self._fill_past_max_bytes(handler)
+            handler.doRollover()
+
+            foreign_handle.set()  # child closes its handle and exits
+            for _ in range(600):
+                if os.path.exists(logfile + ".1"):
+                    break
+                handler.emit(_record("keep writing until rotation succeeds"))
+                handler.flush()
+
+            assert os.path.exists(logfile + ".1"), "rotation never recovered after the handle was released"
+        finally:
+            handler.close()

--- a/src/wiser/__main__.py
+++ b/src/wiser/__main__.py
@@ -3,7 +3,6 @@ import argparse
 import faulthandler
 import importlib
 import logging
-import logging.config
 import os
 import sys
 import traceback
@@ -74,58 +73,16 @@ except Exception:
 
 
 # Hard-code the logging configuration to remove the need for a log-config file.
-# The if statement below ensures that only the main process and no subprocesses
-# can get a file handle to the logger because this can cause a file rotation.
-# The issue is noted in #502
-if multiprocessing.parent_process() is None:  # This is the main process
-    logfile_path = os.path.join(get_wiser_config_dir(), "wiser.log")
-    logging.config.dictConfig(
-        {
-            "version": 1,
-            "formatters": {
-                "simpleFormatter": {
-                    "format": "%(asctime)s %(levelname)-5s %(name)s : %(message)s",
-                },
-            },
-            "handlers": {
-                "consoleHandler": {
-                    "class": "logging.StreamHandler",
-                    "level": "WARNING",
-                    "formatter": "simpleFormatter",
-                    "stream": sys.stderr,
-                },
-                "fileHandler": {
-                    "class": "logging.handlers.RotatingFileHandler",
-                    "level": "DEBUG",
-                    "formatter": "simpleFormatter",
-                    "filename": logfile_path,
-                    "maxBytes": 10_000_000,
-                    "backupCount": 5,
-                },
-            },
-            "loggers": {
-                "root": {
-                    "level": "DEBUG",
-                    "handlers": ["consoleHandler", "fileHandler"],
-                },
-                "matplotlib": {
-                    "level": "WARNING",
-                    "handlers": ["consoleHandler", "fileHandler"],
-                    "qualname": "matplotlib",
-                },
-            },
-        }
-    )
-else:
-    # Remove the "lastResort" handler, so only the null handler is left.
-    root_logger = logging.getLogger()
-    # Remove all handlers except NullHandler
-    for handler in root_logger.handlers[:]:
-        if not isinstance(handler, logging.NullHandler):
-            root_logger.removeHandler(handler)
-    # Ensure at least a NullHandler is present
-    if not any(isinstance(h, logging.NullHandler) for h in root_logger.handlers):
-        root_logger.addHandler(logging.NullHandler())
+#
+# This module's top-level code runs in the scheduler's pool workers too: in the
+# frozen build each worker is a fresh WISER.exe whose bootloader executes this
+# file from the top, and only reaches the freeze_support() call at the bottom
+# afterwards. So configure_logging() has to decide for itself whether it is the
+# app or a worker -- and only the app may open wiser.log, or rotation fails on
+# Windows with WinError 32 (#502).
+from wiser.logging_setup import configure_logging
+
+configure_logging(os.path.join(get_wiser_config_dir(), "wiser.log"))
 
 logger = logging.getLogger(__name__)
 

--- a/src/wiser/logging_setup.py
+++ b/src/wiser/logging_setup.py
@@ -1,0 +1,225 @@
+"""Process-aware logging configuration for WISER.
+
+WISER writes a single rotating log file (``wiser.log``) in the config directory.
+Rotation renames ``wiser.log`` -> ``wiser.log.1``, and on Windows that rename
+fails with ``PermissionError: [WinError 32]`` if *any* other handle to the file
+is open.  Keeping the log file open in exactly one process is therefore a
+correctness requirement, not a tidiness preference.  See issue #502.
+
+This module owns the two things that requirement needs:
+
+* :func:`is_worker_process` -- an *import-time* answer to "am I a multiprocessing
+  worker?", which is harder than it looks (see below).
+* :class:`SafeRotatingFileHandler` -- a rotating handler that degrades to "keep
+  writing to the current file" instead of raising, for the second-handle cases
+  we cannot prevent (antivirus, a search indexer, a tail'ing editor, or a second
+  copy of WISER started by the user).
+"""
+
+from __future__ import annotations
+
+import logging
+import logging.config
+import multiprocessing
+import multiprocessing.spawn
+import os
+import sys
+import time
+from logging.handlers import RotatingFileHandler
+
+# How long to wait before retrying a rollover that failed because another
+# process held the log file open. Without a cooldown, every subsequent record
+# re-attempts the rename (the file is still over maxBytes) and each failure
+# prints a "--- Logging error ---" traceback, which is the console spam in #502.
+ROLLOVER_RETRY_SECONDS = 60.0
+
+# Log volume drivers. Numba emits a DEBUG record per bytecode instruction, per
+# SSA block, per typing pass while compiling; with the root logger at DEBUG that
+# is tens of MB per compile, and it is what drives wiser.log to its rotation
+# threshold in the first place.
+NOISY_LIBRARY_LOGGERS = ("matplotlib", "numba")
+
+
+def is_worker_process() -> bool:
+    """Return True if this interpreter is a multiprocessing child, not the app.
+
+    This must be answerable *while the main module is still executing its
+    top-level code*, which rules out the obvious check.
+    ``multiprocessing.parent_process()`` reads a module global that is assigned
+    inside ``BaseProcess._bootstrap()``, and in a child that runs *after* the
+    main module has been re-executed:
+
+    * Frozen (PyInstaller): the child is a fresh ``WISER.exe`` launched with
+      ``--multiprocessing-fork``.  The bootloader runs ``wiser/__main__.py`` from
+      the top, and only the ``multiprocessing.freeze_support()`` call at the very
+      bottom hands control to ``spawn_main() -> _bootstrap()``.
+    * Source: ``spawn._main()`` calls ``prepare()`` -- which re-runs the main
+      module -- before it calls ``self._bootstrap()``.
+
+    Either way ``parent_process()`` still returns ``None`` throughout the
+    top-level code, so a child that asks it believes it is the main process.
+
+    The checks below are the ones that *are* true that early, in the same order
+    the stdlib and PyInstaller use them.
+    """
+    # Already bootstrapped (fork children, or any import after startup).
+    if multiprocessing.parent_process() is not None:
+        return True
+
+    # `python -m ...` / frozen spawn child: argv is
+    # [exe, "--multiprocessing-fork", "pipe_handle=...", ...]. This is the same
+    # test `multiprocessing.spawn.freeze_support()` and PyInstaller's
+    # pyi_rth_multiprocessing hook use to recognize a child.
+    if multiprocessing.spawn.is_forking(sys.argv):
+        return True
+
+    # Helper processes the frozen bootloader also starts by re-running the entry
+    # script: the resource tracker and the forkserver (macOS / Linux).
+    if len(sys.argv) >= 2 and sys.argv[-2] == "-c":
+        if sys.argv[-1].startswith(
+            ("from multiprocessing.resource_tracker", "from multiprocessing.forkserver")
+        ):
+            return True
+
+    # Source spawn child re-running the main module: `spawn._main()` sets
+    # `_inheriting` on the current process before `prepare()` re-executes the
+    # main module, and deletes it afterwards.
+    if getattr(multiprocessing.current_process(), "_inheriting", False):
+        return True
+
+    return False
+
+
+class SafeRotatingFileHandler(RotatingFileHandler):
+    """A RotatingFileHandler that survives a rename blocked by another handle.
+
+    Windows refuses to rename an open file, so a rollover raises
+    ``PermissionError`` (WinError 32) whenever something else holds the log open.
+    The stock handler leaves ``self.stream`` closed and lets the error escape to
+    ``handleError``, which prints a full traceback -- and because the file is
+    still oversized, the *next* record tries to roll over again.  That feedback
+    loop is the multi-minute console spam users see.
+
+    Here a failed rollover is absorbed: the stream is reopened on the existing
+    file and rollover is not re-attempted until ``retry_seconds`` has passed, so
+    logging continues uninterrupted and the log simply grows past ``maxBytes``
+    until whoever holds the second handle lets go.
+    """
+
+    def __init__(self, *args, retry_seconds: float = ROLLOVER_RETRY_SECONDS, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._retry_seconds = retry_seconds
+        self._rollover_blocked_until = 0.0
+        self._reported_blocked_rollover = False
+
+    def shouldRollover(self, record: logging.LogRecord) -> int:
+        if time.monotonic() < self._rollover_blocked_until:
+            return 0
+        return super().shouldRollover(record)
+
+    def doRollover(self) -> None:
+        try:
+            super().doRollover()
+        except OSError as exc:
+            self._rollover_blocked_until = time.monotonic() + self._retry_seconds
+
+            # doRollover() closes the stream before renaming, so a failure part
+            # way through leaves us with nowhere to write. Reattach to the file
+            # we failed to rename; it still exists, and append mode picks up
+            # where we left off.
+            if self.stream is None:
+                self.stream = self._open()
+
+            # Say this once per handler rather than once per record: the whole
+            # point of the class is to not spam the console.
+            if not self._reported_blocked_rollover:
+                self._reported_blocked_rollover = True
+                sys.stderr.write(
+                    f"WISER: could not rotate log file {self.baseFilename} "
+                    f"({exc}); another process is holding it open. Continuing to "
+                    f"log to the existing file.\n"
+                )
+
+
+def configure_logging(logfile_path: str) -> None:
+    """Install WISER's logging configuration for the current process.
+
+    The main process logs WARNING+ to stderr and DEBUG+ to a rotating
+    ``logfile_path``.  Worker processes get no handlers at all: they must not
+    hold a second handle on the log file (#502), and worker task code prints
+    rather than logs.
+    """
+    if is_worker_process():
+        _configure_worker_logging()
+        return
+
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "formatters": {
+                "simpleFormatter": {
+                    "format": "%(asctime)s %(levelname)-5s %(name)s : %(message)s",
+                },
+            },
+            "handlers": {
+                "consoleHandler": {
+                    "class": "logging.StreamHandler",
+                    "level": "WARNING",
+                    "formatter": "simpleFormatter",
+                    "stream": sys.stderr,
+                },
+                "fileHandler": {
+                    # Passed as a callable rather than a dotted path so this
+                    # keeps working in the PyInstaller build, where dictConfig's
+                    # string import of a bundled module is one more thing to go
+                    # wrong.
+                    "()": SafeRotatingFileHandler,
+                    "level": "DEBUG",
+                    "formatter": "simpleFormatter",
+                    "filename": logfile_path,
+                    "maxBytes": 10_000_000,
+                    "backupCount": 5,
+                },
+            },
+            "loggers": {
+                "root": {
+                    "level": "DEBUG",
+                    "handlers": ["consoleHandler", "fileHandler"],
+                },
+                # Capped at WARNING so their DEBUG firehose does not fill the log
+                # (and force rollovers) on every numba compile / plot redraw.
+                **{name: {"level": "WARNING"} for name in NOISY_LIBRARY_LOGGERS},
+            },
+        }
+    )
+
+
+def _configure_worker_logging() -> None:
+    """Give a worker process a root logger that writes nowhere.
+
+    A NullHandler keeps ``logging.lastResort`` from dumping worker records onto
+    the console, and the WARNING level means numba's per-instruction DEBUG calls
+    short-circuit in ``isEnabledFor()`` instead of building records that are only
+    going to be discarded.
+    """
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        if not isinstance(handler, logging.NullHandler):
+            root_logger.removeHandler(handler)
+    if not any(isinstance(h, logging.NullHandler) for h in root_logger.handlers):
+        root_logger.addHandler(logging.NullHandler())
+    root_logger.setLevel(logging.WARNING)
+
+
+def open_log_file_handles(logfile_path: str) -> list[logging.Handler]:
+    """Return the handlers in this process that hold ``logfile_path`` open.
+
+    Used by the tests to assert the invariant this module exists to maintain:
+    exactly one process opens the log file.
+    """
+    target = os.path.abspath(logfile_path)
+    return [
+        handler
+        for handler in logging.getLogger().handlers
+        if isinstance(handler, logging.FileHandler) and os.path.abspath(handler.baseFilename) == target
+    ]

--- a/src/wiser/logging_setup.py
+++ b/src/wiser/logging_setup.py
@@ -22,7 +22,6 @@ import logging
 import logging.config
 import multiprocessing
 import multiprocessing.spawn
-import os
 import sys
 import time
 from logging.handlers import RotatingFileHandler
@@ -209,17 +208,3 @@ def _configure_worker_logging() -> None:
     if not any(isinstance(h, logging.NullHandler) for h in root_logger.handlers):
         root_logger.addHandler(logging.NullHandler())
     root_logger.setLevel(logging.WARNING)
-
-
-def open_log_file_handles(logfile_path: str) -> list[logging.Handler]:
-    """Return the handlers in this process that hold ``logfile_path`` open.
-
-    Used by the tests to assert the invariant this module exists to maintain:
-    exactly one process opens the log file.
-    """
-    target = os.path.abspath(logfile_path)
-    return [
-        handler
-        for handler in logging.getLogger().handlers
-        if isinstance(handler, logging.FileHandler) and os.path.abspath(handler.baseFilename) == target
-    ]


### PR DESCRIPTION
## What does this change do?

Fixes the repeating `PermissionError: [WinError 32]` log-rotation spam in the console, and explains why the previous attempt at this fix did not work.

The invariant is that only the main process may hold `wiser.log` open. Every scheduler pool worker was opening it too, so when any process tried to roll the file over, Windows refused to rename a file the other processes still had open.

Closes #502.

## What type of PR is this? (check all applicable)
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [x] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?

On Windows, `RotatingFileHandler` rolls over by renaming `wiser.log` → `wiser.log.1`, and the OS refuses that rename while any other process holds the file open. The failure surfaces as a `--- Logging error ---` traceback **per log record**, for minutes at a time — reliably triggered by running spectral feature fitting once `wiser.log` is near its 10 MB threshold, because numba's compiler logs a DEBUG record per bytecode instruction and per SSA block.

The previous fix (#502) tried to stop workers from opening the log with:

```python
if multiprocessing.parent_process() is None:  # This is the main process
    ...dictConfig with a RotatingFileHandler...
```

**That guard cannot work, and the traceback proves it.** The call stack of the failing process is:

```
File "__main__.py", line 386, in <module>              <- multiprocessing.freeze_support()
File "pyi_rth_multiprocessing.py", line 81, in _freeze_support
File "multiprocessing\spawn.py", line 122, in spawn_main
File "multiprocessing\process.py", line 314, in _bootstrap
File "concurrent\futures\process.py", line 252, in _process_worker   <- a scheduler pool worker
...numba compiling...
File "logging\handlers.py", line 115, in rotate
PermissionError: [WinError 32] ... 'wiser.log' -> 'wiser.log.1'
```

The process doing the failed rollover **is a pool worker**, and it reached `_bootstrap()` *through* `__main__.py` line 386. In the frozen build each worker is a fresh `WISER.exe --multiprocessing-fork`, whose bootloader executes `wiser/__main__.py` from the top and only reaches `freeze_support()` at the very bottom.

`multiprocessing.parent_process()` reads a module global that is assigned in exactly one place — `BaseProcess._bootstrap()` (`multiprocessing/process.py:302`). So when the worker ran the logging block at line 80, that global was still `None`: the guard asked "am I a child?" using a flag the child does not set until ~300 lines later. **Every worker took the main-process branch and opened its own handle on `wiser.log`.** (The same ordering holds when running from source: `spawn._main()` calls `prepare()`, which re-runs the main module, before `self._bootstrap()`.)

## How did you implement the change?

The logging configuration moves out of `__main__.py` into a new `src/wiser/logging_setup.py`, which fixes three things:

1. **`is_worker_process()` — detect a worker with state that exists that early.** Chiefly `--multiprocessing-fork` in `sys.argv`, which is the same test `multiprocessing.spawn.freeze_support()` and PyInstaller's `pyi_rth_multiprocessing` hook use to recognize a child, plus `_inheriting` for the from-source spawn path and `parent_process()` for already-bootstrapped children. Workers now get a `NullHandler` and open no log file.

2. **`SafeRotatingFileHandler` — survive the second-handle cases we cannot prevent** (antivirus, a search indexer, an editor tailing the log, a second copy of WISER). A blocked rename no longer escapes to `handleError`: the stream is reattached to the existing file and rollover is suppressed for 60s. This also kills the retry storm — the stock handler re-attempts the rename on *every subsequent record* because the file is still over `maxBytes`, which is why the spam lasted minutes instead of printing once.

3. **Cap `numba` at WARNING** (alongside the existing `matplotlib` cap). Its per-instruction DEBUG output is what fills 10 MB and forces the rollover in the first place. WISER's own loggers keep DEBUG.

## Added tests?
- [x] yes

`src/tests/test_logging_setup.py`. Each test was verified **red against the pre-fix baseline (`94d8402e`)** before being accepted, not just green afterwards:

| Test | On `main` | With fix |
|---|---|---|
| `test_worker_opens_no_handle_on_the_log_file` | **FAILED** | PASSED |
| `test_numba_debug_logging_is_capped_in_the_app` | **FAILED** | PASSED |
| `test_app_still_opens_exactly_one_log_file_handle` | passed | passed |
| `test_stock_handler_raises_winerror_32` | passed | passed |
| 3 × `SafeRotatingFileHandler` tests | passed | passed |

- **`test_worker_opens_no_handle_on_the_log_file` is the regression test.** It runs the real `wiser/__main__.py` in a subprocess set up exactly as a spawned worker is (`--multiprocessing-fork` argv, config dir pointed at `tmp_path`), then asserts the worker opened no handle on the log file. Against the old guard it reports `['wiser.log']` and fails. It needs no PyInstaller build — it reproduces the *condition* the frozen bootloader creates.
- `test_app_still_opens_exactly_one_log_file_handle` is a deliberate control: it passes on both, and exists to prove the worker test isn't passing merely because logging is broken everywhere.
- `test_stock_handler_raises_winerror_32` passes on both **by design**. It reproduces the reported error end-to-end (a real second process holds the log open; the stdlib handler raises `PermissionError` with `winerror == 32`) and characterizes the OS behaviour this change works around. It documents the mechanism rather than guarding it.
- The three `SafeRotatingFileHandler` tests guard the new resilience layer (blocked-rename recovery, retry cooldown, and recovery once the other handle is released).

## Added to documentation?
- [x] no documentation needed

## Checklist
- [x] There is an issue associated with this pull request (#502)
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced (`ruff check` and `ruff format --check` clean)
- [x] Branch is up-to-date with main/master (0 commits behind `origin/main`)
- [ ] All CI checks passed

## Desktop Screenshots/Recordings

Reproduced live on the failing machine during development. With `wiser.log` at 10,001,216 bytes (just past the 10 MB threshold) and six `WISER.exe` processes running — one app plus five pool workers, each holding the file open — startup previously produced the traceback wall. With this change it emits a single line and starts cleanly:

```
WISER: could not rotate log file C:\Users\...\WISER-3.0b0\wiser.log ([WinError 32] The process
cannot access the file because it is being used by another process); another process is holding
it open. Continuing to log to the existing file.
```

## [optional] Are there any post-merge tasks we need to perform?

- The fix stops *new* workers from opening the log, but any WISER instance already running from an older build keeps its handle. Anyone reproducing this should fully close WISER and delete `wiser.log` (which will be stuck at ~10 MB) to get a clean baseline.
- Worth confirming once in a PyInstaller build, since the frozen bootloader is the environment where the bug actually bites. The regression test simulates that condition but cannot run inside a frozen `--test_mode` run (it needs `python -c`; `sys.executable` is `WISER.exe` there), so it is skipped in that context.
