### PR TITLE
doc: Updating docs on make sign-windows

### DIFF
--- a/doc/codesign-win.md
+++ b/doc/codesign-win.md
@@ -73,7 +73,8 @@ Currently, we let the `Build and Smoke Test WISER` action build the Windows
 installer, and we sign it locally by running
 `make sign-windows LINK=<link-to-windows-artifact>`. We get the link to the
 Windows artifact by right-clicking on `wiser-Windows-X64` and selecting
-_Copy Link Address_. Once the installer is signed, we upload it.
+_Copy Link Address_. Once the installer is signed, we upload it. See
+[CI/CD and Releases](ci-cd-and-releases.md) to learn more.
 
 You can also build and sign in a single Make target. Because building is so
 machine-dependent, however, we prefer to build on the runners using the steps

--- a/doc/codesign-win.md
+++ b/doc/codesign-win.md
@@ -69,8 +69,16 @@ original build machine.
 
 ## Building and Signing: the `make dist-win` command
 
-On Windows, building and signing happen together in a single Make target. From
-the top of the WISER repository, in the `wiser-prod` conda environment, run:
+Currently, we let the `Build and Smoke Test WISER` action build the Windows
+installer, and we sign it locally by running
+`make sign-windows LINK=<link-to-windows-artifact>`. We get the link to the
+Windows artifact by right-clicking on `wiser-Windows-X64` and selecting
+_Copy Link Address_. Once the installer is signed, we upload it.
+
+You can also build and sign in a single Make target. Because building is so
+machine-dependent, however, we prefer to build on the runners using the steps
+above. If you still want to build and sign locally, activate the `wiser-prod`
+conda environment, change to the root directory of WISER, and run:
 
 ```
 make dist-win

--- a/doc/codesign-win.md
+++ b/doc/codesign-win.md
@@ -67,7 +67,7 @@ from the Windows Certificate Store at signing time, the only machine-specific
 secret you need is the thumbprint — there is nothing else to copy off of the
 original build machine.
 
-## Building and Signing: the `make dist-win` command
+## Building and Signing
 
 Currently, we let the `Build and Smoke Test WISER` action build the Windows
 installer, and we sign it locally by running


### PR DESCRIPTION
## What does this change do?
The docs don't mentioned `make sign-windows LINK=<link-to-windows-artifact>` where the windows artifact is in Build and Smoke Test WISER. This PR adds that to the docs.

Closes #718

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [X] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?
So developers know where to find things.

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed