### PR TITLE
doc: Updating docs with newer information and caltech -> lasp info

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,14 +46,12 @@ We agree to restrict the following behaviors in our community. Instances, threat
 
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
-When an incident does occur, it is important to report it promptly. To report a possible violation, **email jgarciak@caltech.edu with [WISER Code of Conduct Violation] in the subject line.** This email will go to Joshua Garcia-Kimble, a WISER maintainer. **If your incident involves Joshua Garcia-Kimble, please email bethany.ehlmann@lasp.colorado.edu instead.** This email will go to Bethany Ehlmann, the WISER project lead.
+When an incident does occur, it is important to report it promptly. To report a possible violation, **email matthew.maclay@lasp.colorado.edu with [WISER Code of Conduct Violation] in the subject line.** This email will go to Matthew Maclay, a WISER maintainer. **If your incident involves Matthew Maclay, please email bethany.ehlmann@lasp.colorado.edu instead.** This email will go to Bethany Ehlmann, the WISER project lead.
 
 Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 
 
 ## Addressing and Repairing Harm
-
-****
 
 If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,26 @@ added by running: `git commit -s -m "message"`.
 
 ## Table of Contents
 
+- [Environment Details](#environment-details)
+- [How to submit changes](#how-to-submit-changes)
+- [How to report a bug](#how-to-report-a-bug)
+- [How to request an "enhancement"](#how-to-request-an-enhancement)
+- [Style Guide / Coding Conventions](#style-guide--coding-conventions)
+- [Your First Code Contribution](#your-first-code-contribution)
+- [Code of Conduct](#code-of-conduct)
+- [Who is currently involved?](#who-is-currently-involved)
+- [Where can I ask for help?](#where-can-i-ask-for-help)
+- [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
+  - [Why we chose DCO over CLA](#why-we-chose-dco-over-cla)
+- [Project Roles](#project-roles)
+  - [Project Lead (BDFL)](#project-lead-bdfl)
+  - [Maintainer](#maintainer)
+    - [Becoming a maintainer](#becoming-a-maintainer)
+  - [Committer](#committer)
+    - [Becoming a committer](#becoming-a-committer)
+  - [Contributor](#contributor)
+    - [How to contribute](#how-to-contribute)
+- [List of Authors](#list-of-authors)
 
 ## Environment Details
 
@@ -54,13 +74,13 @@ only require a few lines of code and a test or two
 
 Read _CODE_OF_CONDUCT.md_ for more information.
 
-## Who is involved?
+## Who is currently involved?
 
 | Role | Name | Institution | 
 |------|------|-------------|
 | Project Lead [(BDFL)](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) | [Bethany Ehlmann](https://www.linkedin.com/in/bethany-ehlmann-1112b81/) | CU Boulder
-| Maintainer | [Joshua Garcia-Kimble](https://www.linkedin.com/in/joshua-garcia-kimble-45211a16b/) | Caltech |
-| Maintainer | Matthew Maclay | LASP |
+| Maintainer | [Matthew Maclay](https://www.linkedin.com/in/matthew-maclay/) | LASP |
+| Contributor | [Joshua Garcia-Kimble](https://www.linkedin.com/in/joshua-garcia-kimble-45211a16b/) | Caltech |
 
 ## Where can I ask for help?
 
@@ -202,10 +222,12 @@ in one place.
 
 | Role | Name | Institution | 
 |------|------|-------------|
-| Maintainer | [Joshua Garcia-Kimble](https://www.linkedin.com/in/joshua-garcia-kimble-45211a16b/) | Caltech |
-| Past Maintainer | Donnie Pinkston | Caltech |
-| Past Maintainer | Dr. Rebecca Greenberger | Caltech (Now The Aerospace Corporation) |
-| Contributor | Dr. Andrew Annex | SETI Institute |
-| Contributor | Daphne Nea | UCLA '27 |
+| Project Lead [(BDFL)](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) | [Bethany Ehlmann](https://www.linkedin.com/in/bethany-ehlmann-1112b81/) | CU Boulder
+| Maintainer | [Matthew Maclay](https://www.linkedin.com/in/matthew-maclay/) | LASP |
+| Past Maintainer | [Joshua Garcia-Kimble](https://www.linkedin.com/in/joshua-garcia-kimble-45211a16b/) | Caltech |
+| Past Maintainer | [Donnie Pinkston](https://www.cms.caltech.edu/people/pinkston) | Caltech |
+| Past Maintainer | [Dr. Rebecca Greenberger](https://www.linkedin.com/in/rebecca-greenberger-18842482/) | Caltech (Now The Aerospace Corporation) |
+| Contributor | [Dr. Andrew Annex](https://www.linkedin.com/in/andrewannex/) | SETI Institute |
+| Contributor | [Daphne Nea](https://www.linkedin.com/in/daphne-nea/) | UCLA '27 |
 | Contributor | Amy Wang | Cornell '23 |
 | Contributor | Sahil Azad | Caltech '25 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ added by running: `git commit -s -m "message"`.
 
 If you are thinking about contributing to WISER with code,
 then you will need to set up your environment. We have detailed
-documentation on how to do this under _doc\sphinx-general-wiser-docs\source\developer-content\environment-setup.md_
+documentation on how to do this in the [Developer Environment Setup](doc/sphinx-general-wiser-docs/source/developer-content/environment-setup.md) guide.
 
 ## How to submit changes
 
@@ -47,32 +47,32 @@ If that all sounded very complicated, that's okay. [This link](https://medium.co
 goes through the process.
 
 For information on how your pull request will be reviewed, go 
-to _doc\sphinx-general-wiser-docs\source\developer-content\code-review-and-quality.md_.
+to the [Contributing & Code Quality](doc/sphinx-general-wiser-docs/source/developer-content/contributing-and-quality.md) guide.
 
 ## How to report a bug
 
-Read more on how to report a bug here: _doc\sphinx-general-wiser-docs\source\general-content\bug-submitting-guide.md_. 
+Read more on how to report a bug here: [Reporting a Bug](doc/sphinx-general-wiser-docs/source/contributing.md#reporting-a-bug).
 
 ## How to request an "enhancement"
 
-Read more on how to submit a feature/enhancement request here: _doc\sphinx-general-wiser-docs\source\general-content\feature-submitting-guide.md_.
+Read more on how to submit a feature/enhancement request here: [Requesting a Feature](doc/sphinx-general-wiser-docs/source/contributing.md#requesting-a-feature).
 
 ## Style Guide / Coding Conventions
 
-Many of our style and coding conventions can be found here: _doc\sphinx-general-wiser-docs\source\developer-content\code-review-and-quality.md_.
+Many of our style and coding conventions can be found here: [Contributing & Code Quality](doc/sphinx-general-wiser-docs/source/developer-content/contributing-and-quality.md).
 
 ## Your First Code Contribution
 
 If you are unsure where to begin contributing to WISER, you can look through our beginner or help-wanted issues.
 
-- [Beginner Issues](https://github.com/Ehlmann-research-group/WISER/issues?q=state%3Aopen%20label%3Abeginner) - issues which
+- [Beginner Issues](https://github.com/Ehlmann-research-group/WISER/issues?q=state%3Aopen%20label%3A%22good%20first%20issue%22) - issues which
 only require a few lines of code and a test or two
 
 - [Help wanted issues](https://github.com/Ehlmann-research-group/WISER/issues?q=state%3Aopen%20label%3A%22help%20wanted%22) - More involved than a `beginner` issue, but still somewhat isolated.
 
 ## Code of Conduct
 
-Read _CODE_OF_CONDUCT.md_ for more information.
+Read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for more information.
 
 ## Who is currently involved?
 
@@ -140,9 +140,7 @@ WISER is Bethany Ehlmann.
 A maintainer doesn't have to write code. A maintainer for
 WISER is defined in very broad terms: someone who has
 responsibility over the direction of the project and is
-committed to improving it. WISER's current maintainers are
-listed below:
-1. Joshua Garcia-Kimble
+committed to improving it.
 
 #### Becoming a maintainer
 Becoming a maintainer of WISER isn't a set-in-stone process.
@@ -208,7 +206,7 @@ a maintainer comments on if this new feature aligns with
 the mission of WISER before you code. That way you don't
 put in a lot of work to not see the new feature make it into
 the project. Learn more about creating issues for feature
-requests here at _doc/sphinx-general-wiser-docs/feature-submitting-guide.md_.
+requests here at [Requesting a Feature](doc/sphinx-general-wiser-docs/source/contributing.md#requesting-a-feature).
 
 You can also get in contact with the maintainers or Project Lead
 if you want to do other forms of contributions like triaging

--- a/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
@@ -257,8 +257,8 @@ release time, so what ships is exactly what you tested.
     `doc/sphinx-general-wiser-docs/source/extending-wiser/` to reflect any changes to plugin
     interfaces or dependencies in the latest version.
 
-11. **Announce** — if you have permission, email wiser-announce@caltech.edu with a summary of
-    the release. If not, reach out to someone who does with the email you want sent.
+11. **Announce** — if you have permission, email wiser-announcements@lists.lasp.colorado.edu with a summary of
+    the release. If not, reach out to someone who deals with the email you want sent.
 
 > **Note**: This process can only be done by a maintainer with
 > access to all of these resources. This intentionally limits who can

--- a/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
@@ -202,28 +202,37 @@ release time, so what ships is exactly what you tested.
    Linux asset name is read from `version.py` at build time, so it must be correct
    *before* you build.
 
-2. **Build and test** — run **Build and Smoke Test WISER** (`prod-deploy.yml`) via
+2. **Verify app metadata is current**:
+
+   - **Check the year.** Ctrl+F for whatever the current year is throughout the app and
+     go through each hit to make sure the year is correct — some may not need to be
+     changed. (We should turn this into a single variable in the future.)
+   - **Check the feature flags.** Search for `FLAGS.` and check `feature_flags.py`,
+     confirming the `FEATURE_GATES` dictionary is correct. Then check
+     `app_config.py` and confirm everything referencing `feature_flags.` is correct.
+
+3. **Build and test** — run **Build and Smoke Test WISER** (`prod-deploy.yml`) via
    `workflow_dispatch` on the commit you intend to release. Every platform builds; each
    Linux distro runs the full `--test_mode` suite in-container (a leg only produces a
    tarball if its tests pass), and Windows/macOS run a `--smoke` launch check. Note the
    **run ID** — you will promote this exact run.
 
-3. **Verify locally** — download the Linux tarballs from the run and test if needed. Build,
+4. **Verify locally** — download the Linux tarballs from the run and test if needed. Build,
    `--test_mode`, code-sign, and clean-install-test the Windows/macOS installers locally
    (CI does not produce the signed installers). See the signing certificate requirements
    below.
 
-4. **Create the release** on the *same commit* you built. Publish it as a **pre-release**
+5. **Create the release** on the *same commit* you built. Publish it as a **pre-release**
    (see the Pre-release flag section) so it stays out of `…/releases/latest` while you
    attach and verify assets. A published pre-release also lets the publish workflow confirm
    the tag matches the built commit.
 
-5. **Attach the Linux assets** — run **Publish release assets**
+6. **Attach the Linux assets** — run **Publish release assets**
    (`publish-release-assets.yml`) with the build **run ID** and the release **tag**. It
    checks the run succeeded and that the tag points at the built commit, then attaches the
    six Linux tarballs.
 
-6. **Upload the signed Windows/macOS installers** with `RELEASE_TAG=<tag>` so each is
+7. **Upload the signed Windows/macOS installers** with `RELEASE_TAG=<tag>` so each is
    uploaded to the release with its canonical name in one step:
 
    `make sign-mac LINK=<artifact-url> MAC_DIST_GITHUB_NAME=<artifact-name> RELEASE_TAG=<tag>`
@@ -238,16 +247,11 @@ release time, so what ships is exactly what you tested.
 
    b. WISER has no code-signing mechanism for Linux; the Linux assets are attached unsigned.
 
-7. **Finalize the release notes** on the GitHub release. Point users at the attached
+8. **Finalize the release notes** on the GitHub release. Point users at the attached
    release assets — never a `…/actions/runs/<id>` URL.
 
-8. **Go live** — once every asset is present with its canonical name, uncheck **"Set as a
+9. **Go live** — once every asset is present with its canonical name, uncheck **"Set as a
    pre-release"** (and keep "Set as the latest release" on) so `latest` resolves to it.
-
-9. **Update the website** — if you are making an official release, add the download links on
-   the [WISER website](https://ehlmann.caltech.edu/wiser/index.html). Release notes live on
-   the GitHub release itself (step 7) — there is no separate release-notes page to maintain.
-   (Once the downloads page reads the release API, these per-release link edits go away.)
 
 10. **Update the plugin API documentation** in
     `doc/sphinx-general-wiser-docs/source/extending-wiser/` to reflect any changes to plugin

--- a/doc/sphinx-general-wiser-docs/source/index.rst
+++ b/doc/sphinx-general-wiser-docs/source/index.rst
@@ -49,7 +49,7 @@ exploring WISER:
   `header file <https://avng.jpl.nasa.gov/pub/DThompson/istutor/ang20171108t184227_corr_v2p13_subset_bil.hdr>`_)
 - `AVIRIS Data Portal <https://aviris.jpl.nasa.gov/dataportal/>`_ --- archive of airborne imaging-spectrometer scenes
 - `PDS Geosciences Node <https://pds-geosciences.wustl.edu/>`_ --- planetary hyperspectral datasets (CRISM, OMEGA, and more)
-- `Ehlmann Lab datasets <https://ehlmann.caltech.edu/publications/datasets.html>`_ --- laboratory and field imaging-spectroscopy data
+- `Ehlmann Lab datasets <https://lasp.colorado.edu/ehlmann-lab/datasets/>`_ --- laboratory and field imaging-spectroscopy data
 
 ----
 
@@ -57,8 +57,8 @@ Subscribe to Email Updates
 --------------------------
 
 To receive notifications about new WISER releases, send an email to
-``wiser-announce-request@caltech.edu`` with the subject line **Subscribe**.
-Follow the instructions in the reply to confirm your subscription.
+``sympa@lists.lasp.colorado.edu`` with the subject line **subscribe wiser-announcements**
+and a blank message.
 
 
 Installation
@@ -68,7 +68,7 @@ Download WISER
 ~~~~~~~~~~~~~~
 
 Pre-built installers for macOS, Windows, and Linux are available at:
-`ehlmann.caltech.edu/wiser <https://ehlmann.caltech.edu/wiser/index.html>`_
+`lasp.colorado.edu/ehlmann-lab/wiser/ <https://lasp.colorado.edu/ehlmann-lab/wiser/>`_
 
 Download the installer for your platform and follow the on-screen instructions.
 Users can also download and install WISER from


### PR DESCRIPTION
## What does this change do?
As the title says. 

Closes #736

## What type of PR is this? (check all applicable) 
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Important Additional Info
Some of where it says California Institute of Technology or Caltech I don't have the expertise to change and it will be up to Matt to do so. Mainly these below parts:
```
Update in `Makefile` this line ‘OSX_BUNDLE_ID=edu.caltech.gps.WISER’ to be whatever it should be for lasp
Update in `WISER_macOS.spec` this line “             bundle_identifier='edu.caltech.gps.WISER',” figure out what lasp or cu boulders is
In `src/wiser/gui/ui_files/about_dialog.ui` the file has a bunch of mentions of caltech and California Institute of Technology regarding legal things. I don’t know how to touch this but we probably want some of this to say CU Boulder as well.
Also in `doc\sphinx-general-wiser-docs\source\[conf.py](http://conf.py/)` we only have the copyright as "2019-2026, California Institute of Technology" and nothing for Boulder
In win-install.nsi we only mentioned Caltech and not CU boulder. We need to look into if there is an official name for CU Boulder to use here and the legalness of what putting that in the win-install.nsi file means
```

Also just Ctrl + F either 'caltech' or 'california' to find where.

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

## Added to documentation?  
- [x] yes
- [ ] no documentation needed 

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed
