### PR TITLE
fix: Three quick wins — spectra-import tests, ROI spectrum color, scrollable plugin panels

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/extending-wiser/ui_plugins.rst
+++ b/doc/sphinx-general-wiser-docs/source/extending-wiser/ui_plugins.rst
@@ -193,3 +193,25 @@ very simple:
 
                 # Compute the Gaussian blur based on the parameters
                 ...
+
+Making a plugin panel scrollable
+--------------------------------
+
+A plugin panel with many inputs -- a long list of parameters, for example --
+can easily grow taller than the screen, leaving some controls unreachable.
+Wrap the panel's content in a scroll area with the ``make_scrollable()`` helper
+so that scrollbars appear whenever the content does not fit:
+
+.. code-block:: python
+
+    from wiser import plugins
+
+    content = plugins.load_ui_file(path)      # or any hand-built QWidget
+    scrollable = plugins.make_scrollable(content)
+
+    # Use the scroll area wherever the content widget would have gone, e.g.
+    # as the central widget of the plugin's window or inside a layout.
+    layout.addWidget(scrollable)
+
+The returned ``QScrollArea`` resizes its content with the window, so the
+scrollbars only appear when the panel genuinely does not fit.

--- a/src/tests/test_avg_spectrum.py
+++ b/src/tests/test_avg_spectrum.py
@@ -11,6 +11,7 @@ This module verifies:
 Tests include GUI-based and non-GUI validation for datasets represented as
 NumPy arrays and ENVI files on disk.
 """
+
 import unittest
 from pathlib import Path
 
@@ -226,6 +227,16 @@ class TestRoiAvgSpectrum(unittest.TestCase):
                 wiser_ui.close()
             app.quit()
             del app
+
+    def test_roi_avg_spectrum_defaults_to_roi_color(self):
+        """The extracted spectrum's plot color follows its ROI's color, so the
+        spectrum is visually tied to the region it came from (#731 / #99)."""
+        (dataset,) = RasterDataLoader().load_from_file(str(_JPL_HDR), interactive=False)
+        roi = RegionOfInterest(name="rocks", color="#12ab34")
+
+        spectrum = ROIAverageSpectrum(dataset, roi)
+
+        self.assertEqual(spectrum.get_color(), "#12ab34")
 
     def test_raster_to_combined_rectangles1(self):
         raster1 = np.array(

--- a/src/tests/test_plugins_utils.py
+++ b/src/tests/test_plugins_utils.py
@@ -55,3 +55,21 @@ class TestPluginsUtils(unittest.TestCase):
         """The BandMathPlugin type should be reported as a plugin."""
         p = plugins.BandMathPlugin()
         self.assertTrue(utils.is_plugin(p))
+
+    # ======================================================
+    # plugins.utils.make_scrollable()
+
+    def test_make_scrollable_wraps_widget(self):
+        """make_scrollable() returns a resizable QScrollArea holding the
+        widget, so an oversized plugin panel scrolls instead of being cut
+        off."""
+        from PySide6.QtWidgets import QApplication, QLabel, QScrollArea
+
+        _ = QApplication.instance() or QApplication([])
+        content = QLabel("plugin panel")
+
+        area = plugins.make_scrollable(content)
+
+        self.assertIsInstance(area, QScrollArea)
+        self.assertIs(area.widget(), content)
+        self.assertTrue(area.widgetResizable())

--- a/src/tests/test_spectra_text_import_export.py
+++ b/src/tests/test_spectra_text_import_export.py
@@ -171,6 +171,72 @@ class TestTrailingDelimiterImport(unittest.TestCase):
         np.testing.assert_allclose(spectra[1].get_spectrum(), [2, 5, 8])
         np.testing.assert_allclose(spectra[2].get_spectrum(), [3, 6])
 
+    def test_comma_delimited_trailing_padding_is_stripped(self):
+        """The comma-delimited flavor of the Excel export (the exact example
+        from issue #725): every row carries a long run of trailing commas that
+        must not become phantom spectra."""
+        trailing = "," * 19
+        lines = [
+            "Wavelength_um,ARKSAW_18_G,ARKSAW_15_TS,ARKSAW_17_M" + trailing + "\n",
+            "0.3466,26.5672,19.726,27.2727" + trailing + "\n",
+            "0.3482,26.9417,19.3805,27.3134" + trailing + "\n",
+            "0.3498,26.8571,19.6957,27.2464" + trailing + "\n",
+            "0.3514,26.682,19.7034,27.0283" + trailing + "\n",
+            "0.353,27.1622,19.7531,27.6606" + trailing + "\n",
+        ]
+
+        spectra = import_spectra_text(
+            lines,
+            delim=",",
+            has_header=True,
+            wavelength_cols=WavelengthCols.FIRST_COL,
+        )
+
+        self.assertEqual(
+            [s.get_name() for s in spectra],
+            ["ARKSAW_18_G", "ARKSAW_15_TS", "ARKSAW_17_M"],
+        )
+        self.assertTrue(all(s.num_bands() == 5 for s in spectra))
+        np.testing.assert_allclose(spectra[0].get_spectrum(), [26.5672, 26.9417, 26.8571, 26.682, 27.1622])
+
+    def test_stray_value_in_padding_region_is_an_error(self):
+        """A value sitting in the padding region (beyond the real columns) is
+        not padding -- the row genuinely has more columns than the header, and
+        the import must reject it rather than silently dropping the value."""
+        lines = [
+            "Wavelength_um,ARKSAW_18_G,ARKSAW_15_TS,ARKSAW_17_M,,,\n",
+            "0.3466,26.5672,19.726,27.2727,,,\n",
+            "0.3482,26.9417,19.3805,27.3134,,3.14,\n",
+        ]
+
+        with self.assertRaises(ValueError):
+            import_spectra_text(
+                lines,
+                delim=",",
+                has_header=True,
+                wavelength_cols=WavelengthCols.FIRST_COL,
+            )
+
+    def test_header_only_column_is_kept_as_empty_spectrum(self):
+        """A column that has a header name but no values is a real (if empty)
+        spectrum, not padding: the name is within the real column count, so the
+        spectrum is kept with zero bands."""
+        lines = [
+            "Wavelength_um,ARKSAW_18_G,EMPTY_SAMPLE,,\n",
+            "0.3466,26.5672,,,\n",
+            "0.3482,26.9417,,,\n",
+        ]
+
+        spectra = import_spectra_text(
+            lines,
+            delim=",",
+            has_header=True,
+            wavelength_cols=WavelengthCols.FIRST_COL,
+        )
+
+        self.assertEqual([s.get_name() for s in spectra], ["ARKSAW_18_G", "EMPTY_SAMPLE"])
+        self.assertEqual([s.num_bands() for s in spectra], [2, 0])
+
 
 class TestExportImportRoundTrip(unittest.TestCase):
     """Bug 3: spectra exported by WISER should be re-importable."""

--- a/src/tests/test_spectra_text_import_export.py
+++ b/src/tests/test_spectra_text_import_export.py
@@ -202,14 +202,16 @@ class TestTrailingDelimiterImport(unittest.TestCase):
     def test_stray_value_in_padding_region_is_an_error(self):
         """A value sitting in the padding region (beyond the real columns) is
         not padding -- the row genuinely has more columns than the header, and
-        the import must reject it rather than silently dropping the value."""
+        the import must reject it rather than silently dropping the value.
+        The error names the stray value and its column, since post-stripping
+        column counts would not match what the user sees in their file."""
         lines = [
             "Wavelength_um,ARKSAW_18_G,ARKSAW_15_TS,ARKSAW_17_M,,,\n",
             "0.3466,26.5672,19.726,27.2727,,,\n",
             "0.3482,26.9417,19.3805,27.3134,,3.14,\n",
         ]
 
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r"'3\.14'.*column 6"):
             import_spectra_text(
                 lines,
                 delim=",",

--- a/src/wiser/gui/import_spectra_text.py
+++ b/src/wiser/gui/import_spectra_text.py
@@ -1,7 +1,7 @@
+import logging
 import math
 import os
 import sys
-import traceback
 
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -14,6 +14,8 @@ from astropy import units as u
 from .generated.import_spectra_text_ui import Ui_ImportSpectraTextDialog
 
 from wiser.raster import spectra_export
+
+logger = logging.getLogger(__name__)
 
 
 def avg_occurrences_per_line(lines, ch):
@@ -193,7 +195,10 @@ class ImportSpectraTextDialog(QDialog):
             self._spectra = spectra
 
         except Exception as e:
-            traceback.print_exc()
+            # The failure is shown in the results pane; parse errors while the
+            # user is dialing in the configuration are expected, so keep the
+            # console quiet and record the traceback at debug level only.
+            logger.debug("Could not parse text into spectra", exc_info=True)
 
             msg = self.tr(
                 '<p style="color:red">ERROR:  Could not parse text into spectra.</p><p>Reason:  {0}</p>'

--- a/src/wiser/plugins/__init__.py
+++ b/src/wiser/plugins/__init__.py
@@ -7,7 +7,7 @@ from .types import Plugin, ToolsMenuPlugin, ContextMenuPlugin, BandMathPlugin
 
 from .decorators import log_exceptions
 
-from .utils import load_ui_file
+from .utils import load_ui_file, make_scrollable
 
 __all__ = [
     "ToolsMenuPlugin",
@@ -16,4 +16,5 @@ __all__ = [
     "ContextMenuType",
     "log_exceptions",
     "load_ui_file",
+    "make_scrollable",
 ]

--- a/src/wiser/plugins/utils.py
+++ b/src/wiser/plugins/utils.py
@@ -7,7 +7,7 @@ from .types import Plugin, ToolsMenuPlugin, ContextMenuPlugin, BandMathPlugin
 
 from PySide6.QtCore import QFile
 from PySide6.QtUiTools import QUiLoader
-from PySide6.QtWidgets import QWidget
+from PySide6.QtWidgets import QScrollArea, QWidget
 
 
 logger = logging.getLogger(__name__)
@@ -39,6 +39,26 @@ def instantiate(fully_qualified_class_name: str) -> Plugin:
     module_obj = importlib.import_module(module_name)
     class_obj = getattr(module_obj, class_name)
     return class_obj()
+
+
+def make_scrollable(widget: QWidget, parent: Optional[QWidget] = None) -> QScrollArea:
+    """
+    Wraps the given widget in a QScrollArea so that a plugin panel taller or
+    wider than the available window space scrolls instead of being cut off.
+    Scrollbars only appear when the content doesn't fit.
+
+    Typical use, from a plugin building its GUI:
+
+        content = load_ui_file(path)          # or any hand-built QWidget
+        scrollable = make_scrollable(content)
+        layout.addWidget(scrollable)          # or show it as the window itself
+
+    Returns the QScrollArea containing ``widget``.
+    """
+    area = QScrollArea(parent)
+    area.setWidget(widget)
+    area.setWidgetResizable(True)
+    return area
 
 
 def load_ui_file(ui_file_path: str, parent: Optional[QWidget] = None) -> QWidget:

--- a/src/wiser/raster/spectra_export.py
+++ b/src/wiser/raster/spectra_export.py
@@ -243,7 +243,7 @@ class ImportedSpectrumData:
 
         # Try to match the "all-bands name" pattern that WISER outputs.  This is
         # likely not present in other sources of spectral data.
-        m = re.fullmatch("Wavelength \(([^)]*)\)", self.allbands_name)
+        m = re.fullmatch(r"Wavelength \(([^)]*)\)", self.allbands_name)
         if m:
             return m.group(1).strip()
 
@@ -496,10 +496,23 @@ def import_spectra_text(
 
         # Every row must match the real column count.  A row with fewer columns,
         # or with actual (non-blank) data beyond the expected columns, is a
-        # genuine mismatch and is rejected.
-        if len(line_parts) != num_cols:
+        # genuine mismatch and is rejected.  For the too-many case, name the
+        # stray value and its column:  the raw file may end every row in a run
+        # of delimiters, so a post-stripping column count alone would not match
+        # what the user sees in their file.
+        if len(line_parts) > num_cols:
+            stray = next(i for i in range(num_cols, len(line_parts)) if line_parts[i].strip() != "")
             raise ValueError(
-                f"Line {line_no} has {len(line_parts)} columns, "
+                f"Line {line_no} has a value ({line_parts[stray].strip()!r}) in "
+                + f"column {stray + 1}, but the first line establishes only "
+                + f"{num_cols} real columns.  Empty trailing columns (extra "
+                + "delimiters from a spreadsheet export) are ignored, but a "
+                + "column holding a value is never discarded."
+            )
+
+        if len(line_parts) < num_cols:
+            raise ValueError(
+                f"Line {line_no} has only {len(line_parts)} columns, "
                 + f"but the first line has {num_cols} columns."
             )
 

--- a/src/wiser/raster/spectrum.py
+++ b/src/wiser/raster/spectrum.py
@@ -720,6 +720,11 @@ class ROIAverageSpectrum(RasterDataSetSpectrum):
         self._roi: RegionOfInterest = roi
         self.set_avg_mode(avg_mode)
 
+        # Default the plot color to the ROI's color so the spectrum is
+        # visually tied to its region; callers may still override it.
+        if roi.get_color() is not None:
+            self.set_color(roi.get_color())
+
     def get_roi(self) -> RegionOfInterest:
         return self._roi
 


### PR DESCRIPTION
## What does this change do?

Three small, independent fixes from the issue backlog, one commit each.
Closes #725. Closes #731. Closes #99. Closes #735.

- **#725** — adds the acceptance tests the issue calls for (comma-delimited
  Excel-export example, stray value in the padding region is an error,
  header-only column is kept as an empty spectrum). The fix itself already
  landed in f5705a52; these tests pin the behavior.
- **#731 / #99** — an ROI's average spectrum now defaults its plot color to
  the ROI's color, so the spectrum is visually tied to its region. #99 is the
  same request, filed earlier.
- **#735** — new `wiser.plugins.make_scrollable(widget)` helper so plugin
  authors can wrap an oversized panel in a resizable `QScrollArea` with one
  line, plus a section in the "Extending WISER" GUI-plugins docs.

## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] Chore
- [ ] Revert

## Why is this change needed?

User-reported issues: #731, #735, and the requests behind #725 came from users
(#735 and #731 from omkamps, an active plugin author); #99 is the same
color request from 2024. #725's issue text promised specific acceptance tests
that did not exist yet.

## How did you implement the change?

- ROI color: `ROIAverageSpectrum.__init__` slor())`.
  The spectrum plot already prefers a pre-set color over assigning a random
  one, ROI colors are validated as matplotliitor,
  and project restore still applies any persisted color on top of the default.
- Scrollable plugins: plugins build their ownot wrap
  them centrally; `make_scrollable` is an opt-in helper in `wiser.plugins`
  (alongside `load_ui_file`), exported from  in
  `extending-wiser/ui_plugins.rst`. Scrollbars appear only when the content
  does not fit.
- Spectra-import tests: three new cases in
  `TestTrailingDelimiterImport` exercising t
  `real_width`/`strip_padding` logic.

## Added tests?
- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

5 new tests: 3 for #725, 1 for #731, 1 for #
test_spectra_text_import_export.py 8/8, test_avg_spectrum.py +
test_project_spectra.py 23/23, test_plugins_n_add.py
11/11 (headless, QT_QPA_PLATFORM=offscreen).

## Added to documentation?
- [x] yes
- [ ] no documentation needed

New "Making a plugin panel scrollable" section in the Extending WISER
GUI-plugins page. Sphinx build verified loca

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [ ] All CI checks passed

## Desktop Screenshots/Recordings

Not applicable — no WISER UI change; the scroll behavior is opt-in for plugin
authors.

## [optional] Are there any post-merge tasks

- Comment on #735 (and optionally #726) poin
  `plugins.make_scrollable()` so he can pick it up in his parameter plugin.
- #99 closes as a duplicate of #731 via this