### PR TITLE
doc: Record concurrency, rendering, and caching rationale from the handoff notes

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/bandmath-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/bandmath-internals.md
@@ -230,12 +230,31 @@ flowchart LR
 
 Each window is evaluated independently, and its result bands are written to an on-disk GDAL dataset incrementally.
 
+```{note}
+Chunking splits the **band** axis only, so the smallest chunk it can produce is one whole band.
+A single band larger than the memory budget still overflows it, which is reachable on images
+such as Gale HiRISE where one band can exceed 2 GB. The fix is to make chunking
+dimension-agnostic (#761) rather than to patch the band loop, since each local patch entrenches
+the band-only assumption further.
+
+Band-math plugins, the plugin API, and the plugin docs were all written assuming the whole
+dataset is in memory, so a chunking rewrite has to account for them or it breaks third-party
+plugins silently. That is tracked separately as #754.
+```
+
 ### Read-ahead pipeline
 
 The async evaluator runs two thread pools in addition to the `asyncio` event loop:
 
 - `_read_thread_pool` — 4 workers; reads raster band data from disk
 - `_write_thread_pool` — 1 worker; writes computed band windows back to disk
+
+```{warning}
+These reads are multithreaded, and they are safe only because `RasterDataImpl.reopen_dataset()`
+opens a fresh GDAL handle per read. Do not swap that for GDAL's single-handle multithreaded
+reads without re-verifying the output against a known-good reference: see
+[Reading concurrently](system-design.md#reading-concurrently) and issue #752.
+```
 
 Each expression tree node (operator) gets a pair of `queue.Queue` objects keyed by `LHS_KEY` and `RHS_KEY`. The operator submits the *next* window's read to the thread pool before it even starts computing the *current* window. By the time the current window's computation finishes, the next window's data is often already in the queue.
 

--- a/doc/sphinx-general-wiser-docs/source/developer-content/bandmath-internals.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/bandmath-internals.md
@@ -201,6 +201,20 @@ lark.visitors.Transformer
 - `_transform_tree()` — awaits `_transform_children()`, then calls the handler for the current node.
 - `_call_userfunc()` — detects whether the handler method is `async def` or a regular `def` and awaits it accordingly.
 
+```{note}
+`AsyncTransformer` is slated for **removal** — see issue #765.
+
+The concurrency is real and it does make evaluation faster (expect to give up roughly 20%; the
+original measurement was not preserved). The cost is that it is a hand-written reimplementation
+of a third-party class which entangles `asyncio` into the core of the evaluator, and the
+[read-ahead pipeline](#read-ahead-pipeline) below — a future queue maintained per expression
+node — exists only to feed it. The two are one decision and come out together.
+
+The intended replacement is parallelism from process-pool chunking (#761), with band math
+running in a subprocess so it cannot freeze the GUI thread. Do not extend `AsyncTransformer` or
+add new callers to the read-ahead queues.
+```
+
 ### Band-window chunking
 
 For an `IMAGE_CUBE` result, the spectral dimension is split into **band windows**. `compute_bands_per_chunk()` calculates the maximum number of bands that fit in the available memory budget. `iter_band_windows(total_bands, num_bands)` yields `(current_bands, next_bands)` pairs — the second element is the window that will be needed next, enabling read-ahead.

--- a/doc/sphinx-general-wiser-docs/source/developer-content/data-caching.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/data-caching.md
@@ -215,4 +215,27 @@ histogram cache works as intended.
 This page documents the *intended* design (the caches are meant to store on
 miss and serve on subsequent requests). The note is here so readers aren't
 misled by the current code; fixing the guard is a separate change.
+
+Tracked as issue #772. The fix is not purely a flipped condition: the branch
+adds `value.nbytes` unconditionally, which would double-count the size on a
+genuine replacement, so the insert and replace paths need distinct accounting.
+Until it is fixed, any measurement of the rendering path is a measurement of an
+uncached pipeline — see [Rendering Pipeline](rendering-pipeline.md).
 ```
+
+---
+
+## Relationship to LoD Rendering
+
+The computation cache's real payoff is in `get_band_data_normalized()`
+(`src/wiser/raster/dataset.py`), where it saves re-normalizing a band on every
+call — the rendering hot path. It was built for one concrete scenario: keeping
+the image shown in a `RasterView` cached so that switching between datasets, and
+dragging in the Stretch Builder, stay responsive.
+
+Whether the per-dataset read cache on `Dataset` should stay a separate mechanism,
+or fold into the storage service and client, is deliberately parked in issue #762
+rather than being answered here. The reason is that its fate is not its own: if
+LoD-pyramid rendering (#69) makes data access and compute cheap enough, this
+cache may stop earning its keep entirely. Settle the rendering question before
+rewriting the cache.

--- a/doc/sphinx-general-wiser-docs/source/developer-content/design-documents.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/design-documents.md
@@ -125,3 +125,32 @@ Relevant background:
 
 - [GDAL and multiprocessing](https://gdal.org/tutorials/multiprocessing.html)
 - [Pickle error with GDAL Dataset](https://gis.stackexchange.com/questions/361703/pickle-error-with-gdal-dataset)
+
+---
+
+## Usage Telemetry (Investigated, Not Pursued)
+
+**Decision: WISER does not collect usage telemetry, and this is not an oversight.**
+
+The question was whether to instrument WISER to learn which features people actually use, so
+development effort could follow real usage rather than guesswork. It was investigated and
+deliberately dropped.
+
+The reason is not technical difficulty but compliance surface. Collecting usage data from a
+desktop application carries obligations under the EU GDPR, the California CCPA, and comparable
+regimes — lawful basis, disclosure, subject-access and deletion requests, retention limits, and
+processor agreements. Doing that properly is the bulk of the work, and it outweighs the value of
+the signal for a research tool of WISER's size. If it is ever revisited, start from "compliance
+is the hard part", not from "how do we collect events".
+
+**What to do instead:** download statistics carry far less legal surface for a similar signal.
+The `snapshot-download-counts` workflow already records a daily snapshot of every release
+asset's cumulative download count to the `stats` branch, giving per-platform and per-release
+trends over time. Prefer strengthening that over instrumenting the application.
+
+**Not to be confused with crash reporting.** WISER does support opt-in crash reporting
+(`src/wiser/gui/bug_reporting.py`), which is off by default, asked for explicitly on first run,
+and changeable under **Preferences → General → Online bug reporting**. A crash report describes
+a failure — the exception, the call sequence, the WISER version, the platform — and carries no
+imagery, spectra, ROIs, or file contents. That is a defect-diagnosis channel, deliberately
+narrow, and it is not a route to add usage analytics.

--- a/doc/sphinx-general-wiser-docs/source/developer-content/design-documents.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/design-documents.md
@@ -149,8 +149,16 @@ asset's cumulative download count to the `stats` branch, giving per-platform and
 trends over time. Prefer strengthening that over instrumenting the application.
 
 **Not to be confused with crash reporting.** WISER does support opt-in crash reporting
-(`src/wiser/gui/bug_reporting.py`), which is off by default, asked for explicitly on first run,
-and changeable under **Preferences → General → Online bug reporting**. A crash report describes
-a failure — the exception, the call sequence, the WISER version, the platform — and carries no
-imagery, spectra, ROIs, or file contents. That is a defect-diagnosis channel, deliberately
-narrow, and it is not a route to add usage analytics.
+(`src/wiser/gui/bug_reporting.py`). It is off by default — `general.online_bug_reporting`
+defaults to `False` — and is asked for explicitly on first run by the *Online Bug Reporting*
+dialog. It is changed afterwards in the **WISER Configuration** dialog, reached from
+*Preferences…* in the WISER application menu on macOS or *File → Settings…* on Windows, under
+**General → Error Reporting**, via the checkbox *Send WISER exceptions and crashes to BugSnag*.
+
+A crash report describes a failure — the exception, the call sequence, the WISER version, the
+platform — and carries no imagery, spectra, ROIs, or file contents. It is a defect-diagnosis
+channel, deliberately narrow, and it is not a route to add usage analytics.
+
+Naming the current provider above documents the interface as it ships; it is not a commitment to
+that provider. Whether WISER should keep sending crash reports to a third-party service at all
+is an open question, tracked in issue #775.

--- a/doc/sphinx-general-wiser-docs/source/developer-content/design-documents.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/design-documents.md
@@ -130,7 +130,8 @@ Relevant background:
 
 ## Usage Telemetry (Investigated, Not Pursued)
 
-**Decision: WISER does not collect usage telemetry, and this is not an oversight.**
+**Decision: WISER does not collect usage telemetry, and this is not an oversight.** Opt-in
+crash reporting is a separate and much narrower channel, described at the end of this section.
 
 The question was whether to instrument WISER to learn which features people actually use, so
 development effort could follow real usage rather than guesswork. It was investigated and
@@ -155,10 +156,20 @@ dialog. It is changed afterwards in the **WISER Configuration** dialog, reached 
 *Preferences…* in the WISER application menu on macOS or *File → Settings…* on Windows, under
 **General → Error Reporting**, via the checkbox *Send WISER exceptions and crashes to BugSnag*.
 
-A crash report describes a failure — the exception, the call sequence, the WISER version, the
-platform — and carries no imagery, spectra, ROIs, or file contents. It is a defect-diagnosis
-channel, deliberately narrow, and it is not a route to add usage analytics.
+A crash report describes a failure: the exception, the stack trace, the WISER version, and the
+platform. No imagery, spectra, ROIs, or file contents are attached, and the channel is not a
+route to add usage analytics.
+
+Read that as a description of the channel rather than as a privacy guarantee. A stack trace
+carries source file paths, which on a user's machine embed the home directory and therefore the
+username. `before_bugsnag_notify()` in `src/wiser/gui/bug_reporting.py` is the hook where such
+fields would be stripped, and it currently strips nothing; it carries a standing TODO to do so.
+The user-facing statement of what leaves the machine belongs in the privacy policy, not on this
+page.
 
 Naming the current provider above documents the interface as it ships; it is not a commitment to
 that provider. Whether WISER should keep sending crash reports to a third-party service at all
 is an open question, tracked in issue #775.
+
+Recorded from handoff notes on the `joshua-handoff` branch, which is retained as the primary
+source.

--- a/doc/sphinx-general-wiser-docs/source/developer-content/rendering-pipeline.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/rendering-pipeline.md
@@ -169,6 +169,7 @@ Both setters null out `RasterView._joint_render_cache` and call
 **once per pane** — the context pane, main view, and zoom pane each hold a
 `RasterView` that renders the same change. On large images this is the single
 biggest source of interface freezes in WISER.
+```
 
 It also means "opening a dataset is slow" is mostly a *rendering* cost rather
 than a read cost. `loader.load_from_file()` probes drivers and reads metadata,
@@ -197,7 +198,6 @@ rendering code that caching was designed to absorb.
 Tracked in #758 (moving the NumPy portion off-thread), #764 (making a stretch
 change cancellable), and #69 (LoD-pyramid rendering, which would reduce the cost
 enough to change what the right fix is).
-```
 
 ---
 

--- a/doc/sphinx-general-wiser-docs/source/developer-content/rendering-pipeline.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/rendering-pipeline.md
@@ -162,6 +162,45 @@ Both setters null out `RasterView._joint_render_cache` and call
 
 ---
 
+## Known Issue: The Pipeline Runs on the GUI Thread
+
+```{warning}
+`update_display_image()` runs **synchronously on the GUI thread**, and it runs
+**once per pane** — the context pane, main view, and zoom pane each hold a
+`RasterView` that renders the same change. On large images this is the single
+biggest source of interface freezes in WISER.
+
+It also means "opening a dataset is slow" is mostly a *rendering* cost rather
+than a read cost. `loader.load_from_file()` probes drivers and reads metadata,
+not pixels; the band read, data-ignore masking, normalization, stretch, and
+compositing all happen here, driven off the `dataset_added` signal.
+
+Because all three paths in [How Changes Reach the Screen](#how-changes-reach-the-screen)
+funnel through this one method, moving it off-thread improves dataset open, the
+stretch builder, and the band chooser together — and a regression here breaks all
+three at once.
+
+Two constraints shape any fix:
+
+- The `QImage` / `QPixmap` tail cannot leave the GUI thread. The seam has to be
+  cut between the NumPy work and the Qt handoff: finish the array off-thread,
+  build the Qt object on the GUI thread.
+- `_display_data`, `_joint_render_cache`, and the shared render cache are mutated
+  mid-render. Concurrent or stale renders must be cancelled, or discarded on
+  arrival, or fast clicking in the band chooser will paint the wrong image.
+
+Note also that the render and computation caches do not currently serve hits (see
+[Data Caching](data-caching.md) and issue #772), so this path runs fully uncached
+today. Profile with that fixed, or the measurement will attribute cost to the
+rendering code that caching was designed to absorb.
+
+Tracked in #758 (moving the NumPy portion off-thread), #764 (making a stretch
+change cancellable), and #69 (LoD-pyramid rendering, which would reduce the cost
+enough to change what the right fix is).
+```
+
+---
+
 ## Where to Read Next
 
 - [Band Chooser](band-chooser.md) — `_display_bands` and `_colormap`.

--- a/doc/sphinx-general-wiser-docs/source/developer-content/system-design.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/system-design.md
@@ -2,6 +2,63 @@
 
 This page documents internal architecture and design patterns in WISER.
 
+## Concurrency Model: Why WISER Uses Subprocesses
+
+The task, storage, and scheduler machinery documented below exists for one reason, and it is
+worth stating before the mechanics: **in Python, keeping a GUI responsive while computing is not
+a matter of spawning a thread.**
+
+The question this answers comes up often, usually as "ENVI stays responsive and fast without any
+of this — why can't WISER just spawn a thread and compute?" ENVI is written in IDL, which has
+real parallel threads and is built for fast array computation: it can spawn a thread, share
+memory, compute, and be done. Python cannot. The GIL makes threads concurrent but not parallel,
+so genuinely CPU-bound work has to go to a **subprocess**, which means data is serialized out to
+the worker, computed on, and serialized back. That transfer cost is real; it has been reduced,
+but it cannot be eliminated. Python is also not built for array computation the way IDL is —
+even with NumPy, there is a cost to context switches between Python and the underlying C/C++.
+
+Two consequences follow, and both are load-bearing:
+
+- Anything that runs on the GUI thread and takes real time freezes the whole application. Moving
+  work off that thread is the standard, not an optimization.
+- The architecture optimizes for **low memory overhead and a responsive GUI**, and pays for that
+  in data-transfer time. This is a deliberate trade-off rather than a discovered constraint. It
+  is a reasonable one to revisit with fresh measurements — but revisit it knowing it is there,
+  not by accident.
+
+### Choosing a mechanism
+
+| The work | Use | Notes |
+|----------|-----|-------|
+| Long, expensive, needs progress and cancellation | Task system (`src/wiser/utils/task_system.py`) | Chunked execution under RAM and disk constraints; reports to the activity monitor. Documented in full below. |
+| One-off CPU-bound work | `WorkScheduler` process pool (`src/wiser/utils/work_scheduler.py`) | No semantic task, no plan. Appropriate when the work is short or has no meaningful sub-stages. |
+| I/O-bound work | `WorkScheduler` thread pool | Threads are fine here: the GIL is released while waiting on I/O. |
+| Anything touching `QImage`, `QPixmap`, or a widget | GUI thread only | Qt objects cannot be created or mutated off the GUI thread. Cut the seam between the computation and the Qt handoff: return a finished array, build the Qt object on the GUI thread. |
+
+A thread can also carry long CPU-bound work when most of the cost sits in NumPy or Numba code
+that releases the GIL, at the price of taking resources from the main thread. That is sometimes
+the right trade — notably where the result is large enough that serializing it back to the main
+process would cost more than the parallelism gains.
+
+The single documented standard for making this choice, including worked examples, is tracked in
+issue #753; until it lands, prefer the table above over copying whichever nearby example is
+closest to hand.
+
+### Reading concurrently
+
+Because concurrent readers must not share one GDAL handle, `RasterDataImpl.reopen_dataset()`
+opens a fresh handle for every read (`src/wiser/raster/dataset_impl.py`). This is why
+multithreaded reads are safe, and it is also a real per-read cost on formats that are slow to
+open.
+
+```{warning}
+GDAL 3.10 advertises multithreaded reads from a single handle, which would make the reopen
+unnecessary. Testing it returned **corrupted data**. Do not remove the reopen without first
+re-verifying multithreaded reads against a known-good reference output — see issue #752.
+```
+
+---
+
 ## WISER Task, Storage, and Scheduler System Overview
 
 This document describes the current architecture of WISER's task execution stack and how task planning, storage, and

--- a/doc/sphinx-general-wiser-docs/source/developer-content/system-design.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/system-design.md
@@ -30,7 +30,7 @@ Two consequences follow, and both are load-bearing:
 
 | The work | Use | Notes |
 |----------|-----|-------|
-| Long, expensive, needs progress and cancellation | Task system (`src/wiser/utils/task_system.py`) | Chunked execution under RAM and disk constraints; reports to the activity monitor. Documented in full below. |
+| Long, expensive, needs progress and cancellation | Task system (`src/wiser/utils/task_system.py`) | Chunked execution under RAM and disk constraints; reports to the activity monitor. Documented in full below. Use it, but do not build on it: it is more machinery than the problem needs, and simplifying it is tracked in #759. |
 | One-off CPU-bound work | `WorkScheduler` process pool (`src/wiser/utils/work_scheduler.py`) | No semantic task, no plan. Appropriate when the work is short or has no meaningful sub-stages. |
 | I/O-bound work | `WorkScheduler` thread pool | Threads are fine here: the GIL is released while waiting on I/O. |
 | Anything touching `QImage`, `QPixmap`, or a widget | GUI thread only | Qt objects cannot be created or mutated off the GUI thread. Cut the seam between the computation and the Qt handoff: return a finished array, build the Qt object on the GUI thread. |
@@ -44,6 +44,10 @@ The single documented standard for making this choice, including worked examples
 issue #753; until it lands, prefer the table above over copying whichever nearby example is
 closest to hand.
 
+Work that still runs on the GUI thread and should not: the render path described in
+[Rendering Pipeline](rendering-pipeline.md) (#758), and ROI average-spectra computation in
+`src/wiser/gui/rasterpane.py` (#468).
+
 ### Reading concurrently
 
 Because concurrent readers must not share one GDAL handle, `RasterDataImpl.reopen_dataset()`
@@ -56,6 +60,9 @@ GDAL 3.10 advertises multithreaded reads from a single handle, which would make 
 unnecessary. Testing it returned **corrupted data**. Do not remove the reopen without first
 re-verifying multithreaded reads against a known-good reference output — see issue #752.
 ```
+
+Recorded from handoff notes on the `joshua-handoff` branch, which is retained as the primary
+source.
 
 ---
 

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -400,6 +400,13 @@ class GDALRasterDataImpl(RasterDataImpl):
         Opens and returns a new GDAL dataset equivalent to the current one,
         always creating a new dataset from the file path. This is needed to do
         asynchronous I/O.
+
+        A separate handle per read is deliberate: concurrent readers must not
+        share one GDAL handle. GDAL 3.10 advertises multithreaded reads from a
+        single handle, which would make this reopen unnecessary, but testing it
+        returned corrupted data. Do not remove the reopen without first
+        re-verifying multithreaded reads against a known-good reference output.
+        See issue #752.
         """
         file_paths = self.get_filepaths()
         if not file_paths:


### PR DESCRIPTION
## What does this change do?

Moves the architectural reasoning that lived only in a departing maintainer's notes into the developer docs, and corrects two pages that currently read as endorsements of code we intend to remove or fix. Docs only, plus one docstring — no behaviour change.

## What type of PR is this? (check all applicable)
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] Chore
- [ ] Revert

## Why is this change needed?

The `joshua-handoff` branch holds three unmerged notes files from the departing primary developer. Their substance has now been filed as issues #752–#773, but three categories of content do not belong in an issue tracker, and one of them means the current public docs are actively misleading:

1. **`bandmath-internals.md` documents `AsyncTransformer` purely as a virtue** ("allows for I/O to happen in parallel which reduces time spent evaluating"), with no indication that its own author considered it a maintainability mistake to be deleted. A reader following the docs would extend it. Same shape in `rendering-pipeline.md`: it describes the pipeline accurately but never says it runs synchronously on the GUI thread, so the reader cannot see why it is the top performance problem.
2. **Evergreen rationale with no home in a ticket.** Nothing in the repo explains why CPU-bound work goes to a subprocess rather than a thread — `system-design.md` never mentions the GIL. It is the question every new contributor asks, and the reason the whole task/scheduler stack exists.
3. **A decision record that existed nowhere.** Usage telemetry was investigated and deliberately dropped; that finding was on the branch only.

Associated issues: #752 (GDAL landmine), #753 (off-GUI-thread standard — this is that issue's documentation deliverable), #758, #762, #764, #765, #769, #772, #69.

## How did you implement the change?

Five targeted doc additions and one docstring, referencing symbols rather than line numbers so they do not rot:

- **`system-design.md`** — new *Concurrency Model* section: the GIL and the ENVI/IDL contrast; a table of which mechanism to use for which kind of work; the rule that Qt objects stay on the GUI thread; the explicit statement that the design trades data-transfer time for low memory overhead and a responsive GUI, so a future revisit is informed rather than accidental. Plus a *Reading concurrently* subsection explaining why `reopen_dataset()` opens a fresh handle per read, with the GDAL 3.10 corruption warning.
- **`rendering-pipeline.md`** — new known-issue section: `update_display_image()` runs synchronously on the GUI thread and once per pane; a slow dataset open is mostly render cost, not read cost (`load_from_file()` reads metadata, not pixels); the three entry paths share one funnel, so one fix or one regression affects all three; and the two constraints any fix must respect (the Qt tail cannot move; per-view mutable state must be cancelled or discarded).
- **`bandmath-internals.md`** — note that `AsyncTransformer` and the read-ahead queues that exist only to feed it are slated for removal together, with the expected speed give-up and the intended replacement.
- **`data-caching.md`** — links the `add_cache_item` guard to #772, notes that the fix needs different accounting for insert vs replace, records that any render-path measurement today is a measurement of an uncached pipeline, and explains why the read cache should not be rewritten before the LoD question is settled.
- **`design-documents.md`** — telemetry decision record: rejected, why compliance rather than implementation is the hard part, that download statistics are the cheaper signal and the `snapshot-download-counts` workflow already collects them, and how this differs from the existing opt-in crash reporting.
- **`dataset_impl.py`** — `reopen_dataset()` docstring now states that the per-read handle is deliberate and must not be removed without re-verifying multithreaded reads.

Deliberately **not** merged from that branch: `ISSUE_DRAFTS.md` (now redundant with #752–#773, and a second source of truth would diverge immediately), `ROADMAP.md` (asserts priorities already superseded, and publishing it implies a maintenance commitment), and the first-person self-assessments, which belong in a private handoff rather than the public record. The branch is retained as the primary source and is cited by the issues.

## Added tests?
- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

Documentation and one docstring; no executable behaviour changes.

## Added to documentation?
- [x] yes
- [ ] no documentation needed

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors — `make html` succeeds; the 4 remaining Sphinx warnings are pre-existing cross-reference issues in `georeferencer-internals.md` and `mosaic-internals.md`, none from these files
- [x] No new lint/style issues introduced — `ruff check` and `ruff format --check` pass on the pinned 0.1.15
- [x] Branch is up-to-date with main
- [ ] All CI checks passed — pending

## [optional] Are there any post-merge tasks we need to perform?

- **#772 is the cheap one to take next.** `Cache.add_cache_item` guards its insert with `if key in self._cache:`, and every caller inserts only after a miss, so the render and computation caches never serve a hit. It was written up in `data-caching.md` but never filed. It also gates honest profiling for #758.
- The concurrency table in `system-design.md` is the current answer for #753; when that issue lands its worked examples, they belong on the same page.
- If the in-flight `privacy-policy.md` page merges, cross-link it from the telemetry decision record.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)