### PR TITLE
test: Adding regression tests for spectra import and the fix

### DIFF
--- a/src/tests/test_spectra_text_import_export.py
+++ b/src/tests/test_spectra_text_import_export.py
@@ -102,6 +102,37 @@ class TestTrailingDelimiterImport(unittest.TestCase):
         self.assertTrue(all(s.get_name() for s in spectra), "no spectrum should be unnamed")
         self.assertTrue(all(s.num_bands() == 2 for s in spectra))
 
+    def test_ragged_trailing_delimiters_are_tolerated(self):
+        """Bug 1/2 variant: Excel does not always emit the *same* number of
+        trailing tabs on every line -- the header and each data row can carry a
+        different-length run (here 4, 1, 3, 4, 2).  After stripping trailing
+        empties every row should normalize to the four real columns, yielding
+        the three real spectra with no phantom or truncated ones."""
+        lines = [
+            "Wavelength_um\tARKSAW_18_G\tARKSAW_15_TS\tARKSAW_17_M\t\t\t\t\n",  # 4 trailing
+            "0.3466\t26.5672\t19.726\t27.2727\t\n",  # 1 trailing
+            "0.3482\t26.9417\t19.3805\t27.3134\t\t\t\n",  # 3 trailing
+            "0.3498\t26.8571\t19.6957\t27.2464\t\t\t\t\n",  # 4 trailing
+            "0.3514\t26.682\t19.7034\t27.0283\t\t\n",  # 2 trailing
+        ]
+
+        spectra = import_spectra_text(
+            lines,
+            delim="\t",
+            has_header=True,
+            wavelength_cols=WavelengthCols.FIRST_COL,
+        )
+
+        self.assertEqual(
+            [s.get_name() for s in spectra],
+            ["ARKSAW_18_G", "ARKSAW_15_TS", "ARKSAW_17_M"],
+        )
+        self.assertTrue(all(s.get_name() for s in spectra), "no spectrum should be unnamed")
+        # All four data rows survive for every real spectrum.
+        self.assertTrue(all(s.num_bands() == 4 for s in spectra))
+        np.testing.assert_allclose(spectra[0].get_spectrum(), [26.5672, 26.9417, 26.8571, 26.682])
+        np.testing.assert_allclose(spectra[2].get_spectrum(), [27.2727, 27.3134, 27.2464, 27.0283])
+
 
 class TestExportImportRoundTrip(unittest.TestCase):
     """Bug 3: spectra exported by WISER should be re-importable."""

--- a/src/tests/test_spectra_text_import_export.py
+++ b/src/tests/test_spectra_text_import_export.py
@@ -133,6 +133,44 @@ class TestTrailingDelimiterImport(unittest.TestCase):
         np.testing.assert_allclose(spectra[0].get_spectrum(), [26.5672, 26.9417, 26.8571, 26.682])
         np.testing.assert_allclose(spectra[2].get_spectrum(), [27.2727, 27.3134, 27.2464, 27.0283])
 
+    def test_variable_length_spectra_with_trailing_padding(self):
+        """Variable-length spectra AND ragtag trailing padding at once.
+
+        The file holds three spectra of different lengths (A: 5 values, B: 3,
+        C: 2) sharing one wavelength column.  A shorter spectrum signals its end
+        with an empty value *within* the real columns, so those in-width blanks
+        must be preserved.  On top of that, every row carries a different number
+        of trailing tabs that correspond to no spectrum at all -- pure padding
+        that must be stripped.  Both behaviors have to hold simultaneously: strip
+        the blanks beyond the four real columns, keep the blanks inside them.
+        """
+        # Four real columns: WVS + A + B + C.  Empty A/B/C cells mark a spectrum
+        # as finished; the tabs appended after column C are padding only.
+        lines = [
+            "WVS\tA\tB\tC\t\t\n",  # header + 2 padding tabs
+            "0.3\t1\t2\t3\t\t\t\n",  # all present + 3 padding tabs
+            "0.4\t4\t5\t6\n",  # all present, no padding
+            "0.5\t7\t8\t\t\t\t\t\n",  # C ends here + 4 padding tabs
+            "0.6\t9\t\t\t\n",  # B ends here (C already ended) + 1 padding tab
+            "0.7\t11\t\t\t\t\t\t\n",  # only A remains + 5 padding tabs
+        ]
+
+        spectra = import_spectra_text(
+            lines,
+            delim="\t",
+            has_header=True,
+            wavelength_cols=WavelengthCols.FIRST_COL,
+        )
+
+        # The padding never becomes a spectrum: exactly the three real ones.
+        self.assertEqual([s.get_name() for s in spectra], ["A", "B", "C"])
+        # Each spectrum keeps only the values it actually had; the in-width
+        # blanks correctly truncated the shorter ones.
+        self.assertEqual([s.num_bands() for s in spectra], [5, 3, 2])
+        np.testing.assert_allclose(spectra[0].get_spectrum(), [1, 4, 7, 9, 11])
+        np.testing.assert_allclose(spectra[1].get_spectrum(), [2, 5, 8])
+        np.testing.assert_allclose(spectra[2].get_spectrum(), [3, 6])
+
 
 class TestExportImportRoundTrip(unittest.TestCase):
     """Bug 3: spectra exported by WISER should be re-importable."""

--- a/src/tests/test_spectra_text_import_export.py
+++ b/src/tests/test_spectra_text_import_export.py
@@ -1,0 +1,144 @@
+"""Regression tests for importing/exporting spectra as delimited text.
+
+These tests capture three defects reported by WISER users around the
+"Import Spectra from Text" dialog and the spectrum-export feature:
+
+1.  Trailing delimiters on *data rows only* (a common artifact of Excel's
+    "Save As -> Tab delimited (.txt)") make every data row have one more
+    column than the header, so parsing aborts with a "Line N has X columns,
+    but first line has Y columns" error even though the data is fine.
+
+2.  Trailing delimiters on *every* row (header included) are consistent, so
+    parsing "succeeds" -- but the extra empty trailing columns are imported as
+    phantom, empty spectra.  A file with 3 real spectra plus a run of trailing
+    tabs imports as many more (the user's report: 3 spectra read as 22).
+
+3.  Spectra exported by WISER (``export_spectrum_list``, which writes
+    wavelength/value column pairs) cannot be re-imported with the matching
+    "odd columns specify wavelength values" option: the importer crashes with
+    an ``IndexError`` because it mis-indexes the header names.
+
+Each test asserts the *desired* behavior, so it currently fails (red) and
+should pass once the corresponding bug is fixed.
+"""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import pytest
+from astropy import units as u
+
+import tests.context  # noqa: F401 -- adds src/ to sys.path
+
+from wiser.raster.spectra_export import (
+    WavelengthCols,
+    import_spectra_text,
+    import_spectra_textfile,
+    export_spectrum_list,
+)
+from wiser.raster.spectrum import NumPyArraySpectrum
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.regression,
+]
+
+
+class TestTrailingDelimiterImport(unittest.TestCase):
+    """Bugs 1 & 2: trailing delimiters left behind by Excel text exports."""
+
+    def test_trailing_delimiter_on_data_rows_is_tolerated(self):
+        """Bug 1: header has no trailing tab but every data row does (the
+        ``Muscovite_test.txt`` case).  The trailing empty column should be
+        ignored, not treated as a fatal column-count mismatch."""
+        # Header: 3 columns, no trailing tab.  Data rows: 3 values + trailing
+        # tab -> would split into 4 columns.
+        lines = [
+            "WVS\tMUSC_SC\tMUSC\n",
+            "0.3\t6.4616\t0.32308\t\n",
+            "0.305\t6.646\t0.3323\t\n",
+            "0.31\t6.794\t0.3397\t\n",
+        ]
+
+        spectra = import_spectra_text(
+            lines,
+            delim="\t",
+            has_header=True,
+            wavelength_cols=WavelengthCols.FIRST_COL,
+        )
+
+        # First column is the wavelength, so we expect the two named spectra.
+        self.assertEqual([s.get_name() for s in spectra], ["MUSC_SC", "MUSC"])
+        self.assertEqual([s.num_bands() for s in spectra], [3, 3])
+        np.testing.assert_allclose(spectra[0].get_spectrum(), [6.4616, 6.646, 6.794])
+        np.testing.assert_allclose(spectra[1].get_spectrum(), [0.32308, 0.3323, 0.3397])
+
+    def test_trailing_delimiters_on_all_rows_do_not_create_phantom_spectra(self):
+        """Bug 2: every row (header included) ends in a run of trailing tabs
+        (the ``C1 Samples`` case where 3 spectra were read as 22).  The empty
+        trailing columns must not become empty spectra."""
+        # Four real columns (wavelength + 3 spectra), then four trailing tabs.
+        trailing = "\t\t\t\t"
+        lines = [
+            "Wavelength_um\tARKSAW_18_G\tARKSAW_15_TS\tARKSAW_17_M" + trailing + "\n",
+            "0.3466\t26.5672\t19.726\t27.2727" + trailing + "\n",
+            "0.3482\t26.9417\t19.3805\t27.3134" + trailing + "\n",
+        ]
+
+        spectra = import_spectra_text(
+            lines,
+            delim="\t",
+            has_header=True,
+            wavelength_cols=WavelengthCols.FIRST_COL,
+        )
+
+        # Exactly the three real spectra -- no empty-named phantoms.
+        self.assertEqual(
+            [s.get_name() for s in spectra],
+            ["ARKSAW_18_G", "ARKSAW_15_TS", "ARKSAW_17_M"],
+        )
+        self.assertTrue(all(s.get_name() for s in spectra), "no spectrum should be unnamed")
+        self.assertTrue(all(s.num_bands() == 2 for s in spectra))
+
+
+class TestExportImportRoundTrip(unittest.TestCase):
+    """Bug 3: spectra exported by WISER should be re-importable."""
+
+    def test_exported_spectra_can_be_reimported(self):
+        """``export_spectrum_list`` writes (wavelength, value) column pairs.
+        Re-importing with ``ODD_COLS`` (what the dialog auto-selects for these
+        files) should recover the original spectra."""
+        wavelengths = [0.5 * u.um, 0.6 * u.um, 0.7 * u.um]
+        src = [
+            NumPyArraySpectrum(np.array([0.1, 0.2, 0.3]), name="specA", wavelengths=wavelengths),
+            NumPyArraySpectrum(np.array([0.4, 0.5, 0.6]), name="specB", wavelengths=wavelengths),
+        ]
+
+        fd, path = tempfile.mkstemp(suffix=".txt")
+        os.close(fd)
+        try:
+            export_spectrum_list(path, src)
+
+            imported = import_spectra_textfile(
+                path,
+                delim="\t",
+                has_header=True,
+                wavelength_cols=WavelengthCols.ODD_COLS,
+            )
+        finally:
+            os.remove(path)
+
+        self.assertEqual([s.get_name() for s in imported], ["specA", "specB"])
+        np.testing.assert_allclose(imported[0].get_spectrum(), [0.1, 0.2, 0.3])
+        np.testing.assert_allclose(imported[1].get_spectrum(), [0.4, 0.5, 0.6])
+
+        # Wavelengths should survive the round trip too.
+        for spec in imported:
+            values = [w.to(u.um).value for w in spec.get_wavelengths()]
+            np.testing.assert_allclose(values, [0.5, 0.6, 0.7])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/wiser/raster/spectra_export.py
+++ b/src/wiser/raster/spectra_export.py
@@ -450,8 +450,8 @@ def import_spectra_text(
     if wavelength_cols == WavelengthCols.ODD_COLS:
         num_spectra = num_cols // 2
         if has_header:
-            spectrum_names = [header_parts[i] for i in range(1, num_spectra, 2)]
-            wavelength_names = [header_parts[i] for i in range(0, num_spectra, 2)]
+            spectrum_names = [header_parts[i] for i in range(1, num_cols, 2)]
+            wavelength_names = [header_parts[i] for i in range(0, num_cols, 2)]
         else:
             spectrum_names = make_spectrum_names(num_spectra)
             wavelength_names = [None] * num_spectra

--- a/src/wiser/raster/spectra_export.py
+++ b/src/wiser/raster/spectra_export.py
@@ -343,13 +343,85 @@ def import_spectra_text(
             line = line[:-1]
         return line
 
+    def split_line(line: str) -> List[str]:
+        """Split a single input line into its delimited fields.
+
+        The trailing newline character is removed first (if present) so it does
+        not become part of the final field, then the line is split on the
+        configured ``delim``.
+
+        Args:
+            line: A single raw line of input text, which may or may not end
+                with a ``"\\n"`` newline character.
+
+        Returns:
+            The line's fields, in order, as a list of strings.  The list always
+            has at least one element (a line with no delimiter yields a single
+            field).
+        """
+        return remove_trailing_newline(line).split(delim)
+
+    def real_width(parts: List[str]) -> int:
+        """Count the columns in a row, ignoring trailing blank fields.
+
+        Tools such as Excel pad rows with empty trailing delimiters when saving
+        tab-delimited text (e.g. ``"a\\tb\\t\\t\\t"``).  Those trailing blank
+        fields are padding artifacts, not real columns, so they are excluded
+        from the count.  Blank fields that are followed by a non-blank field
+        are *not* trailing and are therefore still counted.
+
+        Args:
+            parts: The fields of a single row, as returned by ``split_line``.
+
+        Returns:
+            The number of leading fields up to and including the last
+            non-blank (non-whitespace-only) field.  Returns ``0`` if every
+            field is blank.
+        """
+        n = len(parts)
+        while n > 0 and parts[n - 1].strip() == "":
+            n -= 1
+        return n
+
     def make_spectrum_names(n):
         return [f"Spectrum {i}" for i in range(1, n + 1)]
 
     if wavelength_cols not in WavelengthCols:
         raise ValueError("wavelength_cols must be a value from WavelengthCols")
 
-    num_cols = len(lines[0].split(delim))
+    if len(lines) == 0:
+        raise ValueError("Input has no lines to parse.")
+
+    # The first line (the header when present, otherwise the first data row)
+    # defines the real column count.  Trailing blank fields are padding
+    # artifacts and are ignored; blank fields *within* this width are kept
+    # because they mark where a shorter spectrum has ended.
+    num_cols = real_width(split_line(lines[0]))
+
+    def strip_padding(parts: List[str]) -> List[str]:
+        """Remove trailing blank padding fields that lie beyond ``num_cols``.
+
+        Only blank (whitespace-only) fields *past* the real column count are
+        dropped.  Blank fields that fall within the first ``num_cols`` columns
+        are preserved, because inside the real data region an empty value is
+        meaningful -- it marks where a shorter spectrum has ended.
+
+        This does not pad rows that are shorter than ``num_cols``; such rows are
+        left as-is so the caller's column-count check can reject them.
+
+        Args:
+            parts: The fields of a single row, as returned by ``split_line``.
+                Not modified in place.
+
+        Returns:
+            A new list containing ``parts`` with any trailing blank fields
+            beyond ``num_cols`` removed.
+        """
+        parts = list(parts)
+        while len(parts) > num_cols and parts[-1].strip() == "":
+            parts.pop()
+        return parts
+
     if wavelength_cols == WavelengthCols.ODD_COLS:
         if num_cols < 2:
             raise ValueError(
@@ -366,15 +438,11 @@ def import_spectra_text(
         raise ValueError("Input has only one column, so wavelengths " + "cannot be in the first column.")
 
     line_no = 1
-    header_line = None
     header_parts = None
     if has_header:
-        header_line = lines[0]
+        header_parts = strip_padding(split_line(lines[0]))
         lines = lines[1:]
         line_no = 2
-
-        header_line = remove_trailing_newline(header_line)
-        header_parts = header_line.split(delim)
 
     spectrum_names = []
     wavelength_names = []
@@ -421,22 +489,19 @@ def import_spectra_text(
         #       f'allbands_name="{spectrum_data.allbands_name}"')
 
     for line in lines:
-        # Remove any newline off the end of the line.
-        line = remove_trailing_newline(line)
-
-        # Split apart the line with the delimiter.  If we know the # of columns
-        # by now, complain if this line has a different # of columns.
-        line_parts = line.split(delim)
+        # Split the line, dropping any trailing blank fields that are just
+        # delimiter padding (e.g. from Excel's tab-delimited export).
+        line_parts = strip_padding(split_line(line))
         # print(f'Line {line_no} parts:  {line_parts}')
 
-        if num_cols is not None:
-            if len(line_parts) != num_cols:
-                raise ValueError(
-                    f"Line {line_no} has {len(line_parts)} columns, "
-                    + f"but first line has {num_cols} columns."
-                )
-        else:
-            num_cols = len(line_parts)
+        # Every row must match the real column count.  A row with fewer columns,
+        # or with actual (non-blank) data beyond the expected columns, is a
+        # genuine mismatch and is rejected.
+        if len(line_parts) != num_cols:
+            raise ValueError(
+                f"Line {line_no} has {len(line_parts)} columns, "
+                + f"but the first line has {num_cols} columns."
+            )
 
         # Update each spectrum we are importing.
         for i in range(num_spectra):


### PR DESCRIPTION
## What does this change do?
Fixes three bugs in the "Import Spectra from Text" / spectrum export pipeline
(`wiser/raster/spectra_export.py`), all triggered by tab-delimited `.txt`
files that Excel produces:

1.  Files with a trailing tab on data rows only (no trailing tab on the
    header) failed to import with `"Line N has X columns, but first line has
    Y columns"`, even though the data was valid.
2.  Files with a consistent trailing tab on every row (header included)
    "succeeded" but silently imported extra empty/phantom spectra for each
    padding column (one reported file read 3 real spectra as 22).
3.  Spectra exported by WISER's own `export_spectrum_list` (odd/even
    wavelength-value column pairs) could not be re-imported using the "odd
    columns specify wavelength values" option — the import crashed with an
    `IndexError`.

Closes #740
Closes #739
Closes #738

## What type of PR is this? (check all applicable)
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] Chore
- [ ] Revert

## Why is this change needed?
Multiple users reported that spectra text files exported from Excel
("Save As → Tab delimited (.txt)") either failed to import entirely, or
imported with a pile of bogus empty spectra, because Excel pads rows with
invisible trailing delimiters. Separately, WISER's own exported spectra files
could not be re-imported at all, breaking a basic export → import round trip.


## How did you implement the change?
In `import_spectra_text`:

- The real column count (`num_cols`) is now derived from the **first line**
  (header, or first data row if there is no header), ignoring any *trailing*
  blank fields — those are Excel padding, not real columns.
- Every row (header and data) is normalized with a new `strip_padding` helper
  that drops trailing blank fields **beyond** `num_cols`, while leaving blank
  fields *within* the real columns untouched. This distinction matters
  because an in-range empty value is meaningful — it's how the parser detects
  that a shorter spectrum has ended — so it can't simply be stripped
  unconditionally.
- The existing row-length mismatch check is kept, so genuine problems (a
  short row, or real data appearing past the expected columns) still raise a
  clear error.
- For #740, the `ODD_COLS` branch built its name lists with `range(1,
  num_spectra, 2)` / `range(0, num_spectra, 2)`, using half the real column
  count as the range bound — for 2 spectra (4 columns) this produced only 1
  name instead of 2, causing an `IndexError` later when spectra were indexed
  by position. Changed the bound to `num_cols` so the ranges span every
  column.

## Added tests?
- [x] yes

`src/tests/test_spectra_text_import_export.py` (new file), covering:
- Trailing delimiter on data rows only (#738)
- Trailing delimiters on every row → no phantom spectra (#739)
- Ragged/inconsistent trailing delimiter counts across rows
- Variable-length spectra combined with ragged trailing padding (checks that
  in-range blanks that end a spectrum are preserved while out-of-range
  padding is stripped)
- Export → re-import round trip (#740)

All tests were confirmed to fail against the pre-fix code (red) before the
fix was applied, and pass afterward.

## Added to documentation?
- [ ] yes
- [x] no documentation needed

## Checklist
- [x] There is an issue associated with this pull request
- [ ] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [x] All CI checks passed
