### PR TITLE
Sign, notarize, and staple macOS releases in CI

### DIFF
--- a/.github/workflows/sign-macos.yml
+++ b/.github/workflows/sign-macos.yml
@@ -1,0 +1,256 @@
+name: Sign macOS release assets
+
+# Code-signs, notarizes, and staples a macOS build produced by "Build and Smoke Test WISER",
+# then publishes the finished DMG. The build legs upload an unsigned WISER.app.tgz; this
+# workflow turns one into a Developer ID artifact that Gatekeeper accepts offline.
+#
+# The signing key lives in the "release" environment, so a run cannot reach it until a
+# maintainer approves the deployment. A workflow calling this one must pass
+# `secrets: inherit`, or the credentials arrive empty and the job fails at the import step.
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Build run ID (from 'Build and Smoke Test WISER') to sign"
+        required: true
+      arch:
+        description: "Which macOS build(s) to sign"
+        type: choice
+        options: [both, arm64, x64]
+        default: both
+      release_tag:
+        description: "Optional release tag to attach the signed DMG to (leave empty to only produce an artifact)"
+        required: false
+        default: ""
+  workflow_call:
+    inputs:
+      run_id:
+        required: true
+        type: string
+      arch:
+        required: false
+        type: string
+        default: both
+      release_tag:
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sign-macos-${{ inputs.run_id }}-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  sign:
+    # Signing is arch-independent, so both bundles are signed on the same runner type.
+    runs-on: macos-15
+    environment: release
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ${{ fromJSON(inputs.arch == 'both' && '["arm64","x64"]' || format('["{0}"]', inputs.arch)) }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      RUN_ID: ${{ inputs.run_id }}
+      TAG: ${{ inputs.release_tag }}
+
+    steps:
+      - name: Verify the build run and resolve its commit
+        id: verify
+        run: |
+          set -euo pipefail
+
+          # Inputs are passed via env, so they cannot inject shell; validate their shape
+          # anyway so a typo fails immediately with a clear message.
+          [[ "${RUN_ID}" =~ ^[0-9]+$ ]] || { echo "::error::run_id must be a positive integer."; exit 1; }
+          if [ -n "${TAG}" ]; then
+            [[ "${TAG}" =~ ^[A-Za-z0-9._/-]+$ ]] || { echo "::error::tag has unexpected characters."; exit 1; }
+          fi
+
+          read -r conclusion run_sha < <(gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
+            --jq '(.conclusion // "pending") + " " + .head_sha')
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::Build run ${RUN_ID} concluded '${conclusion}', not 'success'. Refusing to sign."
+            exit 1
+          fi
+
+          # Signing an artifact under a tag that points somewhere else is how a DMG ends up
+          # labelled with the wrong version, so the tag must be the built commit.
+          if [ -n "${TAG}" ]; then
+            tag_sha="$(gh api "repos/${REPO}/commits/${TAG}" --jq '.sha' 2>/dev/null || true)"
+            if [ -z "$tag_sha" ]; then
+              echo "::warning::Tag ${TAG} has no commit yet (draft release?). Skipping tag==build-commit check."
+            elif [ "$tag_sha" != "$run_sha" ]; then
+              echo "::error::Tag ${TAG} points at ${tag_sha} but run ${RUN_ID} built ${run_sha}. Refusing to sign."
+              exit 1
+            fi
+          fi
+
+          echo "sha=${run_sha}" >> "$GITHUB_OUTPUT"
+          echo "Verified run ${RUN_ID} (success, ${run_sha})."
+
+      # Checked out at the built commit so version.py names the DMG for the artifact being
+      # signed rather than for whatever main has moved on to.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.verify.outputs.sha }}
+
+      - name: Resolve the app version
+        id: version
+        run: echo "version=$(python3 src/wiser/version.py)" >> "$GITHUB_OUTPUT"
+
+      - name: Download the unsigned app bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: wiser-macOS-${{ matrix.arch == 'arm64' && 'ARM64' || 'X64' }}
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ github.token }}
+          path: dist
+
+      - name: Verify the checksum and unpack
+        run: |
+          set -euo pipefail
+          # The checksum file records the path as dist/WISER.app.tgz, so verify from the root.
+          shasum -a 256 -c dist/WISER.app.tgz.sha256
+          # tar rather than unzip: it preserves the symlinks and modes inside the bundle.
+          tar -C dist -xzf dist/WISER.app.tgz
+          test -d dist/WISER.app
+
+      - name: Import the Developer ID certificate
+        id: cert
+        env:
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MACOS_CERT_P12_BASE64}" ]; then
+            echo "::error::MACOS_CERT_P12_BASE64 is not set in the 'release' environment."
+            exit 1
+          fi
+
+          KEYCHAIN="${RUNNER_TEMP}/wiser-signing.keychain-db"
+          # Per-run password for a keychain that is destroyed at the end of the job; it
+          # protects nothing beyond this runner, so it is generated, not stored as a secret.
+          KEYCHAIN_PW="$(openssl rand -base64 24)"
+          echo "::add-mask::${KEYCHAIN_PW}"
+
+          security create-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+          security set-keychain-settings -lut 21600 "${KEYCHAIN}"
+          security unlock-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+
+          CERT="${RUNNER_TEMP}/cert.p12"
+          base64 -d <<< "${MACOS_CERT_P12_BASE64}" > "${CERT}"
+          security import "${CERT}" -k "${KEYCHAIN}" -P "${MACOS_CERT_PASSWORD}" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          rm -f "${CERT}"
+
+          # Lets codesign use the key without an interactive prompt.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "${KEYCHAIN_PW}" "${KEYCHAIN}" > /dev/null
+          security list-keychains -d user -s "${KEYCHAIN}" login.keychain-db
+
+          # Derive the identity from the keychain instead of hardcoding its name, so a
+          # re-issued certificate needs no workflow edit. Exactly one is expected.
+          IDS="$(security find-identity -v -p codesigning "${KEYCHAIN}" \
+            | sed -nE 's/.*"(.*)".*/\1/p')"
+          COUNT="$(printf '%s\n' "${IDS}" | grep -c . || true)"
+          if [ "${COUNT}" -ne 1 ]; then
+            echo "::error::Expected exactly 1 code-signing identity in the imported keychain, found ${COUNT}."
+            printf '%s\n' "${IDS}"
+            exit 1
+          fi
+          echo "Signing identity: ${IDS}"
+          echo "identity=${IDS}" >> "$GITHUB_OUTPUT"
+          echo "keychain=${KEYCHAIN}" >> "$GITHUB_OUTPUT"
+
+      - name: Stage the notarization credential
+        id: notary
+        env:
+          NOTARY_KEY_P8_BASE64: ${{ secrets.NOTARY_KEY_P8_BASE64 }}
+        run: |
+          set -euo pipefail
+          # An App Store Connect API key is preferred; the Apple ID + app-specific password
+          # path is the fallback until the team key is issued. sign_mac.py picks whichever
+          # set of environment variables is populated.
+          if [ -n "${NOTARY_KEY_P8_BASE64}" ]; then
+            KEY="${RUNNER_TEMP}/notary.p8"
+            base64 -d <<< "${NOTARY_KEY_P8_BASE64}" > "${KEY}"
+            chmod 600 "${KEY}"
+            echo "path=${KEY}" >> "$GITHUB_OUTPUT"
+            echo "Using an App Store Connect API key."
+          else
+            echo "path=" >> "$GITHUB_OUTPUT"
+            echo "Using the Apple ID app-specific password."
+          fi
+
+      - name: Sign, notarize, staple, and package
+        env:
+          AD_CODESIGN_KEY_NAME: ${{ steps.cert.outputs.identity }}
+          NOTARY_KEY_PATH: ${{ steps.notary.outputs.path }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+          AD_USERNAME: ${{ secrets.AD_USERNAME }}
+          AD_TEAM_ID: ${{ secrets.AD_TEAM_ID }}
+          AD_PASSWORD: ${{ secrets.AD_PASSWORD }}
+        run: |
+          set -euo pipefail
+          python3 src/devtools/sign_mac.py \
+            --app-path dist/WISER.app \
+            --app-version "${{ steps.version.outputs.version }}" \
+            --arch "${{ matrix.arch }}" \
+            --notarize \
+            --require-gatekeeper
+
+      - name: Upload the signed DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: wiser-macos-${{ matrix.arch }}-signed
+          path: dist/WISER-*-macos-*.dmg
+          if-no-files-found: error
+
+      - name: Remove the signing keychain
+        if: always()
+        run: |
+          security delete-keychain "${RUNNER_TEMP}/wiser-signing.keychain-db" 2>/dev/null || true
+          rm -f "${RUNNER_TEMP}/cert.p12" "${RUNNER_TEMP}/notary.p8"
+
+  attach:
+    # Split out so the signing job, which holds the private key, never has write access to
+    # the repository.
+    needs: sign
+    if: inputs.release_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      TAG: ${{ inputs.release_tag }}
+    steps:
+      - name: Download the signed DMGs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wiser-macos-*-signed
+          path: signed
+          merge-multiple: true
+
+      - name: Attach them to the release
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          assets=(signed/WISER-*-macos-*.dmg)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "::error::No signed DMGs were produced."
+            exit 1
+          fi
+          printf '%s\n' "${assets[@]}"
+          gh release upload "${TAG}" "${assets[@]}" --clobber -R "${REPO}"
+          echo "Attached ${#assets[@]} signed DMG(s) to ${TAG}."

--- a/Makefile
+++ b/Makefile
@@ -54,20 +54,15 @@ build-mac : generated
 	./check_arch.sh
 
 
+# Sign, notarize, staple, and package the locally built app. The same script runs in CI
+# (.github/workflows/sign-macos.yml), so both paths produce identical artifacts.
+# AD_CODESIGN_KEY_NAME lives in Secret.sh, which is sourced into the environment here.
 dist-mac : build-mac
-	# Codesign the built application
-	bash install-mac/sign_wiser.sh
-
-	# Generate a .dmg file containing the Mac application.
-	hdiutil create dist/tmp.dmg -ov -volname "$(APP_NAME)" -fs HFS+ \
-		-srcfolder dist/$(APP_NAME).app
-	hdiutil convert dist/tmp.dmg -format UDZO \
-		-o dist/$(APP_NAME)-$(APP_VERSION)-macos-$(MAC_ARCH).dmg
-	rm dist/tmp.dmg
-
-	# Submit the disk image to Apple for notarization
-	xcrun notarytool submit dist/$(APP_NAME)-$(APP_VERSION)-macos-$(MAC_ARCH).dmg \
-		--apple-id $(AD_USERNAME) --team-id $(AD_TEAM_ID) --password $(AD_PASSWORD)
+	@set -a; . ./Secret.sh; set +a; \
+	python src/devtools/sign_mac.py --app-path dist/$(APP_NAME).app \
+		--app-name "$(APP_NAME)" --app-version "$(APP_VERSION)" --arch "$(MAC_ARCH)" \
+		--apple-id "$(AD_USERNAME)" --team-id "$(AD_TEAM_ID)" \
+		--app-password "$(AD_PASSWORD)" --notarize
 
 build-win : generated
 	@set WISER_ENV=prod && pyinstaller WISER.spec
@@ -118,7 +113,8 @@ sign-mac:
 	@echo "Apple ID: $(AD_USERNAME)"
 	@echo "Team ID: $(AD_TEAM_ID)"
 	@echo "App Name: $(APP_NAME)"
-	@python src/devtools/sign_mac.py --link "$(LINK)" --app-version "$(APP_VERSION)" \
+	@set -a; . ./Secret.sh; set +a; \
+	python src/devtools/sign_mac.py --link "$(LINK)" --app-version "$(APP_VERSION)" \
 			--apple-id "$(AD_USERNAME)" --team-id "$(AD_TEAM_ID)" \
 			--app-password "$(AD_PASSWORD)" --app-name "$(APP_NAME)" \
 			--artifact-name "$(MAC_DIST_GITHUB_NAME)" --notarize \
@@ -144,4 +140,4 @@ backup-releases:
 		$(if $(TAG),--tag "$(TAG)",) $(if $(ALL),--all,) \
 		$(if $(FORCE),--force,) $(if $(DRY_RUN),--dry-run,)
 
-.PHONY: generated lint typecheck build-mac build-win clean sign-windows backup-releases
+.PHONY: generated lint typecheck build-mac build-win clean sign-mac sign-windows backup-releases

--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,15 @@ build-mac : generated
 
 # Sign, notarize, staple, and package the locally built app. The same script runs in CI
 # (.github/workflows/sign-macos.yml), so both paths produce identical artifacts.
-# AD_CODESIGN_KEY_NAME lives in Secret.sh, which is sourced into the environment here.
+# Both secret files are sourced into the environment rather than expanded into the recipe;
+# sign_mac.py reads the credentials from there, so none of them reach process arguments.
 dist-mac : build-mac
-	@set -a; . ./Secret.sh; set +a; \
+	@set -a; \
+	[ -f ./Secret.sh ] && . ./Secret.sh; \
+	[ -f ./Secret.mk ] && . ./Secret.mk; \
+	set +a; \
 	python src/devtools/sign_mac.py --app-path dist/$(APP_NAME).app \
-		--app-name "$(APP_NAME)" --app-version "$(APP_VERSION)" --arch "$(MAC_ARCH)" \
-		--apple-id "$(AD_USERNAME)" --team-id "$(AD_TEAM_ID)" \
-		--app-password "$(AD_PASSWORD)" --notarize
+		--app-name "$(APP_NAME)" --app-version "$(APP_VERSION)" --arch "$(MAC_ARCH)" --notarize
 
 build-win : generated
 	@set WISER_ENV=prod && pyinstaller WISER.spec
@@ -113,10 +115,12 @@ sign-mac:
 	@echo "Apple ID: $(AD_USERNAME)"
 	@echo "Team ID: $(AD_TEAM_ID)"
 	@echo "App Name: $(APP_NAME)"
-	@set -a; . ./Secret.sh; set +a; \
+	@set -a; \
+	[ -f ./Secret.sh ] && . ./Secret.sh; \
+	[ -f ./Secret.mk ] && . ./Secret.mk; \
+	set +a; \
 	python src/devtools/sign_mac.py --link "$(LINK)" --app-version "$(APP_VERSION)" \
-			--apple-id "$(AD_USERNAME)" --team-id "$(AD_TEAM_ID)" \
-			--app-password "$(AD_PASSWORD)" --app-name "$(APP_NAME)" \
+			--app-name "$(APP_NAME)" \
 			--artifact-name "$(MAC_DIST_GITHUB_NAME)" --notarize \
 			$(if $(RELEASE_TAG),--release-tag "$(RELEASE_TAG)",)
 

--- a/doc/codesign-mac.md
+++ b/doc/codesign-mac.md
@@ -11,6 +11,26 @@ by Apple.  This is a daunting hurdle to overcome, but it is surmountable.
 This document describes how to code-sign and notarize an application for
 MacOSX, using the WISER application as an example.
 
+## The full sequence
+
+Three separate operations are needed, in this order, and all three are required before a
+downloaded WISER opens without a Gatekeeper prompt:
+
+1.  **Code-sign** the `.app` with the Developer ID Application certificate (`codesign`).
+2.  **Notarize** it — upload to Apple's malware scan, which returns a ticket
+    (`xcrun notarytool`).
+3.  **Staple** the ticket to the artifact so Gatekeeper can validate it *offline*
+    (`xcrun stapler`).
+
+The `.app` must be stapled **before** the DMG is built, because an app sitting on a
+read-only disk image cannot be stapled afterwards. The DMG is then signed, notarized and
+stapled in turn. `src/devtools/sign_mac.py` performs the whole sequence:
+
+    sign .app -> notarize -> staple .app -> build DMG -> sign DMG -> notarize -> staple DMG -> verify
+
+The rest of this document explains each operation. To actually run it, use the GitHub
+Action (below) or `make sign-mac`; the sections after that cover what those do.
+
 ## Code-signing by Identified Developers
 
 In order to code-sign an application, one must have an Identified Developer
@@ -154,6 +174,58 @@ Here are descriptions of the relevant arguments `codesign`:
     In particular, see the bug-report linked from the `entitlements.plist`
     file above.
 
+
+## Signing in GitHub Actions
+
+Releases are signed by the **Sign macOS release assets** workflow
+(`.github/workflows/sign-macos.yml`) rather than from a laptop.  Dispatch it with the run
+ID of a completed "Build and Smoke Test WISER" run, and optionally a release tag:
+
+- `run_id` — the build run whose macOS artifact should be signed.
+- `arch` — `both` (default), `arm64`, or `x64`.
+- `release_tag` — when set, the signed DMG is attached to that release.  Leave it empty to
+  produce a workflow artifact only.
+
+The workflow refuses to sign a run that did not conclude successfully, and — when a tag is
+given — refuses when the tag does not point at the commit that was built.  It checks the
+repository out at the build commit, so `version.py` names the DMG for the artifact being
+signed rather than for whatever `main` has since moved on to.
+
+It runs the same `src/devtools/sign_mac.py` as `make sign-mac`, so the local and CI paths
+cannot drift.
+
+### Required configuration
+
+The signing job runs in a **`release` environment**.  Configure that environment with a
+required reviewer: the certificate is unreachable until a maintainer approves the
+deployment, which is what keeps a private key in GitHub acceptable.
+
+Environment secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `MACOS_CERT_P12_BASE64` | Developer ID Application certificate + key, as base64 of a `.p12` |
+| `MACOS_CERT_PASSWORD` | Password protecting that `.p12` |
+| `NOTARY_KEY_P8_BASE64` | App Store Connect API key, as base64 of the `.p8` (preferred) |
+| `NOTARY_KEY_ID` | Key ID for that API key |
+| `NOTARY_ISSUER_ID` | Issuer ID; omit for an individual (non-team) key |
+| `AD_USERNAME`, `AD_TEAM_ID`, `AD_PASSWORD` | Apple ID fallback, used when no API key is set |
+
+Export the `.p12` from Keychain Access (right-click the certificate, Export), then:
+
+```
+base64 -i Certificates.p12 | pbcopy
+```
+
+The signing identity is **not** configured anywhere: the job reads it back out of the
+keychain it imports, and fails if that keychain does not contain exactly one code-signing
+identity.  A re-issued certificate therefore needs no workflow change.
+
+An App Store Connect API key is preferred over the Apple ID credentials because it is
+scoped to the team rather than to one person's login and 2FA, and can be revoked on its
+own.  The workflow uses the API key when `NOTARY_KEY_P8_BASE64` is set and falls back to
+the Apple ID otherwise.
+
 ## Building a Disk Image (.dmg) File
 
 It is of value to build a distributable `.dmg` file from the application,
@@ -274,22 +346,42 @@ xcrun notarytool log <request-id>
  --apple-id=<secret> --team-id=<secret> --password=<secret>
 ```
 
-## Final Steps??
+## Stapling the Ticket
 
-Guess what?  If you you got to this point, you're done!
+Notarization records the result on Apple's servers; it does not change the file you
+uploaded.  Left there, Gatekeeper has to contact Apple over the network the first time a
+user launches the app.  That fails for a user who is offline or behind a captive portal,
+which is a realistic situation for the classroom and field machines WISER runs on.
 
-You might expect that the notarized version of the app needs to be downloaded
-from somewhere, but it actually doesn't work that way.  When you notarize
-a macOS application for distribution, Apple simply records key details about
-the code-signed app and its packaging, and it scans the app's binaries for
-known malware.
+`stapler` attaches the notarization ticket to the artifact itself, so Gatekeeper can
+validate it with no network at all:
 
-Later, when users try to run your application, the Gatekeeper subsystem on
-their computer will talk to the Apple servers, to check this information
-recorded during notarization.
+```
+xcrun stapler staple dist/WISER.app
+xcrun stapler validate dist/WISER.app
+```
 
-Thus, you are now ready to distribute your code-signed `.dmg` file to your
-users!
+Staple the `.app` **before** building the DMG.  Once the app is inside a read-only disk
+image it can no longer be modified, so an app stapled only at the DMG level ships without
+a ticket of its own and phones home on first launch.  Staple the DMG too, after its own
+notarization, so the disk image validates offline as well.
+
+## Verifying the Result
+
+```
+codesign --verify --strict --deep --verbose=2 dist/WISER.app
+xcrun stapler validate dist/WISER.app
+xcrun stapler validate dist/WISER-<version>-macos-<arch>.dmg
+spctl --assess --type exec --verbose=4 dist/WISER.app
+```
+
+The `spctl` assessment is the one that reflects what an end user actually sees; it should
+report `source=Notarized Developer ID`.  **It is only meaningful when Gatekeeper
+assessments are enabled** — on a machine where `spctl --status` says `assessments
+disabled`, `spctl` reports "accepted" for anything, including an unsigned binary.  Check
+`spctl --status` first, and re-enable with `sudo spctl --master-enable` when testing.
+`sign_mac.py` makes this an error rather than a false pass when run with
+`--require-gatekeeper` (as CI does).
 
 ### Testing
 

--- a/doc/codesign-mac.md
+++ b/doc/codesign-mac.md
@@ -226,6 +226,13 @@ scoped to the team rather than to one person's login and 2FA, and can be revoked
 own.  The workflow uses the API key when `NOTARY_KEY_P8_BASE64` is set and falls back to
 the Apple ID otherwise.
 
+It also keeps the credential out of process arguments.  `notarytool` accepts an
+app-specific password only as `--password`, or through a keychain profile that
+`store-credentials` populates the same way, so on the Apple ID path the password is
+visible in `ps` for the duration of the submission.  An API key is passed as a *file
+path*, and the Key ID and Issuer ID are identifiers rather than secrets, so nothing
+sensitive appears in the command line.
+
 ## Building a Disk Image (.dmg) File
 
 It is of value to build a distributable `.dmg` file from the application,

--- a/install-mac/sign_wiser.sh
+++ b/install-mac/sign_wiser.sh
@@ -1,43 +1,56 @@
 #!/usr/bin/env bash
-# Sign every executable object in dist/${APP_NAME}.app
+# Sign every executable object in a WISER .app bundle.
+#
+# Usage: sign_wiser.sh [path/to/WISER.app]
+#
+# The signing identity comes from $AD_CODESIGN_KEY_NAME. When that is unset, Secret.sh is
+# sourced for it (the local developer path); CI sets the variable directly.
 set -euo pipefail
 
-APP_NAME="WISER"
-APP_VERSION="$(python src/wiser/version.py)"
+APP="${1:-dist/WISER.app}"
 
-# load secrets
-source "$(dirname "${BASH_SOURCE[0]}")/../Secret.sh"
+if [ -z "${AD_CODESIGN_KEY_NAME:-}" ]; then
+  SECRETS="$(dirname "${BASH_SOURCE[0]}")/../Secret.sh"
+  if [ ! -f "$SECRETS" ]; then
+    echo "ERROR: AD_CODESIGN_KEY_NAME is unset and $SECRETS does not exist." >&2
+    exit 1
+  fi
+  # shellcheck disable=SC1090
+  source "$SECRETS"
+fi
 
-echo "Signing $APP_VERSION with key $AD_CODESIGN_KEY_NAME"
+if [ -z "${AD_CODESIGN_KEY_NAME:-}" ]; then
+  echo "ERROR: AD_CODESIGN_KEY_NAME is empty." >&2
+  exit 1
+fi
 
-# now you can reference $AD_CODESIGN_KEY_NAME, $AD_USERNAME, etc.
-echo "-- Signing with key: $AD_CODESIGN_KEY_NAME"
+if [ ! -d "$APP" ]; then
+  echo "ERROR: No app bundle at $APP" >&2
+  exit 1
+fi
 
-APP="dist/${APP_NAME}.app"
 IDENT="${AD_CODESIGN_KEY_NAME}"
-ENTITLEMENTS="install-mac/entitlements.plist"
+ENTITLEMENTS="$(dirname "${BASH_SOURCE[0]}")/entitlements.plist"
 
-echo "▶︎ Signing leaf binaries (dylib, so, exec)…"
+echo "Signing $APP with identity: $IDENT"
+
+echo "-- Signing leaf binaries (dylib, so, exec)..."
 find "$APP/Contents" -type f -print0 | xargs -0 file | grep 'Mach-O' | cut -d: -f1 |
 while read -r BIN; do
-  if file "$BIN" | grep -q 'Mach-O'; then
-    codesign --force --options runtime --timestamp \
-             --sign "$IDENT" "$BIN"
-  fi
+  codesign --force --options runtime --timestamp --sign "$IDENT" "$BIN"
 done
 
-echo "▶︎ Signing nested bundles (Frameworks, plug-ins)…"
+echo "-- Signing nested bundles (Frameworks, plug-ins)..."
 find "$APP/Contents" -type d \( -name '*.framework' -o -name '*.bundle' \) |
 while read -r BND; do
-  codesign --force --options runtime --timestamp \
-           --sign "$IDENT" "$BND"
+  codesign --force --options runtime --timestamp --sign "$IDENT" "$BND"
 done
 
-echo "▶︎ Signing top-level app…"
+echo "-- Signing top-level app..."
 codesign --force --options runtime --timestamp \
          --entitlements "$ENTITLEMENTS" \
          --sign "$IDENT" "$APP"
 
-echo "▶︎ Verifying…"
+echo "-- Verifying..."
 codesign --verify --strict --deep --verbose=2 "$APP"
-echo "✅  All done"
+echo "Signed: $APP"

--- a/src/devtools/sign_mac.py
+++ b/src/devtools/sign_mac.py
@@ -91,6 +91,7 @@ def acquire_from_run(link: str, root: Path, dist_name: str, artifact_name: str, 
     """Download the build artifact for a run and unpack the app bundle from it."""
     ensure_tool("gh", "Install: https://cli.github.com/")
     ensure_tool("tar")
+    ensure_tool("shasum")
 
     dist_dir = root / dist_name
     if dist_dir.exists():
@@ -310,6 +311,10 @@ def main():
 
     ensure_tool("hdiutil")
     ensure_tool("xcrun")
+    ensure_tool("codesign")
+    if args.notarize:
+        ensure_tool("ditto")
+        ensure_tool("spctl")
 
     root = Path(args.root).resolve()
 

--- a/src/devtools/sign_mac.py
+++ b/src/devtools/sign_mac.py
@@ -1,11 +1,27 @@
+"""Code-sign, notarize, staple, and package the WISER macOS application.
+
+The app bundle is either downloaded from a GitHub Actions build run (``--link``) or taken
+from disk (``--app-path``, used by CI, where the build already produced it). Everything
+after that is the same code path for both callers.
+
+The sequence follows Apple's recommended order for Developer ID distribution:
+
+    sign the .app -> notarize it -> staple the ticket to the .app -> build the DMG from the
+    stapled app -> sign the DMG -> notarize it -> staple the ticket to the DMG -> verify
+
+Stapling the .app before the DMG is built is what lets a user who drags WISER into
+/Applications launch it with no network round trip to Apple.
+"""
+
 import argparse
+import json
 import os
 import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Sequence
 
 RUN_URL_RE = re.compile(
     r"""
@@ -23,24 +39,32 @@ def die(msg: str, code: int = 1):
     sys.exit(code)
 
 
-def run(cmd, **kwargs):
-    print("+", " ".join(str(c) for c in cmd))
+def run(cmd, redact: Sequence[str] = (), capture: bool = False, **kwargs):
+    shown = []
+    for part in cmd:
+        part = str(part)
+        for secret in redact:
+            if secret:
+                part = part.replace(secret, "***")
+        shown.append(part)
+    print("+", " ".join(shown))
     try:
-        subprocess.run(cmd, check=True, text=True, **kwargs)
+        proc = subprocess.run(
+            cmd,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE if capture else None,
+            **kwargs,
+        )
     except subprocess.CalledProcessError as e:
-        print("❌ Command failed:", " ".join(str(c) for c in cmd), file=sys.stderr)
+        print("Command failed:", " ".join(shown), file=sys.stderr)
         print("Exit code:", e.returncode, file=sys.stderr)
         raise
-
-
-def which(name: str) -> Optional[str]:
-    from shutil import which as _which
-
-    return _which(name)
+    return proc.stdout if capture else None
 
 
 def ensure_tool(name: str, hint: str = ""):
-    if which(name) is None:
+    if shutil.which(name) is None:
         die(f"Required tool '{name}' not found in PATH. {hint}")
 
 
@@ -51,16 +75,7 @@ def parse_run_url(url: str):
     return m.group("owner"), m.group("repo"), m.group("run_id")
 
 
-def prepare_dist(root: Path, dist_name: str) -> Path:
-    dist_dir = root / dist_name
-    if dist_dir.exists():
-        shutil.rmtree(dist_dir)
-    dist_dir.mkdir(parents=True, exist_ok=True)
-    return dist_dir
-
-
 def find_app_bundle(dist_dir: Path, app_name: str) -> Path:
-    # Prefer the expected name; otherwise fall back to first *.app under dist
     expected = dist_dir / f"{app_name}.app"
     if expected.exists():
         return expected
@@ -68,75 +83,23 @@ def find_app_bundle(dist_dir: Path, app_name: str) -> Path:
     if not candidates:
         die(f"No .app bundle found in {dist_dir}. Expected '{app_name}.app'.")
     if len(candidates) > 1:
-        print("WARNING: multiple .app bundles found; using:", candidates[0], file=sys.stderr)
+        die(f"Multiple .app bundles found in {dist_dir}: {[str(c) for c in candidates]}")
     return candidates[0]
 
 
-def parse_args():
-    p = argparse.ArgumentParser(description="Download GH Actions artifact and package WISER for macOS.")
-    p.add_argument("--link", required=True, help="GitHub Actions run URL")
-    p.add_argument("--root", default=".", help="Project root (default: current dir)")
-    p.add_argument("--dist-name", default="dist", help='Dist folder name under root (default: "dist")')
-    p.add_argument("--artifact-name", default="wiser-macOS-X64", help="Artifact name in the run to download")
-    p.add_argument(
-        "--app-name",
-        default=os.environ.get("APP_NAME", "WISER"),
-        help='App bundle base name (default: "WISER")',
-    )
-    p.add_argument(
-        "--app-version", default=os.environ.get("APP_VERSION"), help="Version string for DMG filename"
-    )
-    p.add_argument(
-        "--arch",
-        default=None,
-        choices=["x64", "arm64"],
-        help="Target arch for the DMG filename (default: inferred from --artifact-name)",
-    )
-    p.add_argument(
-        "--sign-script",
-        default=os.path.join(os.path.dirname(__file__), "..", "..", "install-mac", "sign_wiser.sh"),
-        help="Codesign script to run (bash)",
-    )
-    p.add_argument("--notarize", action="store_true", help="Submit DMG to Apple notarization with notarytool")
-    p.add_argument("--apple-id", default=os.environ.get("AD_USERNAME"), help="Apple ID (or set AD_USERNAME)")
-    p.add_argument(
-        "--team-id", default=os.environ.get("AD_TEAM_ID"), help="Apple Team ID (or set AD_TEAM_ID)"
-    )
-    p.add_argument(
-        "--app-password",
-        default=os.environ.get("AD_PASSWORD"),
-        help="App-specific password (or set AD_PASSWORD)",
-    )
-    p.add_argument("--notary-wait", action="store_true", help="Pass --wait to notarytool submit")
-    p.add_argument(
-        "--release-tag",
-        default=None,
-        help="If set, upload the finished DMG to this GitHub release tag (gh release upload --clobber)",
-    )
-    return p.parse_args()
-
-
-def main():
-    args = parse_args()
-
-    if args.release_tag and not args.app_version:
-        die("--release-tag requires --app-version so the uploaded DMG carries the version.")
-
-    root = Path(args.root).resolve()
-    dist_dir = prepare_dist(root, args.dist_name)
-
-    # Tools
+def acquire_from_run(link: str, root: Path, dist_name: str, artifact_name: str, app_name: str) -> Path:
+    """Download the build artifact for a run and unpack the app bundle from it."""
     ensure_tool("gh", "Install: https://cli.github.com/")
-    ensure_tool("tar")  # for getting WISER.app out of tar ball
-    ensure_tool("hdiutil")
-    ensure_tool("xcrun")  # for notarytool
+    ensure_tool("tar")
 
-    owner, repo, run_id = parse_run_url(args.link)
-    print(f"Repo: {owner}/{repo}  Run ID: {run_id}")
-    print(f"Artifact: {args.artifact_name}")
-    print(f"Dist dir: {dist_dir}")
+    dist_dir = root / dist_name
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+    dist_dir.mkdir(parents=True, exist_ok=True)
 
-    # Download artifact into dist/
+    owner, repo, run_id = parse_run_url(link)
+    print(f"Repo: {owner}/{repo}  Run ID: {run_id}  Artifact: {artifact_name}")
+
     run(
         [
             "gh",
@@ -146,123 +109,265 @@ def main():
             "-R",
             f"{owner}/{repo}",
             "-n",
-            args.artifact_name,
+            artifact_name,
             "--dir",
             str(dist_dir),
         ]
     )
 
-    # Make sure the download WISER.app.tgz is correct
-    tar_sha_path = os.path.join(dist_dir, "WISER.app.tgz.sha256")
-    run(["shasum", "-a", "256", "-c", tar_sha_path])
+    # The checksum file records the path as dist/WISER.app.tgz, so verify from the root.
+    run(["shasum", "-a", "256", "-c", str(dist_dir / "WISER.app.tgz.sha256")], cwd=str(root))
+    # tar rather than unzip: it preserves the symlinks and modes inside the bundle.
+    run(["tar", "-C", str(dist_dir), "-xzf", str(dist_dir / "WISER.app.tgz")])
 
-    # Extract the app from the tar (we need to use tar to perserve symlinks)
-    tar_path = os.path.join(dist_dir, "WISER.app.tgz")
+    return find_app_bundle(dist_dir, app_name)
+
+
+def notary_flags(args) -> tuple[list[str], list[str]]:
+    """Return (notarytool credential flags, secret strings to redact from logs)."""
+    if args.notary_key:
+        key = Path(args.notary_key).resolve()
+        if not key.exists():
+            die(f"App Store Connect API key not found: {key}")
+        if not args.notary_key_id:
+            die("--notary-key requires --notary-key-id (or NOTARY_KEY_ID).")
+        flags = ["--key", str(key), "--key-id", args.notary_key_id]
+        # An individual key inherits the caller's role and carries no issuer.
+        if args.notary_issuer:
+            flags += ["--issuer", args.notary_issuer]
+        return flags, [args.notary_key_id, args.notary_issuer or ""]
+
+    if args.apple_id and args.team_id and args.app_password:
+        return (
+            ["--apple-id", args.apple_id, "--team-id", args.team_id, "--password", args.app_password],
+            [args.app_password],
+        )
+
+    die(
+        "Notarization requires either an App Store Connect API key "
+        "(--notary-key/--notary-key-id, env NOTARY_KEY_PATH/NOTARY_KEY_ID) or an Apple ID "
+        "(--apple-id/--team-id/--app-password, env AD_USERNAME/AD_TEAM_ID/AD_PASSWORD)."
+    )
+
+
+def notarize(target: Path, flags: list[str], secrets: list[str]):
+    """Submit to Apple and wait. Raises unless the submission is Accepted."""
+    out = run(
+        ["xcrun", "notarytool", "submit", str(target), *flags, "--wait", "--output-format", "json"],
+        redact=secrets,
+        capture=True,
+    )
+    try:
+        result = json.loads(out)
+    except json.JSONDecodeError:
+        die(f"notarytool returned output that is not JSON:\n{out}")
+
+    status = result.get("status")
+    submission_id = result.get("id")
+    print(f"Notarization {submission_id}: {status}")
+    if status != "Accepted":
+        if submission_id:
+            # Printed directly so the credential flags never reach the log.
+            subprocess.run(["xcrun", "notarytool", "log", submission_id, *flags], text=True)
+        die(f"Notarization of {target.name} was not accepted (status: {status}).")
+
+
+def staple(target: Path):
+    run(["xcrun", "stapler", "staple", str(target)])
+    run(["xcrun", "stapler", "validate", str(target)])
+
+
+def build_dmg(app: Path, dmg: Path, volname: str):
+    tmp_dmg = dmg.with_name("tmp.dmg")
+    run(
+        ["hdiutil", "create", str(tmp_dmg), "-ov", "-volname", volname, "-fs", "HFS+", "-srcfolder", str(app)]
+    )
+    if dmg.exists():
+        dmg.unlink()
+    run(["hdiutil", "convert", str(tmp_dmg), "-format", "UDZO", "-o", str(dmg)])
+    tmp_dmg.unlink(missing_ok=True)
+
+
+def assess_gatekeeper(app: Path, dmg: Path, require: bool):
+    """Run the end-user Gatekeeper assessment, which needs assessments to be enabled.
+
+    On a machine with `spctl --status` disabled the assessment reports "accepted" for
+    anything, so a pass there means nothing. CI passes require=True to make that a hard
+    failure rather than a false green.
+    """
+    status = subprocess.run(["spctl", "--status"], text=True, capture_output=True).stdout
+    if "assessments enabled" not in status:
+        msg = (
+            "Gatekeeper assessments are disabled on this machine, so the end-user "
+            "Gatekeeper check cannot be performed (spctl would report 'accepted' for "
+            "anything). Re-enable with: sudo spctl --master-enable"
+        )
+        if require:
+            die(msg)
+        print(f"WARNING: {msg}", file=sys.stderr)
+        print("The signature and stapled tickets were still verified directly.", file=sys.stderr)
+        return
+
+    run(["spctl", "--assess", "--type", "exec", "--verbose=4", str(app)])
     run(
         [
-            "tar",
-            "-C",
-            str(dist_dir),
-            "-xzf",
-            tar_path,
+            "spctl",
+            "--assess",
+            "--type",
+            "open",
+            "--context",
+            "context:primary-signature",
+            "--verbose=4",
+            str(dmg),
         ]
     )
 
-    # Locate app bundle
-    app_bundle = find_app_bundle(dist_dir, args.app_name)
-    print(f"App bundle: {app_bundle}")
 
-    # Codesign via your script
-    sign_script = (root / args.sign_script).resolve()
+def parse_args():
+    p = argparse.ArgumentParser(description="Code-sign, notarize, staple, and package WISER for macOS.")
+
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--link", help="GitHub Actions run URL to download the build artifact from")
+    src.add_argument("--app-path", help="Path to an already-built .app bundle to sign")
+
+    p.add_argument("--root", default=".", help="Project root (default: current dir)")
+    p.add_argument("--dist-name", default="dist", help='Dist folder name under root (default: "dist")')
+    p.add_argument("--artifact-name", default="wiser-macOS-X64", help="Artifact name in the run to download")
+    p.add_argument(
+        "--app-name",
+        default=os.environ.get("APP_NAME", "WISER"),
+        help='App bundle base name (default: "WISER")',
+    )
+    p.add_argument(
+        "--app-version", default=os.environ.get("APP_VERSION"), help="Version string for the DMG filename"
+    )
+    p.add_argument(
+        "--arch",
+        default=None,
+        choices=["x64", "arm64"],
+        help="Target arch for the DMG filename (default: inferred from --artifact-name)",
+    )
+    p.add_argument(
+        "--identity",
+        default=os.environ.get("AD_CODESIGN_KEY_NAME"),
+        help="Code-signing identity (or set AD_CODESIGN_KEY_NAME)",
+    )
+    p.add_argument(
+        "--sign-script",
+        default=os.path.join(os.path.dirname(__file__), "..", "..", "install-mac", "sign_wiser.sh"),
+        help="Codesign script to run (bash)",
+    )
+
+    p.add_argument("--notarize", action="store_true", help="Notarize and staple with notarytool")
+    p.add_argument(
+        "--notary-key",
+        default=os.environ.get("NOTARY_KEY_PATH"),
+        help="App Store Connect API key .p8 (or set NOTARY_KEY_PATH)",
+    )
+    p.add_argument(
+        "--notary-key-id",
+        default=os.environ.get("NOTARY_KEY_ID"),
+        help="App Store Connect Key ID (or set NOTARY_KEY_ID)",
+    )
+    p.add_argument(
+        "--notary-issuer",
+        default=os.environ.get("NOTARY_ISSUER_ID"),
+        help="App Store Connect Issuer ID; omit for an individual key (or set NOTARY_ISSUER_ID)",
+    )
+    p.add_argument("--apple-id", default=os.environ.get("AD_USERNAME"), help="Apple ID (or set AD_USERNAME)")
+    p.add_argument(
+        "--team-id", default=os.environ.get("AD_TEAM_ID"), help="Apple Team ID (or set AD_TEAM_ID)"
+    )
+    p.add_argument(
+        "--app-password",
+        default=os.environ.get("AD_PASSWORD"),
+        help="App-specific password (or set AD_PASSWORD)",
+    )
+
+    p.add_argument(
+        "--require-gatekeeper",
+        action="store_true",
+        help="Fail if Gatekeeper assessments are disabled instead of warning",
+    )
+    p.add_argument(
+        "--release-tag", default=None, help="If set, upload the finished DMG to this GitHub release tag"
+    )
+    p.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY"),
+        help="owner/repo for --release-tag (default: inferred from --link)",
+    )
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if args.release_tag and not args.app_version:
+        die("--release-tag requires --app-version so the uploaded DMG carries the version.")
+    if not args.identity:
+        die("No code-signing identity. Pass --identity or set AD_CODESIGN_KEY_NAME.")
+
+    ensure_tool("hdiutil")
+    ensure_tool("xcrun")
+
+    root = Path(args.root).resolve()
+
+    if args.link:
+        app = acquire_from_run(args.link, root, args.dist_name, args.artifact_name, args.app_name)
+        owner, repo, _ = parse_run_url(args.link)
+        repo_slug = args.repo or f"{owner}/{repo}"
+    else:
+        app = Path(args.app_path).resolve()
+        if not app.is_dir():
+            die(f"No app bundle at {app}")
+        repo_slug = args.repo
+    print(f"App bundle: {app}")
+
+    flags, secrets = notary_flags(args) if args.notarize else ([], [])
+
+    sign_script = Path(args.sign_script).resolve()
     if not sign_script.exists():
         die(f"Sign script not found: {sign_script}")
-    # Ensure executable bit (safe no-op if already set)
-    try:
-        mode = sign_script.stat().st_mode
-        sign_script.chmod(mode | 0o111)
-    except Exception:
-        pass
+    env = {**os.environ, "AD_CODESIGN_KEY_NAME": args.identity}
+    run(["bash", str(sign_script), str(app)], cwd=str(root), env=env)
 
-    # Many sign scripts expect to be run from repo root
-    run(["bash", str(sign_script), str(app_bundle)], cwd=str(root))
-
-    # Create DMG (tmp then convert to compressed UDZO)
-    tmp_dmg = dist_dir / "tmp.dmg"
-    arch = args.arch or ("arm64" if "ARM64" in args.artifact_name.upper() else "x64")
-    if args.app_version:
-        final_name = f"{args.app_name}-{args.app_version}-macos-{arch}.dmg"
-    else:
-        final_name = f"{args.app_name}-macos-{arch}.dmg"
-    final_dmg = dist_dir / final_name
-
-    # hdiutil create
-    run(
-        [
-            "hdiutil",
-            "create",
-            str(tmp_dmg),
-            "-ov",
-            "-volname",
-            args.app_name,
-            "-fs",
-            "HFS+",
-            "-srcfolder",
-            str(app_bundle),
-        ]
-    )
-
-    # hdiutil convert --> UDZO
-    run(["hdiutil", "convert", str(tmp_dmg), "-format", "UDZO", "-o", str(final_dmg)])
-
-    # remove tmp dmg
-    try:
-        tmp_dmg.unlink(missing_ok=True)  # py3.8+: ok to keep try/except
-    except TypeError:
-        if tmp_dmg.exists():
-            tmp_dmg.unlink()
-
-    print(f"DMG created: {final_dmg}")
-
-    # Notarization (optional)
     if args.notarize:
-        if not (args.apple_id and args.team_id and args.app_password):
-            die(
-                "Notarization requested but --apple-id/--team-id/"
-                "--app-password not provided (or env AD_USERNAME/"
-                "AD_TEAM_ID/AD_PASSWORD)."
-            )
-        notary_cmd = [
-            "xcrun",
-            "notarytool",
-            "submit",
-            str(final_dmg),
-            "--apple-id",
-            args.apple_id,
-            "--team-id",
-            args.team_id,
-            "--password",
-            args.app_password,
-        ]
-        if args.notary_wait:
-            notary_cmd.append("--wait")
-        run(notary_cmd)
+        # notarytool cannot take a bare bundle; ditto preserves the symlinks codesign needs.
+        app_zip = app.with_suffix(".app.zip")
+        app_zip.unlink(missing_ok=True)
+        run(["ditto", "-c", "-k", "--keepParent", str(app), str(app_zip)])
+        notarize(app_zip, flags, secrets)
+        app_zip.unlink(missing_ok=True)
+        staple(app)
+
+    arch = args.arch or ("arm64" if "ARM64" in args.artifact_name.upper() else "x64")
+    stem = f"{args.app_name}-{args.app_version}" if args.app_version else args.app_name
+    dmg = app.parent / f"{stem}-macos-{arch}.dmg"
+    build_dmg(app, dmg, args.app_name)
+
+    run(["codesign", "--force", "--timestamp", "--sign", args.identity, str(dmg)])
+
+    if args.notarize:
+        notarize(dmg, flags, secrets)
+        staple(dmg)
+
+    print("-- Verifying the finished artifacts...")
+    run(["codesign", "--verify", "--strict", "--deep", "--verbose=2", str(app)])
+    run(["codesign", "--verify", "--verbose=2", str(dmg)])
+    if args.notarize:
+        run(["xcrun", "stapler", "validate", str(app)])
+        run(["xcrun", "stapler", "validate", str(dmg)])
+        assess_gatekeeper(app, dmg, args.require_gatekeeper)
+
+    print(f"DMG ready: {dmg}")
 
     if args.release_tag:
-        run(
-            [
-                "gh",
-                "release",
-                "upload",
-                args.release_tag,
-                str(final_dmg),
-                "-R",
-                f"{owner}/{repo}",
-                "--clobber",
-            ]
-        )
-        print(f"Uploaded {final_dmg.name} to release {args.release_tag}")
-
-    print("Done. Artifact downloaded, app signed, DMG built" + (" and notarized." if args.notarize else "."))
+        if not repo_slug:
+            die("--release-tag needs --repo (or GITHUB_REPOSITORY) when signing from --app-path.")
+        ensure_tool("gh", "Install: https://cli.github.com/")
+        run(["gh", "release", "upload", args.release_tag, str(dmg), "-R", repo_slug, "--clobber"])
+        print(f"Uploaded {dmg.name} to release {args.release_tag}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this change do?

Moves macOS release signing off a developer laptop and into a dispatchable GitHub Action,
and corrects the signing sequence itself while that code is being rewritten.

Dispatch **Sign macOS release assets** with the run ID of a completed "Build and Smoke Test
WISER" run, and it produces DMGs that are signed, notarized, stapled, and verified under
the CU Boulder Developer ID, optionally attaching them to a release tag.

## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Hot Fix
- [ ] Build
- [x] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

(Also a documentation update — `doc/codesign-mac.md` is substantially rewritten.)

## Why is this change needed?

Associated issue: **#769** (macOS half; the Windows half stays open).

Every release currently pays the cost of signing by hand from one machine. Beyond the
inconvenience, validating the CU certificate end to end surfaced five defects in that
path, all of which live in the code this PR rewrites:

1. **The `.app` never got a stapled notarization ticket.** The old flow notarized only the
   DMG, and an app sitting on a read-only disk image cannot be stapled afterwards. Once a
   user drags WISER to /Applications it carries no ticket, so Gatekeeper must reach Apple
   on first launch — which fails offline or behind a captive portal. There was no
   `xcrun stapler` call anywhere in the repository, so **every WISER release to date has
   shipped this way.** This is the most plausible explanation for the classroom macOS
   install failures in #646.
2. **The DMG was not code-signed at all** (`codesign -dv` reported "code object is not
   signed at all").
3. **`make sign-mac` could mislabel the DMG.** The version came from `version.py` in the
   working tree rather than from the artifact being signed, so signing an older build run
   from a moved-on `main` produced a DMG named for the wrong version — and with
   `RELEASE_TAG` set, uploaded it straight to a release.
4. **`sign_mac.py` could not read `Secret.mk`,** so running it directly failed at the
   notarize step with the credentials sitting in the file.
5. **`sign_wiser.sh` ignored its `$1` argument** and always signed `dist/WISER.app`, so it
   could silently sign a stale or wrong-architecture bundle.

## How did you implement the change?

**One shared code path.** `src/devtools/sign_mac.py` is restructured so acquisition is
either `--link` (download from a build run, the local path) or `--app-path` (the app is
already on disk, the CI path); everything after that is identical for both callers. The
Makefile targets call the same script, so local and CI cannot drift.

**The corrected sequence,** which is what fixes defects 1 and 2:

```
sign .app -> notarize -> staple .app -> build DMG -> sign DMG -> notarize -> staple DMG -> verify
```

**Guards, rather than conventions.** The workflow resolves the build run's head SHA,
refuses a run that did not conclude successfully, refuses when a supplied tag points at a
different commit than was built, and checks the repository out *at the build commit* so
`version.py` names the DMG for the artifact being signed — defect 3 becomes structurally
impossible rather than a thing to remember.

**Notarization** accepts an App Store Connect API key or Apple ID credentials, preferring
the key when present, so the team key can drop in later with no workflow change. It waits,
parses the JSON status, and fails on anything but `Accepted`, dumping Apple's notary log
first. Credentials are redacted from every echoed command so they cannot reach a CI log.

**Key handling.** The signing job runs in a `release` environment gated on a required
reviewer, holds `contents: read`, and a separate job does the release upload — the job with
the private key never has write access. The signing identity is read back out of the
imported keychain rather than configured anywhere, and the job fails unless exactly one
identity is present, so a re-issued certificate needs no edit.

## Added tests?
- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

There is no test suite for `src/devtools/`, and the meaningful behaviour here is an
interaction with `codesign`, `notarytool`, and Apple's servers. It was validated directly
instead, against a purpose-built throwaway bundle rather than a real build:

- Full non-notarizing path passes end to end; `codesign -dv` on the resulting DMG now shows
  the chain to Apple Root CA, where it previously reported "not signed at all".
- Credential handling refuses empty, partial, and key-without-key-id inputs rather than
  proceeding; the app-specific password is confirmed redacted from echoed commands.
- The Gatekeeper check refuses to report a pass on a machine with assessments disabled,
  instead of falsely green-lighting.

## Added to documentation?
- [x] yes
- [ ] no documentation needed

`doc/codesign-mac.md` gains a sequence overview, a CI section covering the environment and
secrets, and a correction: the old "Final Steps??" section stated you were done after
notarizing, which is precisely the misconception that produced the unstapled app.

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [ ] All CI checks passed

CI unchecked only because it has not run yet at the time of opening.

## Desktop Screenshots/Recordings

Not applicable — no UI change.

## [optional] Are there any post-merge tasks we need to perform?

The workflow cannot run until these exist; none are things a PR can carry:

1. Create a **`release` environment** with a required reviewer.
2. Add the environment secrets: `MACOS_CERT_P12_BASE64`, `MACOS_CERT_PASSWORD`, and either
   `NOTARY_KEY_P8_BASE64` / `NOTARY_KEY_ID` / `NOTARY_ISSUER_ID` or `AD_USERNAME` /
   `AD_TEAM_ID` / `AD_PASSWORD`. They must be *environment* secrets — repository secrets
   would bypass the approval gate.
3. Take one run end to end with `release_tag` left empty, and verify the DMG on a Mac where
   Gatekeeper assessments are actually enabled.

**One known risk for the first run:** the final verification step passes
`--require-gatekeeper`, and I could not confirm in advance whether GitHub's macOS runners
have `spctl` assessments enabled. If they do not, that step fails with a clear message. The
DMG is still correctly signed and stapled in that case, since `codesign --verify` and
`stapler validate` run before it — the remedy is to drop that one flag.

**Not covered here:** Windows signing (still YubiKey-bound; #769 stays open for it) and the
tag-triggered release workflow that would build and sign in one shot. This workflow already
exposes `workflow_call` so it can be reused there.
