### PR TITLE
feat: Making dataset matching better

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/code-documentation.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/code-documentation.md
@@ -23,4 +23,5 @@ crs-creator-internals.md
 plugin-system.md
 mosaic-internals.md
 save-to-project.md
+raster-format-dispatch.md
 ```

--- a/doc/sphinx-general-wiser-docs/source/developer-content/raster-format-dispatch.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/raster-format-dispatch.md
@@ -1,0 +1,352 @@
+# Raster Format Dispatch
+
+When WISER is handed a file path, something has to decide *which* of the raster
+formats it knows about should open it. That decision is **format dispatch**, and
+it lives in `src/wiser/raster/format_registry.py` and
+`RasterDataLoader.load_from_file`.
+
+This page documents how a path becomes a `RasterDataSet`, and — the part most
+developers come here for — [how to add support for a new file
+type](#adding-a-new-format).
+
+---
+
+## Overview
+
+Dispatch is deliberately split into three stages, so that the cheap decisions
+happen before the expensive ones and nothing irreversible happens while WISER is
+still guessing.
+
+| Stage | What it does | Cost |
+|-------|--------------|------|
+| **Order** | Rank the registered formats for this path, most likely first. | String comparison only. |
+| **Identify** | Ask each candidate, in order, whether it recognizes the file. | A few bytes read per candidate. No handles opened. |
+| **Open** | Open the file with the format that won. | One file handle, once. |
+
+```{mermaid}
+flowchart TB
+    Path["load_from_file(path)"]
+    Override{"format= given?"}
+    One["Use that format only.<br/>Fail loudly if it doesn't work."]
+    Order["candidates_for(path)<br/>extension-claimants first, then<br/>everything else, then the catch-all"]
+    Ident["identify() down the list"]
+    Yes{"Confidence.YES?"}
+    Win["Winner"]
+    Maybe["Highest-priority MAYBE"]
+    Open["try_load_file() on the winner"]
+    Build["FormatSpec.loader ->  RasterDataSet(s)"]
+
+    Path --> Override
+    Override -- yes --> One --> Open
+    Override -- no --> Order --> Ident --> Yes
+    Yes -- "stop immediately" --> Win --> Open
+    Yes -- "none were certain" --> Maybe --> Open
+    Open --> Build
+```
+
+### Why not just try every format?
+
+That is what WISER used to do, and it caused three problems worth remembering,
+because each one is a rule the current design exists to enforce:
+
+- **The winner was whichever format was tried last.** The old loop had no
+  `break`, so every format was attempted and the last success overwrote the
+  earlier ones. Which implementation opened a file therefore depended on the
+  declaration order of a dict.
+- **Every successful attempt opened a file handle**, and all but one were
+  discarded.
+- **Identification could block on the user.** The NetCDF sub-dataset dialog ran
+  inside the attempt, so it could be shown for a file that a later format then
+  claimed, throwing away what the user chose.
+
+Hence: exactly one format wins, `identify()` never opens or prompts, and only
+the winner is opened.
+
+---
+
+## The registry
+
+Every format WISER can open is one `FormatSpec` entry in `RASTER_FORMATS`:
+
+```python
+FormatSpec(
+    name="ENVI",                                    # the override token
+    impl=ENVI_GDALRasterDataImpl,                   # class that opens it
+    extensions=frozenset({"", ".hdr", ".img", ".dat"}),
+    priority=70,
+    loader=load_normal_dataset,
+    interactive_step=False,
+)
+```
+
+| Field | Meaning |
+|-------|---------|
+| `name` | Stable identifier. Used by the `format=` override and **written into project files**, so renaming one is a breaking change. |
+| `impl` | The `RasterDataImpl` subclass that opens this format. |
+| `extensions` | Extensions this format claims. An **ordering hint only** (see below). |
+| `priority` | Higher is tried earlier. Breaks ties between equally confident formats. |
+| `loader` | How to turn the opened impl into datasets. Usually `load_normal_dataset`. |
+| `interactive_step` | True if opening can block on a dialog. Informational today; marks what must stay on the main thread when loading moves to a worker. |
+| `is_fallback` | True only for the GDAL catch-all, which always sorts last. |
+
+### Extensions order, they do not gate
+
+This is the single most important thing to understand about the registry.
+
+A format is **never excluded** for failing to claim the path's extension. The
+extension only decides *where in the queue* a format sits. `candidates_for()`
+returns *every* registered format for *every* path — extension-claimants first
+by priority, then everything else by priority, then the catch-all.
+
+The reason is that extensions in this domain are genuinely ambiguous:
+
+| Extension | Could be |
+|-----------|----------|
+| `.img` | ENVI raster **or** PDS3 |
+| `.hdr` | ENVI raster header **or** ENVI spectral library |
+| `.xml` | PDS4 label **or** any other XML |
+| `.lbl` | PDS3 label |
+| *(none)* | ENVI data file |
+
+A strict extension-to-format map would be wrong on real data immediately, and
+would make a file with an unusual extension unloadable even when WISER could
+read it perfectly well. Ordering gives the speed and determinism of extension
+dispatch without the brittleness.
+
+---
+
+## `identify()`
+
+`RasterDataImpl.identify(path)` returns a `Confidence`:
+
+| Value | Meaning | Effect on the search |
+|-------|---------|----------------------|
+| `YES` | Positive content match. | Wins immediately; the search stops. |
+| `MAYBE` | Plausible, no positive signal. | Kept as a fallback if nothing is certain. |
+| `NO` | Positively excluded. | Dropped. |
+
+The base implementation returns `MAYBE` — "no opinion" — so an implementation
+that doesn't override it stays in the running but never outranks a format that
+is actually sure.
+
+`identify()` must be cheap and side-effect-free. Specifically it must **not**:
+
+- open a lasting handle or allocate significant memory,
+- show a dialog or otherwise block on the user,
+- raise for an unreadable or missing file — return `NO` instead.
+
+### It delegates to GDAL
+
+For GDAL-backed formats, `identify()` does **not** hand-roll magic-byte checks.
+It calls `gdal.IdentifyDriverEx`, which runs the driver's own `Identify()`
+without opening the dataset:
+
+```python
+@classmethod
+def identify(cls, path: str) -> Confidence:
+    drv = gdal.IdentifyDriverEx(
+        cls.get_load_filename(path), allowed_drivers=list(cls.get_gdal_drivers())
+    )
+    return Confidence.YES if drv is not None else Confidence.NO
+```
+
+GDAL already maintains the magic-byte and label checks for every driver it
+ships; duplicating them in WISER would only create something to drift.
+
+```{note}
+The Python binding keyword is `allowed_drivers`, not `allowedDrivers`, and
+passing `None` raises rather than meaning "any driver". Omit the argument if you
+want every driver considered.
+```
+
+### `priority` still matters
+
+It is reasonable to ask why priority matters if the first `YES` wins. Because
+`identify()` is not a perfect oracle: an `.img` with a PDS label sitting beside
+an ENVI header will get a confident yes from **both** formats. `identify()`
+decides where the walk *stops*; `priority` decides the order it *walks*, and
+therefore which of two equally confident formats is asked first.
+
+---
+
+## Sidecar files: `DATA_EXTENSIONS` and `SIDECAR_EXTENSIONS`
+
+Some formats are a header file plus a separately-named data file, and the user
+may legitimately select either one. The file-open dialog offers `*.hdr` and
+`*.tfw` filters, so this is a normal thing to happen, not an edge case.
+
+Two class attributes describe that relationship:
+
+```python
+class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
+    DATA_EXTENSIONS = ("", ".img", ".dat")   # the raster itself, in resolution order
+    SIDECAR_EXTENSIONS = (".hdr",)           # what the user might click instead
+```
+
+`DATA_EXTENSIONS` does **two** jobs:
+
+1. **Resolution.** `get_load_filename("scene.hdr")` tries `scene`, then
+   `scene.img`, then `scene.dat`, and returns the first that exists. This runs
+   before `identify()` — GDAL will not identify the header file itself, so
+   skipping it would make WISER reject a dataset the user validly selected.
+2. **Exclusion.** `identify()` returns `NO` for a path whose own extension is
+   not in the list. This matters because GDAL's ENVI driver claims *any* file
+   with a same-stem `.hdr` beside it — without the restriction, an unrelated
+   `scene.tif` sitting next to `scene.hdr` would be identified as ENVI.
+
+Set `DATA_EXTENSIONS = None` (the default) for a self-describing single-file
+format, which imposes no extension restriction. That is the right choice when
+the driver's own content check is strong and extensions vary in the wild — PDS3
+and NetCDF both do this.
+
+---
+
+(adding-a-new-format)=
+## Adding a new format
+
+Adding support for a new file type is normally two steps.
+
+### 1. Write the implementation
+
+Subclass `GDALRasterDataImpl` in `src/wiser/raster/dataset_impl.py` and declare
+which GDAL drivers it uses:
+
+```python
+class MyFormat_GDALRasterDataImpl(GDALRasterDataImpl):
+    GDAL_DRIVERS = ["MYDRIVER"]
+
+    # Only if the format has a header/data split, or you need to stop it
+    # claiming unrelated files that share a basename:
+    # DATA_EXTENSIONS = (".dat",)
+    # SIDECAR_EXTENSIONS = (".hdr",)
+
+    @classmethod
+    def try_load_file(cls, path: str, **kwargs) -> ["MyFormat_GDALRasterDataImpl"]:
+        gdal.UseExceptions()
+        gdal_dataset = gdal.OpenEx(
+            cls.get_load_filename(path),
+            nOpenFlags=gdalconst.OF_READONLY | gdalconst.OF_VERBOSE_ERROR,
+            allowed_drivers=cls.GDAL_DRIVERS,
+        )
+        if gdal_dataset is None:
+            raise ValueError(f"Unable to open file: {path}")
+        return [cls(gdal_dataset)]
+```
+
+Declaring `GDAL_DRIVERS` is all that is needed to get a working `identify()` —
+the inherited implementation uses it. Pass the same list to `OpenEx` so that
+identification and opening can never disagree about which driver is in play.
+
+If the usable driver set can only be determined at run time (JPEG2000 support
+varies by GDAL build), override `get_gdal_drivers()` instead of setting
+`GDAL_DRIVERS`.
+
+### 2. Register it
+
+Add one `FormatSpec` to `RASTER_FORMATS` in `format_registry.py`:
+
+```python
+FormatSpec(
+    name="MyFormat",
+    impl=MyFormat_GDALRasterDataImpl,
+    extensions=frozenset({".myf"}),
+    priority=45,
+),
+```
+
+Priorities are spaced by 5 so a format can be slotted between two existing ones
+without renumbering. Choose one relative to formats it might be confused with:
+if your format and an existing one can both open the same file, the higher
+priority is asked first.
+
+That is the whole registration. There is no second table to update — the spec
+carries the impl, the ordering, and the dataset-construction strategy together.
+
+### Non-GDAL formats
+
+If the format is not read through GDAL — the `pdr` planetary-data library, for
+instance — subclass `RasterDataImpl` directly and write `identify()` by hand.
+Keep to the contract: cheap, no handles, no dialogs, `NO` rather than an
+exception on unreadable input.
+
+### If opening needs to ask the user something
+
+Set `interactive_step=True` on the spec and give it a `loader` that runs the
+dialog, as `load_FITS_dataset` does. Respect the `interactive` keyword in
+`try_load_file`: when it is `False` — project restore, tests, headless use —
+choose a sensible default instead of prompting.
+
+### Checklist
+
+- [ ] `GDAL_DRIVERS` declared (or `identify()` written by hand)
+- [ ] Same driver list used by `try_load_file`
+- [ ] `DATA_EXTENSIONS` set if the format has sidecars or a greedy driver
+- [ ] `FormatSpec` added to `RASTER_FORMATS` with a considered `priority`
+- [ ] `interactive=False` produces a non-prompting default
+- [ ] File-open dialog filter added in `show_open_file_dialog` if users should be
+      able to force this format (see below)
+- [ ] Tests in `src/tests/test_format_registry.py`
+
+---
+
+## Overrides
+
+Detection is only used when nobody has told WISER what the file is. Three
+callers can state the format outright, and all three funnel into the same
+`format=` parameter on `load_from_file`:
+
+| Source | Where |
+|--------|-------|
+| Programmatic callers | `load_from_file(path, format="ENVI")` |
+| The user's file-dialog filter | `show_open_file_dialog` in `src/wiser/gui/app.py` |
+| A saved project | `format` field in the dataset manifest entry |
+
+An override tries **only** that format and raises if it fails, rather than
+quietly falling back to guessing — a wrong override is a mistake worth
+surfacing, not one worth hiding.
+
+### The file-open dialog
+
+Filters are declared as `(text, format_name)` pairs. `QFileDialog` returns which
+filter the user selected, and that selection is treated as a statement of what
+the file is:
+
+```python
+supported_formats = [
+    (self.tr("All supported files (...)"), None),   # None = detect
+    (self.tr("ENVI raster files (*.img *.hdr *.dat)"), "ENVI"),
+    ...
+]
+```
+
+A filter that cannot name a single format — "All supported files", "Try luck
+with GDAL" — maps to `None`, meaning ordinary detection. When adding a format,
+add a filter for it only if a user could plausibly need to force it.
+
+### Project files
+
+`dataset_to_pyrep` records the format that opened each referenced dataset, and
+the load path passes it back as the override. Without this, a project would
+re-detect on every open, and a registry change or a new file appearing beside
+the data could silently resolve the same path to a different implementation than
+the one in use when the project was saved.
+
+Both directions degrade gracefully: a manifest with no `format` field (written
+by an older WISER) falls back to detection, and a `format` naming something no
+longer registered logs a warning and does the same.
+
+---
+
+## Future work
+
+**Splitting the interactive step out of `try_load_file`.** The NetCDF
+sub-dataset dialog still runs inside `try_load_file`. Because only the winning
+format is ever opened, it can no longer be shown speculatively or have its
+result discarded — but it does mean the GUI step and the I/O are still in one
+call, with no seam between them.
+
+Separating them into `open()` (worker-thread safe) and `configure()` (main
+thread only) is what would allow dataset loading to move off the UI thread:
+identify and open on a worker, then marshal only `configure` back to the main
+thread for the formats whose spec sets `interactive_step`. The registry already
+records which formats those are.

--- a/doc/sphinx-general-wiser-docs/source/index.rst
+++ b/doc/sphinx-general-wiser-docs/source/index.rst
@@ -30,11 +30,14 @@ can fall back to any format supported by GDAL for additional coverage.
 
 **Natively supported formats**
 
-- **ENVI raster** (``*.img``, ``*.hdr``)
+- **ENVI raster** (``*.img``, ``*.hdr``, ``*.dat``, or no extension)
 - **TIFF / GeoTIFF** (``*.tiff``, ``*.tif``, ``*.tfw``)
 - **NetCDF** (``*.nc``)
 - **JPEG 2000** (``*.JP2``)
-- **PDS raster** (``*.PDS``, ``*.img``, ``*.lbl``, ``*.xml``)
+- **PDS3 raster** (``*.PDS``, ``*.img``, ``*.lbl``)
+- **PDS4 raster** (``*.xml``)
+- **FITS** (``*.fits``, ``*.fit``, ``*.fts``)
+- **ASCII Grid** (``*.asc``)
 - **ENVI spectral libraries** (``*.sli``, ``*.hdr``)
 - **GDAL-readable formats** --- any format that GDAL can open (e.g. HDF4/5,
   GRIdded Binary, COG, and more)

--- a/doc/sphinx-general-wiser-docs/source/user-content/opening-data-files.md
+++ b/doc/sphinx-general-wiser-docs/source/user-content/opening-data-files.md
@@ -1,0 +1,148 @@
+# Opening Data Files
+
+WISER reads several raster formats natively and can fall back to any format GDAL
+supports. Most of the time you can pick a file and WISER works out the rest.
+
+This page covers the cases where it is worth being deliberate — because **the
+file type you choose in the Open dialog matters**, and so does *which* file you
+pick when a dataset is spread across more than one.
+
+---
+
+## The file type you choose matters
+
+The **file type** dropdown at the bottom of the Open dialog is not only a way of
+hiding files you are not interested in. It also tells WISER **what the file is**.
+
+- Leaving it on **All supported files** asks WISER to work the format out for
+  itself. This is the right choice almost always.
+- Choosing a **specific type** — "ENVI raster files", "NetCDF raster files",
+  "PDS3 raster files", and so on — tells WISER to open the file *as that format*
+  and nothing else.
+
+### Why this matters
+
+Some files can be read by more than one format. A `.img` file might be an ENVI
+raster or a PDS3 product; an `.xml` file might be a PDS4 label or something else
+entirely. WISER inspects the contents rather than trusting the extension, and it
+is right the overwhelming majority of the time.
+
+But when a file is genuinely ambiguous — or when it is unusual enough that
+automatic detection picks a format that reads it, just not the way you want —
+picking the type explicitly settles it.
+
+```{tip}
+If a file opens but the data looks wrong — wrong number of bands, missing
+wavelengths, unexpected scaling — try opening it again with the file type set
+explicitly. Automatic detection may have chosen a format that *can* read the
+file but does not understand all of its metadata.
+```
+
+### Forcing a type will report failure rather than guess again
+
+Choosing a specific file type is treated as a statement of fact. If WISER cannot
+read the file as that format, it reports an error rather than quietly trying
+something else.
+
+That is deliberate: if you have said a file is NetCDF and it is not, having it
+silently open as something else would hide the problem rather than tell you
+about it. Switch back to **All supported files** to let WISER decide.
+
+---
+
+## Which file to pick for multi-file datasets
+
+Several formats store one dataset across more than one file. You may select
+either the header or the data file — WISER finds the other.
+
+### ENVI
+
+An ENVI dataset is a **header** (`.hdr`) plus a **data file**, which may have no
+extension at all, or `.img`, or `.dat`:
+
+```
+scene.hdr     <- the header
+scene.dat     <- the data (or "scene", or "scene.img")
+```
+
+Select either one. Both files must sit in the same directory and share a name;
+WISER cannot open the header on its own.
+
+```{note}
+If you have an ENVI header whose data file is missing or has been renamed to
+something unexpected, WISER reports which filenames it looked for. Renaming the
+data file to match the header — same name, one of the extensions above — is
+usually enough to fix it.
+```
+
+### GeoTIFF
+
+A GeoTIFF is normally a single `.tif` or `.tiff` file. Some are accompanied by a
+`.tfw` world file carrying the georeferencing. Select either the image or the
+world file.
+
+### PDS
+
+PDS3 products may have a **detached label** (`.lbl`) beside the data, or an
+**attached label** inside a single `.img`. Select the label when there is one.
+PDS4 products use an `.xml` label — select that.
+
+---
+
+## Formats WISER opens
+
+| Format | Typical files |
+|--------|---------------|
+| ENVI raster | `*.img`, `*.hdr`, `*.dat`, or no extension |
+| TIFF / GeoTIFF | `*.tif`, `*.tiff`, `*.tfw` |
+| NetCDF | `*.nc` |
+| JPEG 2000 | `*.JP2` |
+| PDS3 | `*.PDS`, `*.img`, `*.lbl` |
+| PDS4 | `*.xml` |
+| FITS | `*.fits`, `*.fit`, `*.fts` |
+| ASCII Grid | `*.asc` |
+| ENVI spectral library | `*.sli`, `*.hdr` |
+| Anything else GDAL reads | HDF4/5, GRIB, COG, and more |
+
+If your file is not in this list, try **Try luck with GDAL** in the file-type
+dropdown. GDAL supports a great many formats beyond those WISER handles
+specially, and this option asks it to open the file with whatever driver fits.
+Data loaded this way may carry less metadata — wavelengths and band names in
+particular — than a natively supported format.
+
+---
+
+## Files containing several datasets
+
+Some files hold more than one dataset. A NetCDF file, for example, may contain
+several variables, each a separate raster.
+
+When you open such a file, WISER asks which one you want before loading. Pick
+the sub-dataset you are interested in and it is loaded as its own dataset in the
+session.
+
+If you save your session as a project, the specific sub-dataset you chose is
+recorded, so reopening the project restores exactly what you had rather than
+asking again.
+
+---
+
+## Troubleshooting
+
+**"Couldn't load file ... unsupported format"**
+: No format WISER knows could read the file. Check the file is complete and not
+  truncated. For ENVI data, check its `.hdr` is present and beside it. As a last
+  resort try **Try luck with GDAL**.
+
+**"Can't find the raster file corresponding to ..."**
+: You selected an ENVI header or a `.tfw` world file, but the matching data file
+  is not beside it. The message lists the filenames WISER looked for.
+
+**The file opens, but as the wrong kind of data**
+: Open it again with the file type set explicitly instead of **All supported
+  files**.
+
+**A file that used to open no longer does**
+: Check whether files have been added or renamed alongside it. A stray header
+  file with the same base name as an unrelated raster can change how a directory
+  is interpreted.

--- a/doc/sphinx-general-wiser-docs/source/user-content/user-manual.rst
+++ b/doc/sphinx-general-wiser-docs/source/user-content/user-manual.rst
@@ -39,6 +39,7 @@ What's in This Manual
    :hidden:
 
    interface-overview
+   opening-data-files
    working-with-data
    data-analysis-tools/data-analysis-tools
    spatial-tools

--- a/src/tests/test_format_registry.py
+++ b/src/tests/test_format_registry.py
@@ -1,0 +1,288 @@
+"""Tests for raster format dispatch -- the registry, identification, and overrides.
+
+Historically ``load_from_file`` attempted every registered format against every
+file and kept whichever happened to succeed last, so which implementation opened
+a file depended on dict declaration order and on how many other formats also
+accepted it.  These tests pin the replacement:
+
+* candidate *ordering* is declared, not accidental,
+* a format that positively identifies a file wins immediately,
+* exactly one file handle is opened per load,
+* an explicit ``format=`` is obeyed and fails loudly rather than falling back.
+
+They also lock two file-naming regressions the old sidecar resolution had:  an
+ENVI cube whose data file is ``.dat``, and a GeoTIFF spelled ``.tiff``.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+import tests.context  # noqa: F401 -- adds src/ to sys.path
+
+from osgeo import gdal
+
+from wiser.raster.dataset_impl import (
+    Confidence,
+    ENVI_GDALRasterDataImpl,
+    GDALRasterDataImpl,
+    GTiff_GDALRasterDataImpl,
+    NetCDF_GDALRasterDataImpl,
+    PDS3_GDALRasterDataImpl,
+    SaveState,
+)
+from wiser.raster.format_registry import (
+    RASTER_FORMATS,
+    candidates_for,
+    format_for_impl,
+    format_names,
+    get_format,
+)
+from wiser.raster.loader import RasterDataLoader
+
+pytestmark = [pytest.mark.functional]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_raster(path, driver):
+    """Create a small single-band raster at ``path`` using ``driver``."""
+    gdal.UseExceptions()
+    ds = gdal.GetDriverByName(driver).Create(str(path), 8, 8, 1, gdal.GDT_Int16)
+    ds.GetRasterBand(1).WriteArray(np.arange(64, dtype=np.int16).reshape(8, 8))
+    ds = None
+    return str(path)
+
+
+@pytest.fixture
+def envi_dat(tmp_path):
+    """An ENVI cube whose data file is ``.dat`` (not the assumed ``.img``)."""
+    _write_raster(tmp_path / "scene.dat", "ENVI")
+    return tmp_path
+
+
+@pytest.fixture
+def tiff_with_stray_hdr(tmp_path):
+    """A GeoTIFF spelled ``.tiff`` with an unrelated same-stem ENVI header.
+
+    GDAL's ENVI driver identifies any file that has a same-stem ``.hdr`` beside
+    it, so without an extension restriction ENVI would claim this GeoTIFF.
+    """
+    _write_raster(tmp_path / "pic.tiff", "GTiff")
+    _write_raster(tmp_path / "other.dat", "ENVI")
+    os.replace(tmp_path / "other.hdr", tmp_path / "pic.hdr")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Registry shape and candidate ordering
+# ---------------------------------------------------------------------------
+
+
+def test_every_format_has_a_unique_name():
+    names = format_names()
+    assert len(names) == len(set(names)), "format names are the override tokens; they must be unique"
+
+
+def test_lookup_is_case_insensitive():
+    assert get_format("envi") is get_format("ENVI")
+    assert get_format("no-such-format") is None
+
+
+def test_exactly_one_fallback_and_it_sorts_last():
+    fallbacks = [s for s in RASTER_FORMATS if s.is_fallback]
+    assert len(fallbacks) == 1
+
+    for path in ("a.hdr", "a.tif", "a.nc", "a.unknown"):
+        assert candidates_for(path)[-1].is_fallback, f"fallback must be last for {path}"
+
+
+def test_extension_promotes_but_never_excludes():
+    """The extension orders the search; it does not restrict it."""
+    order = candidates_for("scene.nc")
+
+    assert order[0].name == "NetCDF", "the format claiming .nc should be tried first"
+    # Every non-fallback format is still a candidate -- a file with a misleading
+    # or unusual extension must still be loadable.
+    assert {s.name for s in order} == {s.name for s in RASTER_FORMATS}
+
+
+def test_ordering_is_by_priority_not_declaration_order():
+    """Two formats claim .img; the higher-priority one is tried first."""
+    order = [s.name for s in candidates_for("scene.img")]
+    assert order.index("PDS3") < order.index("ENVI")
+
+    within_claiming = [s.priority for s in candidates_for("scene.img") if s.claims_extension("scene.img")]
+    assert within_claiming == sorted(within_claiming, reverse=True)
+
+
+def test_files_without_an_extension_are_still_dispatched():
+    order = candidates_for("scene")
+    assert order[0].name == "ENVI", "ENVI data files commonly have no extension"
+    assert order[-1].is_fallback
+
+
+# ---------------------------------------------------------------------------
+# identify()
+# ---------------------------------------------------------------------------
+
+
+def test_identify_recognizes_its_own_format(envi_dat):
+    assert ENVI_GDALRasterDataImpl.identify(str(envi_dat / "scene.dat")) == Confidence.YES
+
+
+def test_identify_resolves_a_sidecar_before_deciding(envi_dat):
+    """Selecting the .hdr must identify as ENVI, not fail on the header itself."""
+    assert ENVI_GDALRasterDataImpl.identify(str(envi_dat / "scene.hdr")) == Confidence.YES
+
+
+def test_identify_rejects_other_formats(envi_dat):
+    scene = str(envi_dat / "scene.dat")
+    for impl in (GTiff_GDALRasterDataImpl, PDS3_GDALRasterDataImpl, NetCDF_GDALRasterDataImpl):
+        assert impl.identify(scene) == Confidence.NO, f"{impl.__name__} should not claim an ENVI file"
+
+
+def test_catch_all_never_claims_certainty(envi_dat):
+    """The GDAL fallback must defer to every named format, never outrank one."""
+    assert GDALRasterDataImpl.identify(str(envi_dat / "scene.dat")) == Confidence.MAYBE
+
+
+def test_identify_does_not_raise_on_a_nonexistent_file(tmp_path):
+    missing = str(tmp_path / "nope.img")
+    for impl in (ENVI_GDALRasterDataImpl, GTiff_GDALRasterDataImpl, GDALRasterDataImpl):
+        assert impl.identify(missing) in (Confidence.NO, Confidence.MAYBE)
+
+
+def test_identify_does_not_open_a_handle(envi_dat, monkeypatch):
+    opens = []
+    monkeypatch.setattr(gdal, "OpenEx", lambda *a, **k: opens.append(a) or None)
+
+    ENVI_GDALRasterDataImpl.identify(str(envi_dat / "scene.dat"))
+    assert opens == [], "identify() must not open the dataset"
+
+
+def test_data_extensions_exclude_a_same_stem_impostor(tiff_with_stray_hdr):
+    """A stray .hdr beside a .tiff must not make it an ENVI dataset."""
+    pic = str(tiff_with_stray_hdr / "pic.tiff")
+
+    assert ENVI_GDALRasterDataImpl.identify(pic) == Confidence.NO
+    assert GTiff_GDALRasterDataImpl.identify(pic) == Confidence.YES
+
+
+# ---------------------------------------------------------------------------
+# Sidecar resolution -- the two regressions
+# ---------------------------------------------------------------------------
+
+
+def test_envi_header_resolves_to_a_dat_data_file(envi_dat):
+    """Regression:  only "" and .img were tried, so .dat cubes failed to open."""
+    resolved = ENVI_GDALRasterDataImpl.get_load_filename(str(envi_dat / "scene.hdr"))
+    assert os.path.basename(resolved) == "scene.dat"
+
+
+def test_envi_header_with_no_data_file_reports_what_it_tried(tmp_path):
+    (tmp_path / "orphan.hdr").write_text("ENVI\n")
+
+    with pytest.raises(ValueError, match="orphan"):
+        ENVI_GDALRasterDataImpl.get_load_filename(str(tmp_path / "orphan.hdr"))
+
+
+def test_world_file_resolves_to_a_tiff_spelled_in_full(tmp_path):
+    """Regression:  .tfw resolved only to .tif, never to .tiff."""
+    _write_raster(tmp_path / "pic.tiff", "GTiff")
+    (tmp_path / "pic.tfw").write_text("1.0\n0.0\n0.0\n-1.0\n0.0\n0.0\n")
+
+    resolved = GTiff_GDALRasterDataImpl.get_load_filename(str(tmp_path / "pic.tfw"))
+    assert os.path.basename(resolved) == "pic.tiff"
+
+
+# ---------------------------------------------------------------------------
+# load_from_file
+# ---------------------------------------------------------------------------
+
+
+def test_load_picks_the_identifying_format(envi_dat):
+    (ds,) = RasterDataLoader().load_from_file(str(envi_dat / "scene.hdr"), interactive=False)
+    assert isinstance(ds.get_impl(), ENVI_GDALRasterDataImpl)
+    assert ds.get_name() == "scene.dat"
+
+
+def test_load_opens_exactly_one_handle(envi_dat, monkeypatch):
+    """The old loop opened one dataset per candidate driver and discarded all but one."""
+    opens = []
+    real_open = gdal.OpenEx
+    monkeypatch.setattr(gdal, "OpenEx", lambda *a, **k: (opens.append(a[0]), real_open(*a, **k))[1])
+
+    RasterDataLoader().load_from_file(str(envi_dat / "scene.hdr"), interactive=False)
+    assert len(opens) == 1, f"expected a single open, got {opens}"
+
+
+def test_load_prefers_the_certain_format_over_a_merely_possible_one(tiff_with_stray_hdr):
+    (ds,) = RasterDataLoader().load_from_file(str(tiff_with_stray_hdr / "pic.tiff"), interactive=False)
+    assert isinstance(ds.get_impl(), GTiff_GDALRasterDataImpl)
+
+
+def test_missing_file_raises_file_not_found(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        RasterDataLoader().load_from_file(str(tmp_path / "absent.img"))
+
+
+def test_unreadable_file_raises_rather_than_returning_nothing(tmp_path):
+    junk = tmp_path / "junk.xyz"
+    junk.write_bytes(b"not a raster at all")
+
+    with pytest.raises(ValueError, match="unsupported format"):
+        RasterDataLoader().load_from_file(str(junk), interactive=False)
+
+
+# ---------------------------------------------------------------------------
+# Explicit override
+# ---------------------------------------------------------------------------
+
+
+def test_override_selects_the_named_format(envi_dat):
+    (ds,) = RasterDataLoader().load_from_file(str(envi_dat / "scene.hdr"), interactive=False, format="ENVI")
+    assert isinstance(ds.get_impl(), ENVI_GDALRasterDataImpl)
+
+
+def test_override_fails_loudly_instead_of_guessing_again(tiff_with_stray_hdr):
+    """A wrong override must surface the mistake, not silently detect something else."""
+    with pytest.raises(ValueError):
+        RasterDataLoader().load_from_file(
+            str(tiff_with_stray_hdr / "pic.tiff"), interactive=False, format="NetCDF"
+        )
+
+
+def test_unknown_override_name_lists_the_valid_ones(envi_dat):
+    with pytest.raises(ValueError, match="Unknown raster format") as excinfo:
+        RasterDataLoader().load_from_file(str(envi_dat / "scene.dat"), format="Nonsense")
+
+    for name in format_names():
+        assert name in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Mapping an opened dataset back to its format
+# ---------------------------------------------------------------------------
+
+
+def test_format_for_impl_round_trips(envi_dat):
+    (ds,) = RasterDataLoader().load_from_file(str(envi_dat / "scene.hdr"), interactive=False)
+    assert format_for_impl(ds.get_impl()) == "ENVI"
+
+
+def test_format_for_impl_matches_on_exact_type_not_subclass():
+    """A subclass must not be reported as its registered base class."""
+
+    class _Subclass(ENVI_GDALRasterDataImpl):
+        def __init__(self):
+            # No dataset is needed to check a type, but the inherited __del__
+            # inspects both of these, so give it something benign to find.
+            self.gdal_dataset = None
+            self._save_state = SaveState.UNKNOWN
+
+    assert format_for_impl(_Subclass()) is None

--- a/src/tests/test_format_registry.py
+++ b/src/tests/test_format_registry.py
@@ -239,6 +239,22 @@ def test_unreadable_file_raises_rather_than_returning_nothing(tmp_path):
         RasterDataLoader().load_from_file(str(junk), interactive=False)
 
 
+def test_gtiff_raises_when_gdal_returns_no_dataset(tmp_path, monkeypatch):
+    """OpenEx can return None without raising; try_load_file must not wrap None."""
+    tif = _write_raster(tmp_path / "pic.tif", "GTiff")
+    monkeypatch.setattr(gdal, "OpenEx", lambda *a, **k: None)
+
+    with pytest.raises(ValueError, match="Unable to open"):
+        GTiff_GDALRasterDataImpl.try_load_file(tif)
+
+
+def test_envi_raises_when_gdal_returns_no_dataset(envi_dat, monkeypatch):
+    monkeypatch.setattr(gdal, "OpenEx", lambda *a, **k: None)
+
+    with pytest.raises(ValueError, match="Unable to open"):
+        ENVI_GDALRasterDataImpl.try_load_file(str(envi_dat / "scene.hdr"))
+
+
 # ---------------------------------------------------------------------------
 # Explicit override
 # ---------------------------------------------------------------------------

--- a/src/tests/test_project_datasets.py
+++ b/src/tests/test_project_datasets.py
@@ -290,18 +290,33 @@ def test_dataset_entry_without_metadata_restores(tmp_path):
     assert restored.get_name() == "in-mem"
 
 
+def _abs(*parts: str) -> str:
+    """
+    An absolute path spelled the way this platform spells it.
+
+    Paths in the manifest go through ``os.path.abspath``, so a POSIX literal
+    like ``/data/scene.nc`` becomes ``C:\\data\\scene.nc`` on Windows.  Building
+    the expectation the same way keeps these assertions platform-independent.
+    """
+    return os.path.abspath(os.path.join(os.sep, *parts))
+
+
 def test_subdataset_base_path_parses_descriptor():
     from wiser.project.persisters.datasets import _subdataset_base_path
 
-    assert _subdataset_base_path('NETCDF:"/data/scene.nc":reflectance') == "/data/scene.nc"
-    assert _subdataset_base_path("/plain/path.tif") == "/plain/path.tif"
+    scene = _abs("data", "scene.nc")
+    plain = _abs("plain", "path.tif")
+
+    assert _subdataset_base_path(f'NETCDF:"{scene}":reflectance') == scene
+    assert _subdataset_base_path(plain) == plain
 
 
 def test_subdataset_recorded_as_base_path_and_descriptor():
     # A subdataset is stored as base path + subdataset_name so the same subdataset
     # re-opens.  (The full NetCDF reopen needs a live NetCDF file + GDAL driver;
     # here we lock the manifest shape.)
-    descriptor = 'NETCDF:"/data/scene.nc":reflectance'
+    base_path = _abs("data", "scene.nc")
+    descriptor = f'NETCDF:"{base_path}":reflectance'
 
     class _StubDataset:
         def get_id(self):
@@ -342,7 +357,7 @@ def test_subdataset_recorded_as_base_path_and_descriptor():
 
     entry = dataset_to_pyrep(_StubDataset(), None, None)
     assert entry["storage"] == STORAGE_REFERENCE
-    assert entry["path"] == "/data/scene.nc"
+    assert entry["path"] == base_path
     assert entry["subdataset_name"] == descriptor
     assert entry["metadata"] == {}
 

--- a/src/tests/test_project_datasets.py
+++ b/src/tests/test_project_datasets.py
@@ -301,6 +301,69 @@ def _abs(*parts: str) -> str:
     return os.path.abspath(os.path.join(os.sep, *parts))
 
 
+def test_referenced_dataset_records_the_format_that_opened_it(tmp_path):
+    """The manifest pins the format so a reopen can't re-detect a different one."""
+    src = _FakeAppState()
+    loader = src.get_loader()
+
+    mem = loader.dataset_from_numpy_array(_sample_array(), None)
+    ext_path = tmp_path / "external.img"
+    loader.save_dataset_as(mem, str(ext_path), format="ENVI", config=None)
+    src.add_dataset(loader.load_from_file(str(ext_path), data_cache=None, interactive=False)[0])
+
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {}
+    save_datasets(src, manifest, bundle)
+
+    (entry,) = manifest["datasets"]
+    assert entry["format"] == "ENVI"
+
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == []
+    (restored,) = dst.get_datasets()
+    assert restored.get_format() == "ENVI"
+
+
+def test_manifest_without_a_format_still_loads(tmp_path):
+    """Projects saved before the format field was added must keep working."""
+    src = _FakeAppState()
+    loader = src.get_loader()
+
+    mem = loader.dataset_from_numpy_array(_sample_array(), None)
+    ext_path = tmp_path / "external.img"
+    loader.save_dataset_as(mem, str(ext_path), format="ENVI", config=None)
+    src.add_dataset(loader.load_from_file(str(ext_path), data_cache=None, interactive=False)[0])
+
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {}
+    save_datasets(src, manifest, bundle)
+    manifest["datasets"][0].pop("format")  # as an older WISER would have written it
+
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == []
+    assert len(dst.get_datasets()) == 1
+
+
+def test_manifest_naming_a_removed_format_falls_back_to_detection(tmp_path):
+    """An unknown format name is ignored, not fatal -- detection is likelier to work."""
+    src = _FakeAppState()
+    loader = src.get_loader()
+
+    mem = loader.dataset_from_numpy_array(_sample_array(), None)
+    ext_path = tmp_path / "external.img"
+    loader.save_dataset_as(mem, str(ext_path), format="ENVI", config=None)
+    src.add_dataset(loader.load_from_file(str(ext_path), data_cache=None, interactive=False)[0])
+
+    bundle = ProjectBundle.create(tmp_path / "proj")
+    manifest = {}
+    save_datasets(src, manifest, bundle)
+    manifest["datasets"][0]["format"] = "AFormatWeNoLongerHave"
+
+    dst = _FakeAppState()
+    assert load_datasets(manifest, dst, bundle) == []
+    assert len(dst.get_datasets()) == 1
+
+
 def test_subdataset_base_path_parses_descriptor():
     from wiser.project.persisters.datasets import _subdataset_base_path
 

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -906,7 +906,10 @@ class DataVisualizerApp(QMainWindow):
             # Spectral libraries are not raster formats; open_file() recognizes
             # them before the raster loader is consulted.
             (self.tr("ENVI spectral libraries (*.sli *.hdr)"), None),
-            (self.tr("Try luck with GDAL (*)"), None),
+            # Forces the registry's GDAL catch-all rather than re-running
+            # detection, so a file WISER's native formats mis-identify can
+            # still be handed straight to GDAL.
+            (self.tr("Try luck with GDAL (*)"), "GDAL"),
         ]
         format_for_filter = dict(supported_formats)
 

--- a/src/wiser/gui/app.py
+++ b/src/wiser/gui/app.py
@@ -882,33 +882,47 @@ class DataVisualizerApp(QMainWindow):
         perform the actual operation of opening the file.
         """
 
-        # These are all file formats that will appear in the file-open dialog
+        # Filters offered in the file-open dialog, each paired with the raster
+        # format it selects.  Choosing a specific filter is taken as a statement
+        # of what the file *is*, and forces that format rather than detecting
+        # one -- which matters for files two formats can both read.  None means
+        # "work it out from the file".
         supported_formats = [
-            self.tr(
-                "All supported files (*.img *.hdr *.tiff *.tif *.tfw *.nc *.sli *.hdr, "
-                "*.JP2 *.PDS *.lbl *.xml)"
+            (
+                self.tr(
+                    "All supported files (*.img *.hdr *.dat *.tiff *.tif *.tfw *.nc *.sli, "
+                    "*.JP2 *.PDS *.lbl *.xml *.asc *.fits)"
+                ),
+                None,
             ),
-            self.tr("ENVI raster files (*.img *.hdr)"),
-            self.tr("TIFF raster files (*.tiff *.tif *.tfw)"),
-            self.tr("NetCDF raster files (*.nc)"),
-            self.tr("JP2 files (*.JP2)"),
-            self.tr("PDS raster files (*.PDS *.img *.lbl *.xml)"),
-            self.tr("ENVI spectral libraries (*.sli *.hdr)"),
-            self.tr("Try luck with GDAL (*)"),
+            (self.tr("ENVI raster files (*.img *.hdr *.dat)"), "ENVI"),
+            (self.tr("TIFF raster files (*.tiff *.tif *.tfw)"), "GTiff"),
+            (self.tr("NetCDF raster files (*.nc)"), "NetCDF"),
+            (self.tr("JP2 files (*.JP2)"), "JP2"),
+            (self.tr("PDS3 raster files (*.PDS *.img *.lbl)"), "PDS3"),
+            (self.tr("PDS4 raster files (*.xml)"), "PDS4"),
+            (self.tr("FITS raster files (*.fits *.fit *.fts)"), "FITS"),
+            (self.tr("ASCII Grid files (*.asc)"), "ASCII"),
+            # Spectral libraries are not raster formats; open_file() recognizes
+            # them before the raster loader is consulted.
+            (self.tr("ENVI spectral libraries (*.sli *.hdr)"), None),
+            (self.tr("Try luck with GDAL (*)"), None),
         ]
+        format_for_filter = dict(supported_formats)
 
         # Let the user select one or more files to open.
-        selected = QFileDialog.getOpenFileNames(
+        selected_files, selected_filter = QFileDialog.getOpenFileNames(
             self,
             self.tr("Open Spectral Data File"),
             self._app_state.get_current_dir(),
-            ";;".join(supported_formats),
+            ";;".join(text for text, _ in supported_formats),
         )
+        chosen_format = format_for_filter.get(selected_filter)
 
-        for filename in selected[0]:
+        for filename in selected_files:
             try:
                 # Open the file on the application state.
-                self._app_state.open_file(filename)
+                self._app_state.open_file(filename, format=chosen_format)
             except Exception as e:
                 mbox = QMessageBox(
                     QMessageBox.Critical,

--- a/src/wiser/gui/app_state.py
+++ b/src/wiser/gui/app_state.py
@@ -337,13 +337,18 @@ class ApplicationState(QObject):
     def clear_status_text(self):
         self._app.show_status_text("")
 
-    def open_file(self, file_path):
+    def open_file(self, file_path, format=None):
         """
         A general file-open operation in WISER.  This method can be used
         for loading any kind of data file whose type and contents can be
         identified automatically.  This operation should not be used for
         importing ASCII spectral data, regions of interest, etc. since
         WISER cannot identify the file's contents automatically.
+
+        :param format: force a specific raster format by name (for example
+            ``"ENVI"``), skipping detection.  Used when the user has stated the
+            format -- by picking a specific filter in the file-open dialog --
+            since that is better information than anything guessing can produce.
         """
 
         # Remember the directory of the selected file, for next file-open
@@ -371,7 +376,9 @@ class ApplicationState(QObject):
         # it as a spectral library didn't work.  Load it as a regular raster
         # data file.
 
-        raster_data_list = self._raster_data_loader.load_from_file(path=file_path, data_cache=self._cache)
+        raster_data_list = self._raster_data_loader.load_from_file(
+            path=file_path, data_cache=self._cache, format=format
+        )
 
         for raster_data in raster_data_list:
             self.add_dataset(raster_data)

--- a/src/wiser/project/persisters/datasets.py
+++ b/src/wiser/project/persisters/datasets.py
@@ -26,12 +26,15 @@ from the manifest dict alone, so they bypass the generic
 application's raster loader directly.
 """
 
+import logging
 import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from wiser.utils.progress import ProgressReporter
 
 from ..bundle import ProjectBundle
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from wiser.gui.app_state import ApplicationState
@@ -82,6 +85,7 @@ def dataset_to_pyrep(
         entry["storage"] = STORAGE_REFERENCE
         entry["path"] = os.path.abspath(_subdataset_base_path(subdataset_name))
         entry["subdataset_name"] = _absolute_subdataset(subdataset_name)
+        _record_format(entry, dataset)
     elif not embed and filepaths:
         entry["storage"] = STORAGE_REFERENCE
         # A reference is resolved on load with no knowledge of where it was saved
@@ -89,6 +93,7 @@ def dataset_to_pyrep(
         # is given file arguments on the command line) would otherwise be looked up
         # against the working directory of whoever opens the project next.
         entry["path"] = os.path.abspath(filepaths[0])
+        _record_format(entry, dataset)
     else:
         # In-memory always, and every dataset under a self-contained save: re-save
         # the pixels to an ENVI sidecar in the bundle.  A subdataset flattens to a
@@ -99,6 +104,58 @@ def dataset_to_pyrep(
         entry["path"] = f"{ProjectBundle.DATASETS_DIR}/{sidecar.name}"
 
     return entry
+
+
+def _record_format(entry: Dict[str, Any], dataset: "RasterDataSet") -> None:
+    """
+    Note which registered format opened ``dataset``, when it is known.
+
+    A referenced dataset is re-opened from its path on load, and without this the
+    format would be re-detected from scratch.  Detection is deterministic but not
+    frozen:  a new format added to the registry, or a stray header file appearing
+    beside the data, could resolve the same path differently later.  Recording
+    the format pins the reopen to the implementation that was actually in use
+    when the project was saved.
+
+    Datasets whose implementation isn't in the registry record nothing, and fall
+    back to detection on load.  The same applies to anything that doesn't expose
+    an implementation at all:  this is an optimization over detection, never a
+    requirement, so it must not be able to fail a save.
+    """
+    from wiser.raster.format_registry import format_for_impl
+
+    get_impl = getattr(dataset, "get_impl", None)
+    if get_impl is None:
+        return
+
+    format_name = format_for_impl(get_impl())
+    if format_name is not None:
+        entry["format"] = format_name
+
+
+def _entry_format(entry: Dict[str, Any]) -> Optional[str]:
+    """
+    The format to force when reopening ``entry``, if it named one we still have.
+
+    An unrecognized name -- an older or hand-edited manifest, or a format since
+    removed -- is deliberately ignored rather than fatal:  falling back to
+    detection is far more likely to load the file than refusing to try.
+    """
+    from wiser.raster.format_registry import get_format
+
+    format_name = entry.get("format")
+    if not format_name:
+        return None
+
+    if get_format(format_name) is None:
+        logger.warning(
+            "Project references unknown raster format %r for %s; detecting instead.",
+            format_name,
+            entry.get("path"),
+        )
+        return None
+
+    return format_name
 
 
 def save_datasets(
@@ -194,7 +251,11 @@ def _load_dataset(
     subdataset_name = entry.get("subdataset_name") or ""
     try:
         datasets = loader.load_from_file(
-            path, data_cache=cache, interactive=False, subdataset_name=subdataset_name
+            path,
+            data_cache=cache,
+            interactive=False,
+            subdataset_name=subdataset_name,
+            format=_entry_format(entry),
         )
     except Exception:
         # A referenced file that exists but is unreadable/unsupported (e.g. an

--- a/src/wiser/raster/dataset.py
+++ b/src/wiser/raster/dataset.py
@@ -682,6 +682,16 @@ class RasterDataSet(Serializable):
         self._description = description
         self.set_dirty()
 
+    def get_impl(self) -> RasterDataImpl:
+        """
+        Returns the implementation object backing this dataset.
+
+        Mostly of interest to code that needs to know *how* the dataset is
+        stored rather than what it contains -- for example, mapping it back to a
+        registered format name when saving a project.
+        """
+        return self._impl
+
     def get_format(self):
         """
         Returns a string describing the type of raster data file that backs this
@@ -1607,9 +1617,6 @@ class RasterDataSet(Serializable):
 
     def set_save_state(self, save_state: SaveState):
         self._impl.set_save_state(save_state)
-
-    def get_impl(self):
-        return self._impl
 
     def get_subdataset_name(self) -> str:
         if hasattr(self._impl, "_subdataset_name"):

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -95,7 +95,7 @@ emit_data_names = set(
         "group_1_mineral_id",
         "group_2_band_depth",
         "group_2_mineral_id",
-        "" "radiance",
+        "radiance",
         "obs",
         "Calcite",
         "Chlorite",
@@ -1166,6 +1166,9 @@ class GTiff_GDALRasterDataImpl(GDALRasterDataImpl):
             allowed_drivers=["GTiff"],
         )
 
+        if gdal_dataset is None:
+            raise ValueError(f"Unable to open GeoTIFF file: {load_path}")
+
         return [cls(gdal_dataset)]
 
     def __init__(self, gdal_dataset):
@@ -1242,7 +1245,7 @@ class FITS_GDALRasterDataImpl(GDALRasterDataImpl):
             _naxis = header["NAXIS"]
             _axis_lengths = []
             for i in range(_naxis):
-                _axis_lengths.append(header[f"NAXIS{i+1}"])
+                _axis_lengths.append(header[f"NAXIS{i + 1}"])
 
             print(f"_naxis: {_naxis}")
             print(f"_axis_lengths: {_axis_lengths}")
@@ -1606,8 +1609,8 @@ class NetCDF_GDALRasterDataImpl(GDALRasterDataImpl):
         else:
             return [GDALRasterDataImpl(gdal_dataset)]
 
-        if instances_list is []:
-            raise ValueError(f"Could not open {path} as netCDF")
+        # An empty list means the user cancelled the subdataset chooser;
+        # load_from_file treats that as a decision, not a failure.
         return instances_list
 
     def __init__(
@@ -1907,7 +1910,7 @@ class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
     SIDECAR_EXTENSIONS = (".hdr",)
 
     @classmethod
-    def try_load_file(cls, path: str, **kwargs) -> ["GTiff_ENVIRasterDataImpl"]:
+    def try_load_file(cls, path: str, **kwargs) -> ["ENVI_GDALRasterDataImpl"]:
         # Turn on exceptions when calling into GDAL
         gdal.UseExceptions()
 
@@ -1917,6 +1920,9 @@ class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
             nOpenFlags=gdalconst.OF_READONLY | gdalconst.OF_VERBOSE_ERROR,
             allowed_drivers=["ENVI"],
         )
+
+        if gdal_dataset is None:
+            raise ValueError(f"Unable to open ENVI file: {load_path}")
 
         return [cls(gdal_dataset)]
 
@@ -2354,7 +2360,7 @@ class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
         if "default_bands" in md:
             s = md["default_bands"].strip()
             if s[0] != "{" or s[-1] != "}":
-                raise ValueError("ENVI file has unrecognized format for " f"default bands:  {s}")
+                raise ValueError(f"ENVI file has unrecognized format for default bands:  {s}")
 
             # Convert all numbers in the band-list to integers, and return it.
             b = [int(v) for v in s[1:-1].split(",")]

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -7,7 +7,7 @@ import pdr
 # import cv2
 from pdr.loaders.datawrap import ReadArray
 
-from enum import Enum
+from enum import Enum, IntEnum
 import math
 from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from contextlib import contextmanager
@@ -51,6 +51,24 @@ class SaveState(Enum):
     IN_DISK_SAVED = 2
     IN_MEMORY_SAVED = 3
     UNKNOWN = 4
+
+
+class Confidence(IntEnum):
+    """
+    How sure a format is that it can open a given file.
+
+    Returned by :meth:`RasterDataImpl.identify`.  Ordered so that a larger value
+    is a stronger claim.
+    """
+
+    NO = 0
+    """Positively excluded -- do not attempt to open."""
+
+    MAYBE = 1
+    """Plausible, but no positive signal.  Used only if nothing is certain."""
+
+    YES = 2
+    """Positive content match.  Stops the format search immediately."""
 
 
 class DriverNames(Enum):
@@ -104,6 +122,25 @@ emit_data_names = set(
 
 
 class RasterDataImpl(abc.ABC):
+    @classmethod
+    def identify(cls, path: str) -> Confidence:
+        """
+        Cheaply decide whether this implementation can open ``path``.
+
+        Called for every candidate format before any file is opened, so it must
+        be fast and must not:
+
+        * open a lasting handle or allocate significant memory,
+        * show a dialog or otherwise block on the user,
+        * raise for an unreadable or nonexistent file -- return
+          :attr:`Confidence.NO` instead.
+
+        The default is :attr:`Confidence.MAYBE`, which means "no opinion":  the
+        format stays in the running but never wins over a format that is
+        certain.  Override it to give a real answer.
+        """
+        return Confidence.MAYBE
+
     def get_format(self) -> str:
         """Returns a string describing the raster data format."""
         pass
@@ -190,6 +227,98 @@ class RasterDataImpl(abc.ABC):
 
 
 class GDALRasterDataImpl(RasterDataImpl):
+    GDAL_DRIVERS: List[str] = []
+    """GDAL driver short-names this implementation opens with.  Subclasses
+    declare the same list they pass to ``gdal.OpenEx(allowed_drivers=...)`` so
+    that identification and opening can never disagree.  Empty means "any
+    driver", which is only appropriate for the catch-all."""
+
+    DATA_EXTENSIONS: Optional[Tuple[str, ...]] = None
+    """Extensions of the file that actually holds the raster, in the order
+    :meth:`get_load_filename` should try them.  ``""`` means "no extension".
+
+    ``None`` (the default) means the format is a single self-describing file and
+    imposes no extension restriction.  When set, it does double duty:  it drives
+    sidecar resolution *and* it excludes -- :meth:`identify` returns
+    :attr:`Confidence.NO` for a path whose own extension is neither a declared
+    data extension nor a recognized sidecar.  That stops header-based formats
+    from claiming unrelated files that merely share a basename."""
+
+    SIDECAR_EXTENSIONS: Tuple[str, ...] = ()
+    """Extensions of companion/header files a user may legitimately select
+    (``.hdr`` for ENVI, ``.tfw`` for GeoTIFF).  :meth:`get_load_filename`
+    rewrites these to the matching data file."""
+
+    @classmethod
+    def get_load_filename(cls, path: str) -> str:
+        """
+        Resolve a user-supplied path to the file that should actually be opened.
+
+        The base implementation handles the common sidecar case:  if ``path`` is
+        one of :attr:`SIDECAR_EXTENSIONS`, look for a file with the same stem and
+        one of :attr:`DATA_EXTENSIONS`, in declared order, and return the first
+        that exists.  Formats without sidecars inherit a pass-through.
+        """
+        if not cls.SIDECAR_EXTENSIONS or cls.DATA_EXTENSIONS is None:
+            return path
+
+        stem, ext = os.path.splitext(path)
+        if ext.lower() not in cls.SIDECAR_EXTENSIONS:
+            return path
+
+        for data_ext in cls.DATA_EXTENSIONS:
+            candidate = stem + data_ext
+            if os.path.isfile(candidate):
+                return candidate
+
+        tried = ", ".join(repr(stem + e) for e in cls.DATA_EXTENSIONS)
+        raise ValueError(f"Can't find the raster file corresponding to {path}.  Tried:  {tried}")
+
+    @classmethod
+    def get_gdal_drivers(cls) -> List[str]:
+        """
+        The GDAL drivers to identify and open with.
+
+        Defaults to :attr:`GDAL_DRIVERS`.  Override when the usable set can only
+        be determined at run time -- JPEG2000 support varies by GDAL build.
+        """
+        return cls.GDAL_DRIVERS
+
+    @classmethod
+    def identify(cls, path: str) -> Confidence:
+        """
+        Ask GDAL whether one of this format's drivers recognizes ``path``.
+
+        Delegates to ``gdal.IdentifyDriverEx``, which runs the driver's own
+        ``Identify()`` without opening the dataset, so WISER never has to
+        duplicate GDAL's magic-byte checks.
+        """
+        drivers = cls.get_gdal_drivers()
+
+        # The catch-all declares no drivers; it has no opinion and defers to
+        # everything else, only running once all named formats have declined.
+        if not drivers:
+            return Confidence.MAYBE
+
+        try:
+            load_path = cls.get_load_filename(path)
+        except (ValueError, OSError):
+            # A sidecar with no matching data file is not this format.
+            return Confidence.NO
+
+        if cls.DATA_EXTENSIONS is not None:
+            ext = os.path.splitext(load_path)[1].lower()
+            if ext not in cls.DATA_EXTENSIONS:
+                return Confidence.NO
+
+        try:
+            driver = gdal.IdentifyDriverEx(load_path, allowed_drivers=list(drivers))
+        except Exception as e:
+            logger.debug("identify(%s) failed for %s:  %s", path, cls.__name__, e)
+            return Confidence.NO
+
+        return Confidence.YES if driver is not None else Confidence.NO
+
     @classmethod
     def try_load_file(cls, path: str, **kwargs) -> ["GDALRasterDataImpl"]:
         # Turn on exceptions when calling into GDAL
@@ -1017,20 +1146,13 @@ class JP2_PDRRasterDataImpl(PDRRasterDataImpl):
 
 
 class GTiff_GDALRasterDataImpl(GDALRasterDataImpl):
-    @classmethod
-    def get_load_filename(cls, path: str) -> str:
-        """
-        GeoTIFF files are sometimes accompanied by a .tfw file.  If we were
-        passed the .tfw file, try to find a corresponding .tif file.
-        """
-        if path.endswith(".tfw"):
-            s = path[:-4] + ".tif"
-            if os.path.isfile(s):
-                path = s
-            else:
-                raise ValueError("Can't find raster file corresponding " + f"to .tfw file {path}")
+    GDAL_DRIVERS = ["GTiff"]
 
-        return path
+    # A .tfw world file may be selected instead of the image; resolve it to the
+    # image itself.  Both spellings of the TIFF extension are accepted -- the
+    # file-open dialog offers *.tiff as well as *.tif.
+    DATA_EXTENSIONS = (".tif", ".tiff")
+    SIDECAR_EXTENSIONS = (".tfw",)
 
     @classmethod
     def try_load_file(cls, path: str, **kwargs) -> ["GTiff_GDALRasterDataImpl"]:
@@ -1051,6 +1173,12 @@ class GTiff_GDALRasterDataImpl(GDALRasterDataImpl):
 
 
 class ASC_GDALRasterDataImpl(GDALRasterDataImpl):
+    GDAL_DRIVERS = ["AAIGrid"]
+
+    # ASCII Grid is a single self-describing text file.  Restricting to .asc
+    # keeps this format from claiming arbitrary text files.
+    DATA_EXTENSIONS = (".asc",)
+
     @classmethod
     def get_load_filename(cls, path: str) -> str:
         """
@@ -1079,6 +1207,9 @@ class ASC_GDALRasterDataImpl(GDALRasterDataImpl):
 
 
 class FITS_GDALRasterDataImpl(GDALRasterDataImpl):
+    GDAL_DRIVERS = ["FITS"]
+    DATA_EXTENSIONS = (".fits", ".fit", ".fts")
+
     @classmethod
     def try_load_file(cls, path: str, **kwargs) -> ["FITS_GDALRasterDataImpl"]:
         # Turn on exceptions when calling into GDAL
@@ -1204,6 +1335,12 @@ class FITS_GDALRasterDataImpl(GDALRasterDataImpl):
 
 
 class PDS3_GDALRasterDataImpl(GDALRasterDataImpl):
+    GDAL_DRIVERS = ["PDS"]
+
+    # No DATA_EXTENSIONS restriction:  a PDS3 label may be detached (.lbl beside
+    # the data) or attached (a single .img), and products in the wild use many
+    # extensions.  The driver's label check is the reliable signal here.
+
     @classmethod
     def try_load_file(cls, path: str, **kwargs) -> ["PDS3_GDALRasterDataImpl"]:
         # Turn on exceptions when calling into GDAL
@@ -1225,6 +1362,11 @@ class PDS3_GDALRasterDataImpl(GDALRasterDataImpl):
 
 
 class PDS4_GDALRasterDataImpl(GDALRasterDataImpl):
+    GDAL_DRIVERS = ["PDS4"]
+
+    # The label is XML; the driver checks the root element, which is a far
+    # stronger signal than the .xml extension.
+
     @classmethod
     def try_load_file(cls, path: str, **kwargs) -> ["PDS4_GDALRasterDataImpl"]:
         # Turn on exceptions when calling into GDAL
@@ -1246,6 +1388,11 @@ class PDS4_GDALRasterDataImpl(GDALRasterDataImpl):
 
 
 class NetCDF_GDALRasterDataImpl(GDALRasterDataImpl):
+    GDAL_DRIVERS = ["netCDF"]
+
+    # No DATA_EXTENSIONS restriction:  the driver identifies on the CDF/HDF5
+    # magic, which is stronger than any extension convention.
+
     _GEOTRANSFORM_KEYS = {"NC_GLOBAL#geotransform", "geotransform"}
     _SRS_KEYS = {"NC_GLOBAL#spatial_ref", "spatial_ref"}
 
@@ -1684,6 +1831,24 @@ class NetCDF_GDALRasterDataImpl(GDALRasterDataImpl):
 
 class JP2_GDALRasterDataImpl(GDALRasterDataImpl):
     @classmethod
+    def get_gdal_drivers(cls) -> List[str]:
+        """
+        JPEG2000 support depends on the GDAL build, so the driver list is
+        resolved at run time rather than declared statically.  If the build has
+        no JPEG2000 driver this returns empty, and :meth:`identify` correctly
+        reports that this format cannot be used.
+        """
+        return cls.get_jpeg2000_drivers()
+
+    @classmethod
+    def identify(cls, path: str) -> Confidence:
+        # Unlike the catch-all, an empty driver list here means "this build
+        # cannot read JPEG2000", which is a definite no rather than no opinion.
+        if not cls.get_gdal_drivers():
+            return Confidence.NO
+        return super().identify(path)
+
+    @classmethod
     def get_jpeg2000_drivers(cls):
         driver_names = [gdal.GetDriver(i).ShortName for i in range(gdal.GetDriverCount())]
         jpeg2000_drivers = []
@@ -1729,20 +1894,17 @@ class JP2_GDALRasterDataImpl(GDALRasterDataImpl):
 
 
 class ENVI_GDALRasterDataImpl(GDALRasterDataImpl):
-    @classmethod
-    def get_load_filename(cls, path: str) -> str:
-        if path.endswith(".hdr"):
-            s = path[:-4]
-            if os.path.isfile(s):
-                path = s
-            else:
-                s = s + ".img"
-                if os.path.isfile(s):
-                    path = s
-                else:
-                    raise ValueError("Can't find raster file corresponding " + f"to ENVI header file {path}")
+    GDAL_DRIVERS = ["ENVI"]
 
-        return path
+    # An ENVI dataset is a header plus a separately-named data file.  The data
+    # file commonly has no extension at all, or .img, or .dat; they are tried in
+    # that order when the user selects the .hdr.
+    #
+    # This list also excludes:  because GDAL's ENVI driver claims any file with
+    # a same-stem .hdr beside it, without this restriction ENVI would identify
+    # an unrelated scene.tif sitting next to scene.hdr.
+    DATA_EXTENSIONS = ("", ".img", ".dat")
+    SIDECAR_EXTENSIONS = (".hdr",)
 
     @classmethod
     def try_load_file(cls, path: str, **kwargs) -> ["GTiff_ENVIRasterDataImpl"]:

--- a/src/wiser/raster/format_registry.py
+++ b/src/wiser/raster/format_registry.py
@@ -1,0 +1,250 @@
+"""
+The raster file-format registry.
+
+This module declares every raster format WISER knows how to open, and the rules
+used to decide which one applies to a given file.  :class:`RasterDataLoader`
+consumes the registry; nothing here opens a file or touches the GUI.
+
+Adding a new format is a single :class:`FormatSpec` entry in
+:data:`RASTER_FORMATS` -- see ``doc/.../adding-a-raster-format`` for the full
+walkthrough.
+
+Dispatch model
+--------------
+
+A file is matched in three steps:
+
+1. **Override.**  If the caller names a format (``load_from_file(format=...)``),
+   only that spec is tried, and a failure is raised rather than swallowed.
+2. **Ordering.**  Candidates are ordered by whether the path's extension is one
+   the format claims, then by descending :attr:`FormatSpec.priority`.  The
+   extension is only an ordering *hint* -- a format is never excluded for
+   failing to claim an extension, so files with unusual or absent extensions
+   still resolve.
+3. **Identification.**  Each candidate's ``identify()`` is called in order.  The
+   first :attr:`Confidence.YES` wins immediately.  If no candidate is certain,
+   the highest-priority :attr:`Confidence.MAYBE` wins.  Only the winner is
+   actually opened.
+"""
+
+import logging
+import os
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import TYPE_CHECKING, Callable, List, Optional, Sequence, Tuple, Type
+
+from .dataset import RasterDataSet
+from .dataset_impl import (
+    Confidence,
+    RasterDataImpl,
+    ENVI_GDALRasterDataImpl,
+    GTiff_GDALRasterDataImpl,
+    NetCDF_GDALRasterDataImpl,
+    ASC_GDALRasterDataImpl,
+    JP2_GDALRasterDataImpl,
+    PDS3_GDALRasterDataImpl,
+    PDS4_GDALRasterDataImpl,
+    FITS_GDALRasterDataImpl,
+    GDALRasterDataImpl,
+)
+
+if TYPE_CHECKING:
+    from .data_cache import DataCache
+
+logger = logging.getLogger(__name__)
+
+
+# Confidence is defined in dataset_impl (where RasterDataImpl.identify needs it)
+# and re-exported here, since the registry is the natural place to look for it.
+__all__ = [
+    "Confidence",
+    "FormatSpec",
+    "RASTER_FORMATS",
+    "candidates_for",
+    "format_names",
+    "get_format",
+    "load_FITS_dataset",
+    "load_normal_dataset",
+]
+
+
+# ---------------------------------------------------------------------------
+# Dataset-construction strategies
+#
+# These run *after* a format has been chosen and opened.  Each takes the opened
+# impl and returns the RasterDataSet objects to hand back to the caller; a list,
+# because one impl may expand into several datasets.
+# ---------------------------------------------------------------------------
+
+
+def load_normal_dataset(impl: RasterDataImpl, data_cache: "DataCache") -> List[RasterDataSet]:
+    """Wrap a single opened impl as a single dataset.  The common case."""
+    return [RasterDataSet(impl, data_cache)]
+
+
+def load_FITS_dataset(impl: RasterDataImpl, data_cache: "DataCache") -> List[RasterDataSet]:
+    """
+    FITS files may hold several images, so ask the user which to load.
+
+    Returns an empty list if the user cancels.
+    """
+    # Imported lazily:  the registry is imported by non-GUI code paths (tests,
+    # project restore) that must not pull in dialog classes.
+    from wiser.gui.fits_loading_dialog import FitsDatasetLoadingDialog
+    from PySide6.QtWidgets import QDialog
+
+    dialog = FitsDatasetLoadingDialog(impl, data_cache)
+    if dialog.exec() == QDialog.Accepted:
+        return dialog.return_datasets
+    return []
+
+
+@dataclass(frozen=True)
+class FormatSpec:
+    """One raster format WISER can open."""
+
+    name: str
+    """Stable identifier.  This is the token used by the ``format=`` override and
+    persisted in project files, so renaming one is a breaking change."""
+
+    impl: Type[RasterDataImpl]
+    """The :class:`RasterDataImpl` subclass that opens this format."""
+
+    extensions: frozenset
+    """Lower-case extensions this format claims, including the leading dot.
+    ``""`` means "no extension".  An **ordering hint only** -- a format is never
+    excluded for failing to claim the path's extension."""
+
+    priority: int = 0
+    """Higher wins.  Breaks ties between formats that are equally confident, and
+    orders the search.  Explicit so that dispatch never depends on declaration
+    order."""
+
+    loader: Callable[[RasterDataImpl, "DataCache"], List[RasterDataSet]] = load_normal_dataset
+    """How to turn the opened impl into datasets."""
+
+    interactive_step: bool = False
+    """True if opening this format can block on a dialog.  Informational for now;
+    it marks the formats that must stay on the main thread once loading moves to
+    a worker thread."""
+
+    is_fallback: bool = False
+    """True for the catch-all that runs only after every other format declines."""
+
+    def claims_extension(self, path: str) -> bool:
+        """True if this format claims the extension of ``path`` (case-insensitive)."""
+        return os.path.splitext(path)[1].lower() in self.extensions
+
+
+# ---------------------------------------------------------------------------
+# The registry
+#
+# Priorities are spaced by 5 so a format can be slotted between two others
+# without renumbering.  Higher = tried earlier.
+# ---------------------------------------------------------------------------
+
+RASTER_FORMATS: Tuple[FormatSpec, ...] = (
+    FormatSpec(
+        name="PDS4",
+        impl=PDS4_GDALRasterDataImpl,
+        extensions=frozenset({".xml"}),
+        priority=90,
+    ),
+    FormatSpec(
+        name="PDS3",
+        impl=PDS3_GDALRasterDataImpl,
+        extensions=frozenset({".lbl", ".pds", ".img"}),
+        priority=85,
+    ),
+    FormatSpec(
+        name="NetCDF",
+        impl=NetCDF_GDALRasterDataImpl,
+        extensions=frozenset({".nc", ".nc4", ".cdf"}),
+        priority=80,
+        # Prompts for a subdataset when the file holds more than one.
+        interactive_step=True,
+    ),
+    FormatSpec(
+        name="ENVI",
+        impl=ENVI_GDALRasterDataImpl,
+        extensions=frozenset({"", ".hdr", ".img", ".dat"}),
+        priority=70,
+    ),
+    FormatSpec(
+        name="GTiff",
+        impl=GTiff_GDALRasterDataImpl,
+        extensions=frozenset({".tif", ".tiff", ".tfw"}),
+        priority=65,
+    ),
+    FormatSpec(
+        name="JP2",
+        impl=JP2_GDALRasterDataImpl,
+        extensions=frozenset({".jp2"}),
+        priority=60,
+    ),
+    FormatSpec(
+        name="FITS",
+        impl=FITS_GDALRasterDataImpl,
+        extensions=frozenset({".fits", ".fit", ".fts"}),
+        priority=55,
+        loader=load_FITS_dataset,
+        interactive_step=True,
+    ),
+    FormatSpec(
+        name="ASCII",
+        impl=ASC_GDALRasterDataImpl,
+        extensions=frozenset({".asc"}),
+        priority=50,
+    ),
+    FormatSpec(
+        name="GDAL",
+        impl=GDALRasterDataImpl,
+        extensions=frozenset(),
+        priority=-100,
+        # Last resort:  let GDAL pick any driver it likes.  Keeps files with
+        # unexpected extensions loadable rather than failing outright.
+        is_fallback=True,
+    ),
+)
+
+
+def get_format(name: str) -> Optional[FormatSpec]:
+    """Look up a spec by :attr:`FormatSpec.name` (case-insensitive)."""
+    lowered = name.lower()
+    for spec in RASTER_FORMATS:
+        if spec.name.lower() == lowered:
+            return spec
+    return None
+
+
+def format_names() -> List[str]:
+    """Every registered format name, for error messages and UI."""
+    return [spec.name for spec in RASTER_FORMATS]
+
+
+def candidates_for(path: str) -> List[FormatSpec]:
+    """
+    Order the registry for ``path``, most likely first.
+
+    Formats claiming the path's extension come first, then everything else, then
+    the fallback.  Within each group, higher :attr:`FormatSpec.priority` wins.
+    Every non-fallback format appears exactly once regardless of extension --
+    the extension orders the search, it does not restrict it.
+    """
+    claiming: List[FormatSpec] = []
+    others: List[FormatSpec] = []
+    fallbacks: List[FormatSpec] = []
+
+    for spec in RASTER_FORMATS:
+        if spec.is_fallback:
+            fallbacks.append(spec)
+        elif spec.claims_extension(path):
+            claiming.append(spec)
+        else:
+            others.append(spec)
+
+    def _sort_key(s):
+        return -s.priority
+
+    return sorted(claiming, key=_sort_key) + sorted(others, key=_sort_key) + sorted(fallbacks, key=_sort_key)

--- a/src/wiser/raster/format_registry.py
+++ b/src/wiser/raster/format_registry.py
@@ -62,6 +62,7 @@ __all__ = [
     "FormatSpec",
     "RASTER_FORMATS",
     "candidates_for",
+    "format_for_impl",
     "format_names",
     "get_format",
     "load_FITS_dataset",
@@ -215,6 +216,23 @@ def get_format(name: str) -> Optional[FormatSpec]:
     for spec in RASTER_FORMATS:
         if spec.name.lower() == lowered:
             return spec
+    return None
+
+
+def format_for_impl(impl: RasterDataImpl) -> Optional[str]:
+    """
+    The registered format name that produced ``impl``, or ``None``.
+
+    Matched on the exact implementation type rather than by ``isinstance``, so
+    that a subclass is never mistaken for its base.  ``None`` means the impl
+    came from somewhere other than the registry (an in-memory NumPy dataset, or
+    a format opened through the GDAL catch-all under a different class), in
+    which case callers should fall back to normal detection.
+    """
+    impl_type = type(impl)
+    for spec in RASTER_FORMATS:
+        if spec.impl is impl_type:
+            return spec.name
     return None
 
 

--- a/src/wiser/raster/format_registry.py
+++ b/src/wiser/raster/format_registry.py
@@ -30,9 +30,8 @@ A file is matched in three steps:
 import logging
 import os
 
-from dataclasses import dataclass, field
-from enum import IntEnum
-from typing import TYPE_CHECKING, Callable, List, Optional, Sequence, Tuple, Type
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Type
 
 from .dataset import RasterDataSet
 from .dataset_impl import (

--- a/src/wiser/raster/loader.py
+++ b/src/wiser/raster/loader.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 
@@ -11,22 +11,12 @@ from wiser.utils.progress import ProgressReporter
 
 from .dataset import RasterDataSet
 from .dataset_impl import (
+    Confidence,
     RasterDataImpl,
     ENVI_GDALRasterDataImpl,
-    GTiff_GDALRasterDataImpl,
     NumPyRasterDataImpl,
-    NetCDF_GDALRasterDataImpl,
-    ASC_GDALRasterDataImpl,
-    JP2_GDALRasterDataImpl,
-    PDS3_GDALRasterDataImpl,
-    PDS4_GDALRasterDataImpl,
-    GDALRasterDataImpl,
-    JP2_GDAL_PDR_RasterDataImpl,
 )
-
-from wiser.gui.fits_loading_dialog import FitsDatasetLoadingDialog
-
-from PySide6.QtWidgets import QDialog
+from .format_registry import FormatSpec, candidates_for, format_names, get_format
 
 if TYPE_CHECKING:
     from wiser.raster.dataset import DataCache
@@ -38,113 +28,194 @@ class RasterDataLoader:
     """
     A loader for loading 2D raster data-sets from the local filesystem, using
     GDAL (Geospatial Data Abstraction Library) for reading the data.
+
+    Which format is used for a given file is decided by the registry in
+    :mod:`wiser.raster.format_registry`; see that module for the dispatch rules.
     """
 
     def __init__(self):
-        # File formats that we recognize.
-        self._formats = {
-            "ENVI": ENVI_GDALRasterDataImpl,
-            "GTiff": GTiff_GDALRasterDataImpl,
-            "NetCDF": NetCDF_GDALRasterDataImpl,
-            "ASCII": ASC_GDALRasterDataImpl,
-            "JP2": JP2_GDALRasterDataImpl,
-            "PDS3": PDS3_GDALRasterDataImpl,
-            "PDS4": PDS4_GDALRasterDataImpl,
-        }
-
-        # What to do when loading in each file format
-        self._format_loaders = {
-            ENVI_GDALRasterDataImpl: self.load_normal_dataset,
-            GTiff_GDALRasterDataImpl: self.load_normal_dataset,
-            NetCDF_GDALRasterDataImpl: self.load_normal_dataset,
-            ASC_GDALRasterDataImpl: self.load_normal_dataset,
-            JP2_GDALRasterDataImpl: self.load_normal_dataset,
-            PDS3_GDALRasterDataImpl: self.load_normal_dataset,
-            PDS4_GDALRasterDataImpl: self.load_normal_dataset,
-            GDALRasterDataImpl: self.load_normal_dataset,
-        }
-
         # This is a counter so we can generate names for unnamed datasets.
         self._unnamed_datasets: int = 0
 
-    def load_normal_dataset(self, impl: RasterDataImpl, data_cache: "DataCache") -> List[RasterDataSet]:
+    # ------------------------------------------------------------------
+    # Format selection
+    # ------------------------------------------------------------------
+
+    def _candidate_formats(self, path: str, format: Optional[str]) -> List[FormatSpec]:
         """
-        The normal way to load in a dataset
+        The formats to consider for ``path``, best first.
+
+        An explicit ``format`` collapses this to exactly one spec:  the caller
+        has stated the format, so guessing past it would only hide their error.
         """
+        if format:
+            spec = get_format(format)
+            if spec is None:
+                raise ValueError(
+                    f'Unknown raster format "{format}".  Known formats:  ' + ", ".join(format_names())
+                )
+            return [spec]
 
-        # This returns a list because load_FITS_dataset could possibly return a list
-        return [RasterDataSet(impl, data_cache)]
+        return candidates_for(path)
 
-    def load_FITS_dataset(self, impl: RasterDataImpl, data_cache: "DataCache") -> List[RasterDataSet]:
-        # We should show the Fits dialog which should return to us
-        self._fits_dialog = FitsDatasetLoadingDialog(impl, data_cache)
-        result = self._fits_dialog.exec()
+    def _rank_candidates(self, path: str, candidates: List[FormatSpec]) -> List[FormatSpec]:
+        """
+        Narrow ``candidates`` to those worth opening, in the order to try them.
 
-        if result == QDialog.Accepted:
-            return self._fits_dialog.return_datasets
-        return []
+        Each candidate is asked to :meth:`~.RasterDataImpl.identify` the file --
+        a cheap check that opens nothing.  The first that answers
+        :attr:`Confidence.YES` wins outright and the walk stops there, so a
+        confident format is never overtaken by one that merely could have
+        worked.  Anything answering :attr:`Confidence.NO` is dropped.
+
+        Formats that are merely plausible follow the winner, in priority order,
+        as fallbacks in case the winner turns out to be unreadable.
+        """
+        winner: Optional[FormatSpec] = None
+        maybes: List[FormatSpec] = []
+
+        for spec in candidates:
+            try:
+                confidence = spec.impl.identify(path)
+            except Exception as e:
+                # identify() is documented not to raise, but a broken one must
+                # not take down the whole load.
+                logger.debug("identify() raised for format %s on %s:  %s", spec.name, path, e)
+                continue
+
+            if confidence == Confidence.YES:
+                winner = spec
+                break
+            if confidence == Confidence.MAYBE:
+                maybes.append(spec)
+
+        if winner is None:
+            return maybes
+        return [winner] + maybes
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
 
     def load_from_file(
-        self, path, data_cache=None, interactive=True, subdataset_name=""
+        self,
+        path,
+        data_cache=None,
+        interactive=True,
+        subdataset_name="",
+        format: Optional[str] = None,
     ) -> List[RasterDataSet]:
         """
-        Load a raster data-set from the specified path.  Returns a
-        list of :class:`RasterDataSet` object.
+        Load a raster data-set from the specified path.  Returns a list of
+        :class:`RasterDataSet` objects -- a list, because one file may contain
+        several sub-datasets.
+
+        :param path: the file to load.
+        :param data_cache: cache the resulting datasets should read through.
+        :param interactive: when False, never prompt; make a sensible default
+            choice instead.  Required for project restore and headless use.
+        :param subdataset_name: open this specific sub-dataset rather than
+            asking which one is wanted.
+        :param format: force a specific registered format by name (for example
+            ``"ENVI"``).  When given, no other format is tried and a failure is
+            raised rather than silently falling back to guessing.
+
+        Raises :class:`FileNotFoundError` if the path does not exist, or
+        :class:`ValueError` if no registered format can read it.
         """
         if not os.path.exists(path):
             raise FileNotFoundError(f"File path {path} does not exist!")
-        # Iterate through all supported formats, and try to use each one to
-        # load the raster data.
-        impl_list = None
-        for driver_name, impl_type in self._formats.items():
+
+        candidates = self._candidate_formats(path, format)
+        attempts = self._rank_candidates(path, candidates)
+
+        if not attempts:
+            raise ValueError(f"Couldn't load file {path}:  unsupported format")
+
+        spec, impl_list = self._open_first_that_works(path, attempts, interactive, subdataset_name)
+
+        # An empty (rather than None) result means the format opened the file but
+        # deliberately produced nothing -- the user cancelled a sub-dataset
+        # prompt.  That is a decision, not a failure, so don't try other formats.
+        if not impl_list:
+            return []
+
+        logger.debug("Loaded %s as format %s", path, spec.name)
+        return self._build_datasets(path, spec, impl_list, data_cache)
+
+    def _open_first_that_works(
+        self,
+        path: str,
+        attempts: List[FormatSpec],
+        interactive: bool,
+        subdataset_name: str,
+    ) -> Tuple[FormatSpec, List[RasterDataImpl]]:
+        """
+        Open ``path`` with the first spec in ``attempts`` that succeeds.
+
+        In the normal case the first attempt is a format that positively
+        identified the file, so exactly one file handle is ever opened.  The
+        remaining entries only matter when a file identifies as a format but
+        then turns out to be unreadable.
+        """
+        errors: List[str] = []
+
+        for spec in attempts:
             try:
                 if subdataset_name:
-                    impl_list = impl_type.try_load_file(
+                    impl_list = spec.impl.try_load_file(
                         path, subdataset_name=subdataset_name, interactive=interactive
                     )
                 else:
-                    impl_list = impl_type.try_load_file(path, interactive=interactive)
+                    impl_list = spec.impl.try_load_file(path, interactive=interactive)
             except Exception as e:
-                logger.debug(
-                    "Couldn't load file %s with driver %s and implementation %s. Error: %s",
-                    path,
-                    driver_name,
-                    impl_type,
-                    e,
-                )
+                logger.debug("Couldn't load %s as format %s:  %s", path, spec.name, e)
+                errors.append(f"{spec.name}: {e}")
+                continue
 
-        # Try luck with gdal
-        try:
-            if impl_list is None:
-                impl_list = GDALRasterDataImpl.try_load_file(path, interactive=interactive)
-        except Exception as e:
-            logger.debug(
-                f"Couldn't load file {path} with driver " + f"{driver_name} and implementation {impl_type}.",
-                e,
-            )
+            if impl_list is not None:
+                return spec, impl_list
 
-        if impl_list is None:
-            raise Exception(f"Couldn't load file {path}:  unsupported format")
+            errors.append(f"{spec.name}: returned no implementation")
 
-        # Used if a dataset contains multiple subdatasets and we want to load all of them
-        outer_datasets = []
+        detail = "; ".join(errors) if errors else "no format claimed the file"
+        raise ValueError(f"Couldn't load file {path}:  unsupported format ({detail})")
+
+    def _build_datasets(
+        self,
+        path: str,
+        spec: FormatSpec,
+        impl_list: List[RasterDataImpl],
+        data_cache: "DataCache",
+    ) -> List[RasterDataSet]:
+        """Turn opened implementations into named datasets."""
+        datasets: List[RasterDataSet] = []
+
         for impl in impl_list:
-            func = self._format_loaders[type(impl)]
-            datasets = func(impl, data_cache)
-            for ds in datasets:
-                files = ds.get_filepaths()
-                if files:
-                    name = os.path.basename(files[0])
-                else:
-                    name = os.path.basename(path)
-                subdataset_name = ds.get_subdataset_name()
-                if subdataset_name is not None:
-                    name += ":" + subdataset_name.split(":")[-1]
+            for ds in spec.loader(impl, data_cache):
+                ds.set_name(self._dataset_name(path, ds))
+                datasets.append(ds)
 
-                ds.set_name(name)
-                outer_datasets.append(ds)
+        return datasets
 
-        return outer_datasets
+    @staticmethod
+    def _dataset_name(path: str, ds: RasterDataSet) -> str:
+        """
+        Name a dataset after its own file, falling back to the requested path,
+        and qualify it with the sub-dataset name when there is one.
+        """
+        files = ds.get_filepaths()
+        name = os.path.basename(files[0]) if files else os.path.basename(path)
+
+        subdataset_name = ds.get_subdataset_name()
+        if subdataset_name is not None:
+            name += ":" + subdataset_name.split(":")[-1]
+
+        return name
+
+    # ------------------------------------------------------------------
+    # Saving and in-memory construction
+    # ------------------------------------------------------------------
 
     def get_save_filenames(self, path: str, format: str = "ENVI") -> List[str]:
         if format == "ENVI":


### PR DESCRIPTION
## What does this change do?

Makes dataset matching better. Closes #667 Closes #744

Rewrites how WISER decides *which* raster format should open a given file. Format
selection used to be an accident of dict ordering; it is now a declared,
inspectable registry with a cheap identification step and an explicit override.

> **Note on the branch name.** This branch is called `feat/ds-load-thread`, but
> **it does not add threading.** Nothing here moves work off the UI thread. What
> it does is restructure dataset loading so that developers have control
> over which format opens a file — which is the prerequisite that was missing
> before threading could be attempted.

## What type of PR is this? (check all applicable)
- [ ] Feature
- [x] Bug Fix
- [x] Documentation Update
- [ ] Style
- [x] Code Refactor
- [x] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?

`RasterDataLoader.load_from_file` picked a format by attempting **every**
registered loader against the file and keeping whichever happened to succeed.
The loop had no `break`, so `impl_list` was reassigned on every success and the
**last** format to succeed won — meaning which implementation opened a file
depended on the declaration order of a dict, not on anything about the file.

That had several consequences:

- **No control over format selection.** A developer could not say "open this as
  ENVI". There was no way to express intent, and no way to predict which format
  would be chosen for an ambiguous file.
- **No granularity per file type.** Every format got the same treatment. There
  was nowhere to hang behavior specific to one format.
- **Adding a format meant editing three separate structures** (`_formats`,
  `_format_loaders`, and the impl itself), which had already drifted apart.

### Bugs this fixes

| Bug | Detail |
|-----|--------|
| **Last-match-wins format selection** | Missing `break` in the attempt loop meant format priority was reverse dict-declaration order: PDS4 > PDS3 > JP2 > ASCII > NetCDF > GTiff > ENVI. An `.img` that both the ENVI and PDS drivers accepted resolved to PDS3. |
| **Leaked GDAL handles** | Every successful attempt opened a `gdal.Dataset` and all but one were discarded, so a file several drivers accepted was fully opened several times per load. |
| **ENVI `.dat` cubes could not be opened** | `get_load_filename` tried only the bare stem and `.img`, so selecting `scene.hdr` beside `scene.dat` raised `ValueError` — despite `*.hdr` being offered in the file-open dialog. |
| **GeoTIFF `.tiff` world files could not be resolved** | `.tfw` mapped only to `.tif`, never `.tiff`, though the dialog filter offers `*.tiff`. |
| **ENVI claimed unrelated rasters** | GDAL's ENVI driver identifies any file with a same-stem `.hdr` beside it, so a stray `scene.hdr` next to an unrelated `scene.tif` made the GeoTIFF look like an ENVI dataset. |
| **Projects re-detected format on every open** | A saved project recorded no format, so a registry change or a new file appearing beside the data could silently reopen a dataset through a different implementation than the one it was saved with. |
| **Platform-dependent test** | `test_subdataset_recorded_as_base_path_and_descriptor` hardcoded POSIX paths and failed on Windows (`'C:\data\scene.nc' == '/data/scene.nc'`). |

## How did you implement the change?

**A format registry.** `src/wiser/raster/format_registry.py` declares one
`FormatSpec` per format — implementation class, claimed extensions, priority,
dataset-construction strategy, and whether opening can block on a dialog.
Registering a format is now a single entry rather than three, so the impl and
the dispatch tables cannot drift apart.

**Extensions order, they do not gate.** Candidates are ranked
extension-claimants first (by priority), then everything else (by priority), then
the GDAL catch-all. A format is never *excluded* for failing to claim the path's
extension, because extensions here are genuinely ambiguous (`.img` is ENVI *and*
PDS3; `.hdr` is a raster header *and* a spectral library; `.xml` is PDS4 and much
else). This keeps files with unusual or absent extensions loadable.

**A cheap `identify()` before any open.** Each candidate is asked whether it
recognizes the file; the first positive match wins and the search stops. For
GDAL-backed formats this delegates to `gdal.IdentifyDriverEx`, which runs the
driver's own `Identify()` **without opening the dataset** — so WISER does not
duplicate GDAL's magic-byte checks and cannot drift from them. Only the winner
is opened: one file handle per load instead of one per accepting driver.

**Explicit overrides.** `load_from_file(..., format="ENVI")` skips detection
entirely and fails loudly rather than silently guessing again. Three callers use
it: programmatic callers, the file-open dialog (the user's selected filter was
previously discarded), and project restore.

**Declared sidecar resolution.** `DATA_EXTENSIONS` / `SIDECAR_EXTENSIONS` replace
the per-class `get_load_filename` implementations. The same list does double
duty: it resolves `scene.hdr` → `scene.dat`, *and* it stops a format claiming a
file whose extension it does not recognize.

### Files touched

| File | Change |
|------|--------|
| `src/wiser/raster/format_registry.py` | **New.** `FormatSpec`, `RASTER_FORMATS`, `candidates_for`, `get_format`, `format_for_impl`. |
| `src/wiser/raster/dataset_impl.py` | `Confidence` enum; `identify()` on the base and on `GDALRasterDataImpl`; generic `get_load_filename`; driver declarations per subclass. |
| `src/wiser/raster/loader.py` | `load_from_file` rewritten around order → identify → open-the-winner; `format=` parameter. |
| `src/wiser/raster/dataset.py` | `get_impl()` accessor. |
| `src/wiser/gui/app.py`, `app_state.py` | Dialog filters paired with format names; selected filter threaded through as an override. |
| `src/wiser/project/persisters/datasets.py` | Record the opening format in the manifest; honor it on restore. |

## Added tests?
- [x] yes
- [ ] no, because they aren’t needed
- [ ] no, because I need help

26 new tests in `src/tests/test_format_registry.py` covering registry shape,
candidate ordering, `identify()` behavior (including that it opens no handle),
the single-open guarantee, override semantics, and both sidecar regressions.
3 new tests in `src/tests/test_project_datasets.py` for the manifest format field
— round-trip, a manifest written before the field existed, and one naming a
format no longer registered.

## Added to documentation?
- [x] yes
- [ ] no documentation needed

- `developer-content/raster-format-dispatch.md` — **new.** How dispatch works,
  why extensions order rather than gate, and a step-by-step guide with a
  checklist for adding a new file type.
- `user-content/opening-data-files.md` — **new.** Explains that the file type
  chosen in the Open dialog matters, which file to pick for multi-file datasets,
  and troubleshooting.
- `index.rst` — format list corrected (FITS and ASCII Grid were missing; PDS
  split into PDS3 and PDS4).

## Checklist
- [X] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [X] No new lint/style issues introduced
- [X] Branch is up-to-date with main/master
- [ ] All CI checks passed

## Desktop Screenshots/Recordings

Not applicable — no visible UI change beyond the file-open dialog's type list,
which gains **FITS** and **ASCII Grid** entries and splits the single **PDS**
entry into **PDS3** and **PDS4** (a combined PDS filter cannot name one format,
so the override would have been inert for it).

## [optional] Are there any post-merge tasks we need to perform?

1. **Confirm the ENVI data-extension list against real data.** It is currently
   `("", ".img", ".dat")`. `.bin`, `.bsq`, `.bil`, and `.bip` also appear in the
   wild and may be worth adding.

2. **Developer environment note (not a merge blocker).** If netCDF tests fail
   locally with `Can't load requested DLL: ...gdal_netCDF.dll`, check for a
   machine-scope `GDAL_DRIVER_PATH` pointing at a *different* conda environment.
   Conda envs set this themselves on activation; a stale machine-level value
   overrides them and loads plugins from the wrong GDAL build.
