### PR TITLE
feat: Back up release assets to Nexus (#750)

### DIFF
--- a/.github/workflows/backup-releases-to-nexus.yml
+++ b/.github/workflows/backup-releases-to-nexus.yml
@@ -1,0 +1,119 @@
+# Mirrors each release's assets into the LASP Nexus raw repository, so the installers
+# survive loss of the GitHub repository. The GitHub release page stays the place users
+# download from; Nexus is the archive of record behind it.
+#
+# The trigger is `released`, not `published`, on purpose: the release process publishes a
+# release as a pre-release first and attaches the installers afterwards, so `published`
+# would fire while the release is still empty. `released` fires when the pre-release flag
+# is cleared, by which point every asset is attached.
+#
+# The weekly run reconciles the whole history — it re-checks every release and uploads only
+# what is missing, so a failed or skipped release-time run repairs itself rather than
+# leaving a silent gap.
+#
+# Only the /repository/ path of the Nexus host is published outside the LASP network
+# (the internal name is not in public DNS), which is why the script uses plain PUT/GET/HEAD
+# against the raw repository and not the Nexus REST API.
+name: Back up release assets to Nexus
+
+on:
+  release:
+    types: [released]
+  schedule:
+    - cron: "0 7 * * 1"      # Mondays 07:00 UTC — reconcile the full release history
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to back up (ignored when 'all' is checked)"
+        required: false
+      all:
+        description: "Back up every non-draft release"
+        type: boolean
+        default: false
+      force:
+        description: "Re-upload objects already present in Nexus"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Report what would transfer without uploading"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # Uploads are idempotent, but overlapping runs would duplicate ~12 GiB of transfer.
+  group: backup-releases-to-nexus
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Back up release assets to Nexus
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_URL: ${{ vars.NEXUS_RAW_URL }}
+          EVENT: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_ALL: ${{ inputs.all }}
+          INPUT_FORCE: ${{ inputs.force }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${NEXUS_USERNAME}" ] || [ -z "${NEXUS_PASSWORD}" ]; then
+            echo "::error::NEXUS_USERNAME / NEXUS_PASSWORD secrets are not configured."
+            exit 1
+          fi
+
+          args=()
+          case "${EVENT}" in
+            release)
+              args+=(--tag "${RELEASE_TAG}")
+              ;;
+            schedule)
+              args+=(--all)
+              ;;
+            workflow_dispatch)
+              if [ "${INPUT_ALL}" = "true" ]; then
+                args+=(--all)
+              elif [ -n "${INPUT_TAG}" ]; then
+                args+=(--tag "${INPUT_TAG}")
+              else
+                echo "::error::Provide a tag, or check 'all'."
+                exit 1
+              fi
+              if [ "${INPUT_FORCE}" = "true" ]; then
+                args+=(--force)
+              fi
+              if [ "${INPUT_DRY_RUN}" = "true" ]; then
+                args+=(--dry-run)
+              fi
+              ;;
+            *)
+              echo "::error::Unsupported event '${EVENT}'."
+              exit 1
+              ;;
+          esac
+
+          # Validate the tag shape so a typo fails fast (it is passed via env, so it cannot
+          # inject shell in any case).
+          for i in "${!args[@]}"; do
+            if [ "${args[$i]}" = "--tag" ]; then
+              tag="${args[$((i + 1))]}"
+              if ! [[ "${tag}" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+                echo "::error::tag '${tag}' has unexpected characters."
+                exit 1
+              fi
+            fi
+          done
+
+          python3 src/devtools/backup_releases_to_nexus.py "${args[@]}"

--- a/Makefile
+++ b/Makefile
@@ -130,4 +130,18 @@ sign-windows:  # Usage `make sign-windows LINK=https://github.com/Ehlmann-resear
 	@rem Call Python script with args
 	@python src\devtools\sign_windows.py --link "$(LINK)" --nsis $(NSIS) --app-version "$(APP_VERSION)" --sha1 "$(SHA1_THUMBPRINT)" $(if $(RELEASE_TAG),--release-tag "$(RELEASE_TAG)",)
 
-.PHONY: generated lint typecheck build-mac build-win clean sign-windows
+# Mirror release assets to the Nexus raw repository. Normally this runs in CI
+# (.github/workflows/backup-releases-to-nexus.yml); use this to backfill or to check the
+# archive by hand. Credentials come from Secret.mk or the environment.
+# Usage `make backup-releases TAG=v3.0b0`, or `make backup-releases ALL=1 DRY_RUN=1`.
+backup-releases:
+	@if [ -z "$(TAG)" ] && [ -z "$(ALL)" ]; then \
+		echo "ERROR: Provide TAG=<tag> or ALL=1"; \
+		exit 1; \
+	fi
+	@NEXUS_USERNAME="$(NEXUS_USERNAME)" NEXUS_PASSWORD="$(NEXUS_PASSWORD)" \
+		python src/devtools/backup_releases_to_nexus.py \
+		$(if $(TAG),--tag "$(TAG)",) $(if $(ALL),--all,) \
+		$(if $(FORCE),--force,) $(if $(DRY_RUN),--dry-run,)
+
+.PHONY: generated lint typecheck build-mac build-win clean sign-windows backup-releases

--- a/Secret-template.mk
+++ b/Secret-template.mk
@@ -22,3 +22,12 @@ AD_TEAM_ID=your-app-specific-team-id
 # Windows Secrets
 
 SHA1_THUMBPRINT=your.sha1.thumbprint.for.yubikey
+
+#-----------------------------------------------------------------------------
+# Nexus Secrets
+#
+# Credentials for the release-asset backup (`make backup-releases`). Use a Nexus
+# user token rather than your account password.
+
+NEXUS_USERNAME=your-nexus-user-token-name
+NEXUS_PASSWORD=your-nexus-user-token-passcode

--- a/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/ci-cd-and-releases.md
@@ -185,6 +185,50 @@ bits you ship are the exact bits you tested.
   with the canonical name via the sign scripts' `--release-tag <tag>` option (see the
   Release Process below).
 
+### Backup to Nexus
+
+Release assets exist in exactly one place — the GitHub release — and that is a single point
+of failure for every binary WISER has ever shipped. **Back up release assets to Nexus**
+(`backup-releases-to-nexus.yml`) copies each release into the LASP Nexus raw repository at
+`https://lasp.colorado.edu/repository/wiser-raw/`, so the installers survive loss of the
+GitHub repository. GitHub stays the place users download from; Nexus is the archive behind it.
+
+Each release is stored under its tag, alongside the metadata needed to make the copy usable
+on its own:
+
+```
+releases/<tag>/<asset name>                    # exactly as attached to the release
+releases/<tag>/source/WISER-<tag>-source.tar.gz
+releases/<tag>/source/WISER-<tag>-source.zip
+releases/<tag>/manifest.json                   # commit sha, dates, sizes, per-asset SHA-256
+releases/<tag>/SHA256SUMS                      # verify with `sha256sum -c SHA256SUMS`
+releases/<tag>/release-notes.md
+```
+
+The workflow runs on three triggers:
+
+- **`released`** — when a release's pre-release flag is cleared. This is deliberately not
+  `published`: the process below publishes a release *before* attaching installers, so
+  `published` would fire while the release is still empty.
+- **Weekly** (Mondays 07:00 UTC) — re-checks the whole release history and uploads only what
+  is missing, so a failed or skipped run repairs itself instead of leaving a silent gap.
+- **`workflow_dispatch`** — for backfilling a tag or the full history, with `dry run` and
+  `force` options.
+
+Uploads are idempotent: an asset already in Nexus at the right size is skipped, so re-running
+is cheap. Every upload is verified against the SHA-256 GitHub records for the asset and the
+size and SHA-1 Nexus reports back; a mismatch fails the run rather than logging a warning.
+
+The same logic runs by hand for a backfill or a spot check — see `make backup-releases`:
+
+```
+make backup-releases TAG=v3.0b0
+make backup-releases ALL=1 DRY_RUN=1     # report what is missing, upload nothing
+```
+
+Credentials come from `NEXUS_USERNAME` / `NEXUS_PASSWORD` in `Secret.mk` or the environment.
+Configuring the Nexus side is covered in [The Nexus release archive](#the-nexus-release-archive).
+
 ### Pre-release flag
 
 The web `…/releases/latest` and the API `latest` endpoint both **exclude** releases
@@ -253,17 +297,138 @@ release time, so what ships is exactly what you tested.
 9. **Go live** — once every asset is present with its canonical name, uncheck **"Set as a
    pre-release"** (and keep "Set as the latest release" on) so `latest` resolves to it.
 
-10. **Update the plugin API documentation** in
+10. **Confirm the Nexus backup** — clearing the pre-release flag triggers **Back up release
+    assets to Nexus**. Check that the run succeeded and that every asset shows as `uploaded`
+    in its job summary. If it did not fire, dispatch it manually with the tag. See
+    [Backup to Nexus](#backup-to-nexus).
+
+11. **Update the plugin API documentation** in
     `doc/sphinx-general-wiser-docs/source/extending-wiser/` to reflect any changes to plugin
     interfaces or dependencies in the latest version.
 
-11. **Announce** — if you have permission, email wiser-announcements@lists.lasp.colorado.edu with a summary of
+12. **Announce** — if you have permission, email wiser-announcements@lists.lasp.colorado.edu with a summary of
     the release. If not, reach out to someone who deals with the email you want sent.
 
 > **Note**: This process can only be done by a maintainer with
 > access to all of these resources. This intentionally limits who can
 > do official WISER releases. If the community thinks that an official
 > WISER release should be done, please reach out to the maintainers.
+
+## The Nexus release archive
+
+The archive is a **raw hosted** repository named `wiser-raw` on the LASP Nexus, holding a
+copy of every release asset WISER has published. Raw is the right format because these are
+opaque binaries — `.dmg`, `.exe`, `.tar`, `.zip` — with no package semantics for Nexus to
+interpret; a format like maven or npm would force a coordinate scheme that means nothing here.
+
+This section is for whoever administers the Nexus side. The workflow that fills the archive
+is described in [Backup to Nexus](#backup-to-nexus).
+
+### Two hostnames, and why it matters
+
+The server answers to two names, and CI can only use one of them:
+
+| | reachable from | serves |
+|---|---|---|
+| `artifacts.pdmz.lasp.colorado.edu` | LASP network / VPN only | the web UI and the full REST API |
+| `lasp.colorado.edu/repository/…` | the public internet | repository paths only |
+
+Despite the `pdmz` in its name, the internal host is not in public DNS and resolves to a
+private (RFC1918) address, so a GitHub-hosted runner cannot reach it. Everything automated
+must go through `https://lasp.colorado.edu/repository/wiser-raw/`.
+
+The public proxy exposes `/repository/` but **not** `/service/rest/`, so the Nexus REST API —
+search, component listing, repository administration — is unavailable from CI. This is why
+the backup tooling uses only `PUT`, `GET`, and `HEAD` against the raw repository. Anything
+you write against this archive should assume the same constraint.
+
+### Creating the repository
+
+In the Nexus UI (**⚙ → Repository → Repositories → Create repository → raw (hosted)**):
+
+- **Name**: `wiser-raw`
+- **Blob store**: the default, or a dedicated store if you want the archive's usage
+  reported separately. Budget roughly **12 GiB** for the existing history and about
+  **4 GiB per future release**.
+- **Deployment policy**: `Allow redeploy`. The workflow refreshes `manifest.json` and
+  `SHA256SUMS` on every run, which `Disable redeploy` would reject. Immutability comes from
+  the CI account having no delete privilege (below) plus the workflow skipping assets that
+  are already present, rather than from the deployment policy.
+- **Cleanup policies**: **none.** Cleanup policies delete components by age or by last-download
+  date, which is precisely wrong for an archive whose purpose is to retain old releases that
+  nobody downloads. Attaching one silently defeats the backup.
+
+### The CI account
+
+Create a dedicated local user (**Security → Users → Create local user**), for example
+`wiser-ci`, and a role (**Security → Roles**) granting exactly these privileges:
+
+```
+nx-repository-view-raw-wiser-raw-add
+nx-repository-view-raw-wiser-raw-browse
+nx-repository-view-raw-wiser-raw-edit
+nx-repository-view-raw-wiser-raw-read
+```
+
+Note what is absent: **no `-delete`**. CI can add and update, never remove. A leaked CI
+credential then cannot destroy the archive, which is the failure mode that matters most for
+a backup.
+
+This Nexus is licensed as Pro, so prefer a **user token** over the account password. Enable
+**Security → Realms → User Token Realm**, sign in as the service account, and generate its
+token under the account menu. The token's name and passcode are used exactly like a username
+and password in HTTP Basic auth. If your Nexus expires user tokens, put a reminder on the
+calendar — an expired token surfaces as a `401` in the weekly backup run.
+
+### GitHub configuration
+
+In **Settings → Secrets and variables → Actions** on the WISER repository:
+
+| kind | name | value |
+|---|---|---|
+| secret | `NEXUS_USERNAME` | the user-token name code (or the account username) |
+| secret | `NEXUS_PASSWORD` | the user-token passcode (or the account password) |
+| variable *(optional)* | `NEXUS_RAW_URL` | overrides the repository URL if it ever moves |
+
+Secrets are not exposed to workflows triggered by pull requests from forks, and this
+workflow has no `pull_request` trigger, so a fork cannot reach these credentials.
+
+### Verifying the setup
+
+A read needs no credentials; a write does. From anywhere on the internet:
+
+```bash
+# read back a file the backup wrote
+curl -I https://lasp.colorado.edu/repository/wiser-raw/releases/v3.0b0/SHA256SUMS
+
+# confirm the CI account can write
+printf 'ok\n' | curl -u "$NEXUS_USERNAME:$NEXUS_PASSWORD" --upload-file - \
+  https://lasp.colorado.edu/repository/wiser-raw/.probe/hello.txt
+```
+
+An unauthenticated `PUT` returns `401` with a `WWW-Authenticate: BASIC` challenge — that is
+the expected response, and confirms the proxy forwards writes rather than blocking them.
+
+Decide deliberately whether anonymous **read** stays enabled. The assets are already public
+on GitHub, so anonymous read costs nothing and keeps restores simple. Disabling it means
+every restore, and every dry run of the backup tool, needs credentials.
+
+### Restoring from the archive
+
+Each tag directory is self-describing, so a restore needs no tooling beyond `curl`:
+
+```bash
+tag=v3.0b0
+base=https://lasp.colorado.edu/repository/wiser-raw/releases/$tag
+
+curl -sO "$base/SHA256SUMS"
+curl -s "$base/manifest.json" | python3 -m json.tool   # commit sha, dates, sizes
+awk '{print $2}' SHA256SUMS | while read -r name; do curl -sO "$base/$name"; done
+sha256sum -c SHA256SUMS
+```
+
+`manifest.json` records the commit each release was built from, so an archived binary can
+always be traced back to its source revision.
 
 ## GitHub Actions Environment Setup
 

--- a/src/devtools/backup_releases_to_nexus.py
+++ b/src/devtools/backup_releases_to_nexus.py
@@ -203,6 +203,23 @@ def nexus_url(base: str, *parts: str) -> str:
     return "/".join([base.rstrip("/")] + [quote(p) for p in parts])
 
 
+def check_segment(value: str, what: str):
+    """Rejects a value that would not stay one segment of a Nexus path.
+
+    A raw repository stores an object at its path, so a tag or asset name carrying a
+    separator would silently nest the object and break the documented
+    releases/<tag>/<asset> layout. Git ref rules already exclude "..", but a tag may
+    legitimately contain "/" (this repository has `rel/1.1b1`), so the shape is checked
+    where the value enters rather than assumed.
+    """
+    if not value or "/" in value or ".." in value or any(ch < " " or ch == "\x7f" for ch in value):
+        die(
+            f"{what} {value!r} is not a single path segment. Refusing to build an ambiguous "
+            "Nexus path from a value containing a separator, a dot segment, or a control "
+            "character."
+        )
+
+
 def github_headers(token: Optional[str], accept: str = "application/vnd.github+json") -> Dict[str, str]:
     headers = {"Accept": accept, "X-GitHub-Api-Version": "2022-11-28"}
     if token:
@@ -249,13 +266,20 @@ def digest_sha256(asset: dict) -> Optional[str]:
 
 
 def verify_upload(url: str, headers: Dict[str, str], size: int, sha1: str, name: str) -> List[str]:
-    """Confirms what Nexus stored matches what was sent. Returns a list of problems."""
+    """Confirms what Nexus stored matches what was sent. Returns a list of problems.
+
+    A missing size counts as a problem rather than a pass: an upload nothing can confirm is
+    not a backup, so the run reports it instead of claiming success it cannot support. The
+    ETag check stays opportunistic because Nexus does not guarantee the header.
+    """
     stored = head(url, headers)
     if stored is None:
         return [f"{name}: not present in Nexus after upload"]
     problems = []
     remote_size = stored.get("Content-Length")
-    if remote_size is not None and int(remote_size) != size:
+    if remote_size is None:
+        problems.append(f"{name}: Nexus reported no size, leaving the upload unverified")
+    elif int(remote_size) != size:
         problems.append(f"{name}: Nexus reports {remote_size} bytes, expected {size}")
     match = ETAG_SHA1_RE.search(stored.get("ETag", ""))
     if match and match.group(1) != sha1:
@@ -279,6 +303,11 @@ class Backup:
         self.warned_unreadable = False
 
     def path_for(self, tag: str, *parts: str) -> str:
+        # self.prefix is operator-supplied and may intentionally span directories, so only
+        # the values taken from the GitHub API are constrained to one segment.
+        check_segment(tag, "Release tag")
+        for part in parts:
+            check_segment(part, "Asset name")
         return nexus_url(self.base, self.prefix, tag, *parts)
 
     def record(self, status: str, name: str, detail: str = ""):
@@ -528,9 +557,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         if not releases:
             die(f"No published releases found in {args.repo}.")
     else:
-        releases = [
-            request_json(f"{GITHUB_API}/repos/{args.repo}/releases/tags/{args.tag}", github_headers(gh_token))
-        ]
+        url = f"{GITHUB_API}/repos/{args.repo}/releases/tags/{args.tag}"
+        try:
+            releases = [request_json(url, github_headers(gh_token))]
+        except urllib.error.HTTPError as exc:
+            if exc.code != 404:
+                raise
+            die(f"No release found for tag '{args.tag}' in {args.repo}.")
 
     backup = Backup(args, gh_token, nexus_auth)
     log(f"{args.repo} -> {backup.base}/{backup.prefix}/" + ("  [dry run]" if args.dry_run else ""))

--- a/src/devtools/backup_releases_to_nexus.py
+++ b/src/devtools/backup_releases_to_nexus.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Mirror GitHub release assets into the LASP Nexus raw repository.
+
+WISER's installers are published as GitHub release assets. This copies each one into a
+Nexus raw repository so the binaries survive loss of the GitHub repository, together with
+a manifest and a `sha256sum -c`-compatible checksum file that make the copy restorable on
+its own.
+
+Layout written per release, relative to the Nexus repository root:
+
+    releases/<tag>/<asset name>
+    releases/<tag>/source/<repo>-<tag>-source.tar.gz
+    releases/<tag>/source/<repo>-<tag>-source.zip
+    releases/<tag>/manifest.json
+    releases/<tag>/SHA256SUMS
+    releases/<tag>/release-notes.md
+
+Only the `/repository/` path of the Nexus host is reachable from outside the LASP network,
+so this speaks plain PUT/GET/HEAD to the raw repository and never uses the Nexus REST API.
+
+Credentials come from the environment: NEXUS_USERNAME and NEXUS_PASSWORD (a Nexus user
+token secret works in place of a password), plus an optional GITHUB_TOKEN.
+
+Usage:
+    python src/devtools/backup_releases_to_nexus.py --tag v3.0b0
+    python src/devtools/backup_releases_to_nexus.py --all --dry-run
+"""
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import quote, urlsplit
+
+GITHUB_API = "https://api.github.com"
+DEFAULT_REPO = "Ehlmann-research-group/WISER"
+
+# The public reverse proxy in front of the LASP Nexus. The internal name
+# (artifacts.pdmz.lasp.colorado.edu) is not in public DNS and resolves to RFC1918 space, so
+# it is unreachable from GitHub-hosted runners; only this path is published.
+DEFAULT_NEXUS_URL = "https://lasp.colorado.edu/repository/wiser-raw"
+
+CHUNK = 1 << 20
+RETRIES = 3
+TIMEOUT = 600
+RETRY_STATUS = {408, 429, 500, 502, 503, 504}
+
+# Nexus reports a raw asset's SHA-1 in its ETag as {SHA1{<hex>}}.
+ETAG_SHA1_RE = re.compile(r"\{SHA1\{([0-9a-f]{40})\}\}")
+
+
+def die(msg: str, code: int = 1):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def log(msg: str = ""):
+    print(msg, flush=True)
+
+
+class StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
+    """Drops Authorization when a redirect crosses to a different host.
+
+    GitHub answers an asset or source-archive download with a redirect to signed
+    object-storage URLs, which reject a request that also carries an Authorization header.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new is not None and urlsplit(newurl).netloc != urlsplit(req.full_url).netloc:
+            for store in (new.headers, new.unredirected_hdrs):
+                for key in [k for k in store if k.lower() == "authorization"]:
+                    del store[key]
+        return new
+
+
+_OPENER = urllib.request.build_opener(StripAuthOnRedirect)
+
+
+def _attempt(req: urllib.request.Request, timeout: int):
+    return _OPENER.open(req, timeout=timeout)
+
+
+def _retry_sleep(attempt: int):
+    time.sleep(min(2**attempt, 30))
+
+
+def request_json(url: str, headers: Dict[str, str]) -> object:
+    for attempt in range(1, RETRIES + 1):
+        try:
+            with _attempt(urllib.request.Request(url, headers=headers), TIMEOUT) as resp:
+                return json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            if exc.code not in RETRY_STATUS or attempt == RETRIES:
+                raise
+        except OSError:
+            if attempt == RETRIES:
+                raise
+        _retry_sleep(attempt)
+    raise RuntimeError("unreachable")
+
+
+def head(url: str, headers: Dict[str, str]) -> Optional[Dict[str, str]]:
+    """Returns the response headers, or None when the object does not exist."""
+    for attempt in range(1, RETRIES + 1):
+        try:
+            req = urllib.request.Request(url, headers=headers, method="HEAD")
+            with _attempt(req, TIMEOUT) as resp:
+                return dict(resp.headers)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            if exc.code not in RETRY_STATUS or attempt == RETRIES:
+                raise
+        except OSError:
+            if attempt == RETRIES:
+                raise
+        _retry_sleep(attempt)
+    raise RuntimeError("unreachable")
+
+
+def download(url: str, headers: Dict[str, str], dest: Path) -> Tuple[str, str, int]:
+    """Streams *url* to *dest*, returning its (sha256, sha1, size).
+
+    Hashing while streaming keeps peak memory flat and avoids a second pass over an asset
+    that can approach half a gigabyte.
+    """
+    for attempt in range(1, RETRIES + 1):
+        sha256, sha1, size = hashlib.sha256(), hashlib.sha1(), 0
+        try:
+            with _attempt(urllib.request.Request(url, headers=headers), TIMEOUT) as resp:
+                with dest.open("wb") as out:
+                    while True:
+                        block = resp.read(CHUNK)
+                        if not block:
+                            break
+                        out.write(block)
+                        sha256.update(block)
+                        sha1.update(block)
+                        size += len(block)
+            return sha256.hexdigest(), sha1.hexdigest(), size
+        except urllib.error.HTTPError as exc:
+            if exc.code not in RETRY_STATUS or attempt == RETRIES:
+                raise
+        except OSError:
+            if attempt == RETRIES:
+                raise
+        _retry_sleep(attempt)
+    raise RuntimeError("unreachable")
+
+
+def put(url: str, headers: Dict[str, str], source: Path, content_type: str) -> int:
+    """Uploads *source* to *url*, reopening the file per attempt so a retry restarts clean."""
+    for attempt in range(1, RETRIES + 1):
+        size = source.stat().st_size
+        hdrs = dict(headers)
+        hdrs["Content-Type"] = content_type
+        hdrs["Content-Length"] = str(size)
+        try:
+            with source.open("rb") as body:
+                req = urllib.request.Request(url, data=body, headers=hdrs, method="PUT")
+                with _attempt(req, TIMEOUT) as resp:
+                    return resp.status
+        except urllib.error.HTTPError as exc:
+            if exc.code == 401:
+                die("Nexus rejected the credentials (401). Check NEXUS_USERNAME / NEXUS_PASSWORD.")
+            if exc.code == 403:
+                die(f"Nexus refused the upload (403). The account needs add/edit on the raw repo: {url}")
+            if exc.code == 413:
+                die(f"Nexus or the reverse proxy rejected the body as too large (413): {size} bytes.")
+            if exc.code == 400:
+                die(
+                    f"Nexus rejected the upload (400) for {url}. A repository set to 'Disable "
+                    "redeploy' cannot replace an object that already exists."
+                )
+            if exc.code not in RETRY_STATUS or attempt == RETRIES:
+                raise
+        except OSError:
+            if attempt == RETRIES:
+                raise
+        _retry_sleep(attempt)
+    raise RuntimeError("unreachable")
+
+
+def put_bytes(url: str, headers: Dict[str, str], data: bytes, content_type: str) -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "payload"
+        path.write_bytes(data)
+        return put(url, headers, path, content_type)
+
+
+def nexus_url(base: str, *parts: str) -> str:
+    return "/".join([base.rstrip("/")] + [quote(p) for p in parts])
+
+
+def github_headers(token: Optional[str], accept: str = "application/vnd.github+json") -> Dict[str, str]:
+    headers = {"Accept": accept, "X-GitHub-Api-Version": "2022-11-28"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def basic_auth(user: str, password: str) -> Dict[str, str]:
+    encoded = base64.b64encode(f"{user}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {encoded}"}
+
+
+def list_releases(repo: str, token: Optional[str]) -> List[dict]:
+    releases, page = [], 1
+    while True:
+        url = f"{GITHUB_API}/repos/{repo}/releases?per_page=100&page={page}"
+        batch = request_json(url, github_headers(token))
+        if not isinstance(batch, list) or not batch:
+            break
+        releases.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return releases
+
+
+def resolve_commit(repo: str, tag: str, token: Optional[str]) -> Optional[str]:
+    """The commit a tag points at, or None when the tag has no ref yet (draft release)."""
+    try:
+        commit = request_json(f"{GITHUB_API}/repos/{repo}/commits/{tag}", github_headers(token))
+        return commit.get("sha") if isinstance(commit, dict) else None
+    except (urllib.error.HTTPError, OSError):
+        return None
+
+
+def digest_sha256(asset: dict) -> Optional[str]:
+    """The SHA-256 GitHub records for an asset, when it has one.
+
+    Assets uploaded before GitHub began recording digests report nothing here, in which
+    case the hash is computed from the bytes as they are streamed.
+    """
+    value = asset.get("digest") or ""
+    return value.split("sha256:", 1)[1] if value.startswith("sha256:") else None
+
+
+def verify_upload(url: str, headers: Dict[str, str], size: int, sha1: str, name: str) -> List[str]:
+    """Confirms what Nexus stored matches what was sent. Returns a list of problems."""
+    stored = head(url, headers)
+    if stored is None:
+        return [f"{name}: not present in Nexus after upload"]
+    problems = []
+    remote_size = stored.get("Content-Length")
+    if remote_size is not None and int(remote_size) != size:
+        problems.append(f"{name}: Nexus reports {remote_size} bytes, expected {size}")
+    match = ETAG_SHA1_RE.search(stored.get("ETag", ""))
+    if match and match.group(1) != sha1:
+        problems.append(f"{name}: Nexus SHA-1 {match.group(1)} does not match uploaded {sha1}")
+    return problems
+
+
+class Backup:
+    def __init__(self, args, gh_token: Optional[str], nexus_auth: Dict[str, str]):
+        self.repo = args.repo
+        self.base = args.nexus_url.rstrip("/")
+        self.prefix = args.prefix.strip("/")
+        self.dry_run = args.dry_run
+        self.force = args.force
+        self.include_source = args.source
+        self.gh_token = gh_token
+        self.nexus_auth = nexus_auth
+        self.rows: List[Tuple[str, str, str]] = []
+        self.problems: List[str] = []
+        self.uploaded_bytes = 0
+        self.warned_unreadable = False
+
+    def path_for(self, tag: str, *parts: str) -> str:
+        return nexus_url(self.base, self.prefix, tag, *parts)
+
+    def record(self, status: str, name: str, detail: str = ""):
+        self.rows.append((status, name, detail))
+        log(f"  {status:<9} {name}{f'  ({detail})' if detail else ''}")
+
+    def existing_size(self, url: str) -> Optional[int]:
+        try:
+            stored = head(url, self.nexus_auth)
+        except urllib.error.HTTPError as exc:
+            # A dry run needs no credentials, but then Nexus may refuse the read; report the
+            # objects as absent rather than failing, so the size estimate still comes out.
+            if exc.code in (401, 403) and self.dry_run:
+                if not self.warned_unreadable:
+                    log("  note: Nexus read refused without credentials; presence checks skipped")
+                    self.warned_unreadable = True
+                return None
+            raise
+        if stored is None:
+            return None
+        length = stored.get("Content-Length")
+        return int(length) if length is not None else None
+
+    def transfer(
+        self,
+        source_url: str,
+        gh_headers: Dict[str, str],
+        dest_url: str,
+        name: str,
+        expected_size: Optional[int],
+        expected_sha256: Optional[str],
+        content_type: str,
+        workdir: Path,
+    ) -> Optional[dict]:
+        """Copies one object from GitHub to Nexus. Returns its recorded metadata."""
+        if not self.force:
+            present = self.existing_size(dest_url)
+            # A size match is a cheap staleness check; SHA256SUMS carries the strong proof.
+            if present is not None and (expected_size is None or present == expected_size):
+                self.record("present", name, f"{present} bytes")
+                return {"name": name, "size": present, "sha256": expected_sha256, "skipped": True}
+
+        if self.dry_run:
+            size_text = f"{expected_size} bytes" if expected_size is not None else "size unknown"
+            self.record("would-add", name, size_text)
+            return {"name": name, "size": expected_size, "sha256": expected_sha256, "skipped": True}
+
+        local = workdir / "payload"
+        try:
+            sha256, sha1, size = download(source_url, gh_headers, local)
+            if expected_sha256 and sha256 != expected_sha256:
+                self.problems.append(f"{name}: download hash {sha256} != GitHub digest {expected_sha256}")
+                self.record("FAILED", name, "hash mismatch on download")
+                return None
+            put(dest_url, self.nexus_auth, local, content_type)
+            found = verify_upload(dest_url, self.nexus_auth, size, sha1, name)
+            if found:
+                self.problems.extend(found)
+                self.record("FAILED", name, "verification failed")
+                return None
+            self.uploaded_bytes += size
+            self.record("uploaded", name, f"{size} bytes")
+            return {"name": name, "size": size, "sha256": sha256, "skipped": False}
+        finally:
+            local.unlink(missing_ok=True)
+
+    def run_release(self, release: dict, workdir: Path):
+        tag = release["tag_name"]
+        log(f"\n{tag}  ({len(release.get('assets') or [])} asset(s))")
+        gh_asset_headers = github_headers(self.gh_token, "application/octet-stream")
+        recorded: List[dict] = []
+
+        for asset in release.get("assets") or []:
+            if asset.get("state") != "uploaded":
+                self.record("skipped", asset["name"], f"state={asset.get('state')}")
+                continue
+            entry = self.transfer(
+                source_url=asset["url"],
+                gh_headers=gh_asset_headers,
+                dest_url=self.path_for(tag, asset["name"]),
+                name=asset["name"],
+                expected_size=asset.get("size"),
+                expected_sha256=digest_sha256(asset),
+                content_type=asset.get("content_type") or "application/octet-stream",
+                workdir=workdir,
+            )
+            if entry:
+                entry.update(
+                    content_type=asset.get("content_type"),
+                    download_count=asset.get("download_count"),
+                    created_at=asset.get("created_at"),
+                    nexus_path=f"{self.prefix}/{tag}/{asset['name']}",
+                )
+                recorded.append(entry)
+
+        source_entries = self.run_source_archives(release, tag, workdir) if self.include_source else []
+        self.write_metadata(release, tag, recorded, source_entries)
+
+    def run_source_archives(self, release: dict, tag: str, workdir: Path) -> List[dict]:
+        """Copies GitHub's generated source archives, whose sizes are unknown until fetched."""
+        short = self.repo.split("/")[-1]
+        entries = []
+        for key, suffix, content_type in (
+            ("tarball_url", "tar.gz", "application/gzip"),
+            ("zipball_url", "zip", "application/zip"),
+        ):
+            url = release.get(key)
+            if not url:
+                continue
+            name = f"{short}-{tag}-source.{suffix}"
+            entry = self.transfer(
+                source_url=url,
+                gh_headers=github_headers(self.gh_token),
+                dest_url=self.path_for(tag, "source", name),
+                name=f"source/{name}",
+                expected_size=None,
+                expected_sha256=None,
+                content_type=content_type,
+                workdir=workdir,
+            )
+            if entry:
+                entry["nexus_path"] = f"{self.prefix}/{tag}/source/{name}"
+                entries.append(entry)
+        return entries
+
+    def write_metadata(self, release: dict, tag: str, assets: List[dict], sources: List[dict]):
+        """Writes the manifest, checksums and release notes; always refreshed, never skipped."""
+        manifest = {
+            "schema": 1,
+            "repository": self.repo,
+            "tag": tag,
+            "release_id": release.get("id"),
+            "release_name": release.get("name"),
+            "commit_sha": resolve_commit(self.repo, tag, self.gh_token),
+            "target_commitish": release.get("target_commitish"),
+            "prerelease": release.get("prerelease"),
+            "created_at": release.get("created_at"),
+            "published_at": release.get("published_at"),
+            "html_url": release.get("html_url"),
+            "backed_up_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "nexus_base_url": self.base,
+            "assets": [{k: v for k, v in a.items() if k != "skipped"} for a in assets],
+            "source_archives": [{k: v for k, v in s.items() if k != "skipped"} for s in sources],
+        }
+        lines = [f"{a['sha256']}  {a['name']}" for a in assets + sources if a.get("sha256")]
+        unknown = [a["name"] for a in assets + sources if not a.get("sha256")]
+        if unknown:
+            log(f"  note: no SHA-256 recorded for {len(unknown)} object(s); re-run with --force to compute")
+
+        if self.dry_run:
+            self.record("would-add", "manifest.json / SHA256SUMS / release-notes.md")
+            return
+
+        put_bytes(
+            self.path_for(tag, "manifest.json"),
+            self.nexus_auth,
+            json.dumps(manifest, indent=2).encode(),
+            "application/json",
+        )
+        put_bytes(
+            self.path_for(tag, "SHA256SUMS"),
+            self.nexus_auth,
+            ("\n".join(lines) + "\n").encode(),
+            "text/plain",
+        )
+        put_bytes(
+            self.path_for(tag, "release-notes.md"),
+            self.nexus_auth,
+            (release.get("body") or "").encode(),
+            "text/markdown",
+        )
+        self.record("uploaded", "manifest.json / SHA256SUMS / release-notes.md")
+
+    def summarize(self) -> str:
+        counts: Dict[str, int] = {}
+        for status, _, _ in self.rows:
+            counts[status] = counts.get(status, 0) + 1
+        parts = [f"{count} {status}" for status, count in sorted(counts.items())]
+        gib = self.uploaded_bytes / (1 << 30)
+        return f"{', '.join(parts)} — {gib:.2f} GiB transferred"
+
+
+def write_step_summary(backup: Backup, tags: List[str]):
+    target = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not target:
+        return
+    lines = [
+        f"## Release backup to Nexus — {', '.join(tags) or 'nothing'}",
+        "",
+        f"`{backup.base}/{backup.prefix}/`",
+        "",
+        backup.summarize(),
+        "",
+        "| status | object |",
+        "|---|---|",
+    ]
+    lines += [f"| {status} | `{name}` |" for status, name, _ in backup.rows]
+    if backup.problems:
+        lines += ["", "### Problems", ""] + [f"- {p}" for p in backup.problems]
+    with open(target, "a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def parse_args(argv: Optional[List[str]] = None):
+    parser = argparse.ArgumentParser(description="Back up GitHub release assets to a Nexus raw repository.")
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--tag", help="Back up a single release tag")
+    scope.add_argument("--all", action="store_true", help="Back up every non-draft release")
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPO,
+        help="owner/repo to read releases from",
+    )
+    parser.add_argument(
+        "--nexus-url",
+        default=os.environ.get("NEXUS_URL") or DEFAULT_NEXUS_URL,
+        help="Nexus raw repository URL",
+    )
+    parser.add_argument("--prefix", default="releases", help="Path prefix inside the repository")
+    parser.add_argument(
+        "--no-source", dest="source", action="store_false", help="Skip GitHub's generated source archives"
+    )
+    parser.add_argument("--force", action="store_true", help="Re-upload objects already in Nexus")
+    parser.add_argument("--dry-run", action="store_true", help="Report what would transfer; upload nothing")
+    parser.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="Succeed when a release has no assets (a release published before its installers are attached)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    gh_token = os.environ.get("GITHUB_TOKEN") or None
+
+    nexus_auth: Dict[str, str] = {}
+    if not args.dry_run:
+        user = os.environ.get("NEXUS_USERNAME")
+        password = os.environ.get("NEXUS_PASSWORD")
+        if not user or not password:
+            die("NEXUS_USERNAME and NEXUS_PASSWORD must be set (or pass --dry-run).")
+        nexus_auth = basic_auth(user, password)
+
+    if args.all:
+        releases = [r for r in list_releases(args.repo, gh_token) if not r.get("draft")]
+        if not releases:
+            die(f"No published releases found in {args.repo}.")
+    else:
+        releases = [
+            request_json(f"{GITHUB_API}/repos/{args.repo}/releases/tags/{args.tag}", github_headers(gh_token))
+        ]
+
+    backup = Backup(args, gh_token, nexus_auth)
+    log(f"{args.repo} -> {backup.base}/{backup.prefix}/" + ("  [dry run]" if args.dry_run else ""))
+
+    empty = []
+    with tempfile.TemporaryDirectory(prefix="wiser-nexus-") as tmp:
+        for release in sorted(releases, key=lambda r: r.get("published_at") or ""):
+            if not (release.get("assets") or []):
+                empty.append(release["tag_name"])
+            backup.run_release(release, Path(tmp))
+
+    tags = [r["tag_name"] for r in releases]
+    log(f"\n{backup.summarize()}")
+    write_step_summary(backup, tags)
+
+    if backup.problems:
+        log("\nProblems:")
+        for problem in backup.problems:
+            log(f"  - {problem}")
+        return 1
+    if empty:
+        joined = ", ".join(empty)
+        # An empty release is expected while sweeping history (v1.3b1 never had assets
+        # attached), but for a named tag it usually means the installers are not up yet.
+        if args.tag and not args.allow_empty:
+            die(
+                f"No assets on {joined}. WISER publishes a release before attaching installers, "
+                "so re-run once they are uploaded (or pass --allow-empty)."
+            )
+        log(f"\nNote: no assets attached to {joined}; only metadata was stored.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What does this change do?

Adds a GitHub Actions workflow that mirrors every WISER release's assets into the LASP Nexus
raw repository (`wiser-raw`), so the installers survive loss of the GitHub repository. Each
release is archived under its tag along with a manifest, a `sha256sum -c`-compatible checksum
file, the release notes, and GitHub's generated source archives.

## What type of PR is this? (check all applicable)
- [x] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [x] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?

Closes #750.

Every binary WISER has ever shipped exists in exactly one place: the GitHub release page.
Losing the repository — org change, accidental deletion, an account problem — takes every
installer with it. This gives us a second, independent copy on LASP-controlled storage.

This is not hypothetical. **`v1.3b1` has no release assets at all**: its builds only ever
existed as Actions artifacts, which expire. Those binaries appear to be gone already. A
`--all` dry run over the current history also shows `v2.0b1` with only 3 assets where later
releases have 9.

The archive covers ~11.9 GiB across 39 assets today, growing ~4 GiB per release. For scale,
the same Nexus already hosts a 104 GB raw repository (`fsw`).

## How did you implement the change?

**`.github/workflows/backup-releases-to-nexus.yml`** — runs on `ubuntu-latest`, no on-prem
runner. Three triggers:

- **`released`**, deliberately not `published`. Our release process publishes a release as a
  pre-release and attaches installers afterwards, so `published` would fire while the release
  is still empty. `released` fires when the pre-release flag is cleared, by which point every
  asset is attached.
- **Weekly cron**, reconciling the full history so a failed or skipped run repairs itself
  rather than leaving a silent gap — the usual way backups rot.
- **`workflow_dispatch`** with `tag` / `all` / `force` / `dry run`, for backfilling.

**`src/devtools/backup_releases_to_nexus.py`** — the transfer logic, stdlib-only (no env
setup step needed in CI). It lives in `devtools/` rather than inline in the workflow so it can
also be run by hand for backfills and spot checks, matching how `sign_mac.py` /
`sign_windows.py` are used. Exposed as `make backup-releases TAG=… | ALL=1`.

Design points worth review:

- **Only `/repository/` is reachable.** The public proxy exposes repository paths but not
  `/service/rest/`, so the script uses plain `PUT`/`GET`/`HEAD` and never touches the Nexus
  REST API. (The internal host, `artifacts.pdmz.lasp.colorado.edu`, is absent from public DNS
  and resolves to RFC1918 space, so a GitHub-hosted runner cannot reach it at all.)
- **Integrity is checked, not assumed.** Downloads are verified against the SHA-256 GitHub
  records per asset; uploads are verified against the size and the SHA-1 Nexus returns in its
  ETag. A mismatch fails the run.
- **Streams one asset at a time** — assets reach 445 MB, and the whole history is ~11.9 GiB;
  peak disk stays at one asset.
- **Idempotent.** An asset already stored at the right size is skipped, so re-runs and the
  weekly reconcile are cheap.
- **Auth is preemptive Basic**, because urllib's challenge-response flow would send a 400 MB
  body twice. A redirect handler strips `Authorization` on cross-host redirects, since GitHub
  redirects asset downloads to signed object-storage URLs that reject a second auth mechanism.
- **Asset-name agnostic** — naming has drifted across releases (`WISER-debian_11-amd64.tar.gz`,
  `wiser-linux-debian11-amd64.zip`, `WISER-3.0b0-linux-debian11-arm64.tar`), so nothing globs
  on expected suffixes.

Requires two repository secrets, `NEXUS_USERNAME` / `NEXUS_PASSWORD` (a Nexus user token is
preferred over an account password), and optionally a `NEXUS_RAW_URL` variable. Secrets are
unavailable to fork PRs and this workflow has no `pull_request` trigger.

## Added tests?
- [ ] yes
- [x] no, because they aren’t needed
- [ ] no, because I need help

Consistent with the other `src/devtools/` scripts, which are not unit-tested. Verified instead
by exercising the real paths:

- `--dry-run` against every release (`--tag` and `--all`), confirming the enumeration and the
  11.9 GiB total.
- A live download of a release source archive through GitHub's cross-host redirect: streamed
  hash matches a re-hash of the file on disk, and the archive is valid gzip.
- The redirect handler checked directly: `Authorization` stripped cross-host, preserved
  same-host, other headers untouched.
- The workflow's argument assembly simulated for all 8 trigger paths, including rejecting a
  malformed tag.

Not yet exercised: the authenticated `PUT` to Nexus, which needs the credentials configured.
An unauthenticated `PUT` returns `401` with a Basic challenge, confirming the proxy forwards
writes rather than blocking them. **First run should be `dry run` + a single tag before the
full backfill.**

## Added to documentation?
- [x] yes
- [ ] no documentation needed

`ci-cd-and-releases.md` gains a **Backup to Nexus** section (layout, triggers, manual use), a
**The Nexus release archive** section covering the Nexus-side configuration — repository
settings, the CI account's privileges, GitHub secrets, verification, and restore steps — and a
new step 10 in the Release Process for confirming the backup ran.

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [ ] All CI checks passed

## Desktop Screenshots/Recordings

n/a — no UI change.

## [optional] Are there any post-merge tasks we need to perform?

1. Create the `wiser-raw` raw hosted repository in Nexus with **no cleanup policy** (a cleanup
   policy deletes by age/last-download, which would silently defeat the archive).
2. Create the CI service account with `add`/`browse`/`edit`/`read` on `wiser-raw` and
   **no `delete`**, so a leaked CI credential cannot destroy the archive.
3. Add the `NEXUS_USERNAME` / `NEXUS_PASSWORD` secrets.
4. Dispatch with **dry run + a single tag**, then run the `all` backfill.
5. Confirm the weekly reconcile run turns green.

Separately, and out of scope here: `v3.0b0`'s Linux assets are named `.tar` while the
documented convention and `publish-release-assets.yml`'s glob (`WISER-*-linux-*.tar.gz`) both
say `.tar.gz`. Worth a follow-up issue.
