### PR TITLE
fix: Store cache entries on a miss so the render and computation caches serve hits

### DIFF
--- a/doc/sphinx-general-wiser-docs/source/developer-content/data-caching.md
+++ b/doc/sphinx-general-wiser-docs/source/developer-content/data-caching.md
@@ -4,8 +4,8 @@ Rendering a raster is expensive: reading and normalizing bands, applying
 stretches, and packing pixels all cost real time, and the same work is requested
 repeatedly as the user scrolls, switches panes, or reopens dialogs. WISER avoids
 recomputation with a three-tier in-memory cache. This page documents what each
-tier stores, how keys and eviction work, the cache lifecycle, and a known issue
-to be aware of.
+tier stores, how keys and eviction work, the cache lifecycle, and how storing on
+a miss keeps the running size and eviction in step.
 
 This is the caching half of the [Rendering Pipeline](rendering-pipeline.md).
 
@@ -186,33 +186,26 @@ flowchart TD
 
 ---
 
-## Known Issue: `Cache.add_cache_item` Guard
+## Storing on a Miss
 
-```{warning}
-The base `Cache.add_cache_item`
-(`src/wiser/raster/data_cache.py`) currently guards its insert
-with `if key in self._cache:` and returns `False` otherwise:
+`Cache.add_cache_item` stores the entry whether or not the key is already
+present. That is what lets the render and computation caches serve hits at all:
+callers only reach it *after* a lookup missed, so the key is never already there
+and an insert-only-if-present guard would drop every new entry.
 
-​```python
-def add_cache_item(self, key, value) -> bool:
-    if key in self._cache:        # <-- only updates EXISTING keys
-        ...
-        self._cache[key] = value
-        self._size += value.nbytes
-        return True
-    return False                  # <-- a brand-new key is never stored
-​```
+Two details keep `_size` honest, and eviction with it:
 
-Callers add an item only **after** a cache miss (`in_cache(key)` returned
-`False`), so the key is never already present — which means new entries are
-never stored. As written, the **render cache and computation cache do not
-actually serve hits**: every render recomputes from scratch. The condition is
-almost certainly meant to be `if key not in self._cache:`.
+- **A replacement subtracts before it adds.** Re-storing a key that is already
+  in the cache gives back the old value's `nbytes` before adding the new
+  value's, so an overwritten key is counted once rather than twice. The
+  refreshed entry moves to the back of the `OrderedDict`, so FIFO eviction
+  treats it as the newest item rather than the oldest.
+- **Eviction runs after the insert.** `_evict()` is called once the new item is
+  in and `_size` includes it, so the loop frees enough room for the incoming
+  value instead of measuring a size that does not yet count it. A value larger
+  than the entire capacity is refused up front — `add_cache_item` returns
+  `False` and nothing is evicted on its behalf.
 
-`HistogramCache` overrides `add_cache_item` *without* this guard, so the
-histogram cache works as intended.
-
-This page documents the *intended* design (the caches are meant to store on
-miss and serve on subsequent requests). The note is here so readers aren't
-misled by the current code; fixing the guard is a separate change.
-```
+`src/tests/test_data_cache.py` covers the miss/store/hit cycle for the render
+and computation caches, the size arithmetic across replacement and removal, and
+FIFO eviction at capacity.

--- a/src/tests/test_data_cache.py
+++ b/src/tests/test_data_cache.py
@@ -1,0 +1,239 @@
+"""Unit tests for the three-tier in-memory cache in ``wiser.raster.data_cache`` (#772).
+
+Small NumPy arrays only -- no widget, no ``QApplication``, no GDAL. These cover the
+contract every caller of the render and computation caches relies on: a miss followed
+by ``add_cache_item`` stores the entry, the next equivalent request hits, and the
+running byte count stays in step with what is actually held so that eviction keeps the
+cache inside its capacity.
+"""
+import unittest
+
+import numpy as np
+import pytest
+
+import tests.context  # noqa: F401 -- adds src/ to sys.path
+
+from wiser.raster.data_cache import (
+    Cache,
+    ComputationCache,
+    DataCache,
+    HistogramCache,
+    RenderCache,
+)
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.unit,
+    pytest.mark.regression,
+]
+
+# The caches only need the "dataset" to be hashable, so a sentinel string stands in for
+# a RasterDataSet throughout and keeps these tests free of GDAL.
+_DATASET = "dataset-a"
+_OTHER_DATASET = "dataset-b"
+
+
+def _array(n_bytes: int) -> np.ndarray:
+    """
+    Returns a float64 array occupying exactly n_bytes bytes.
+
+    Args:
+        n_bytes (int): The size of the array in bytes; must be a multiple of 8.
+    """
+    assert n_bytes % 8 == 0, "float64 arrays are sized in multiples of 8 bytes"
+    return np.arange(n_bytes // 8, dtype=np.float64)
+
+
+class TestAddCacheItemStoresNewKeys(unittest.TestCase):
+    """A miss followed by an add must be served from the cache next time."""
+
+    def test_computation_cache_serves_a_hit_after_a_miss(self) -> None:
+        cache = ComputationCache()
+        key = cache.get_cache_key(_DATASET, band_index=3, normalized=True)
+        arr = _array(800)
+
+        # The sequence every read path in dataset.py follows: look up, read on a
+        # miss, then store what was read.
+        self.assertFalse(cache.in_cache(key))
+        self.assertIsNone(cache.get_cache_item(key))
+        self.assertTrue(cache.add_cache_item(key, arr))
+
+        self.assertTrue(cache.in_cache(key))
+        np.testing.assert_array_equal(cache.get_cache_item(key), arr)
+
+    def test_render_cache_serves_a_hit_after_a_miss(self) -> None:
+        cache = RenderCache()
+        key = cache.get_cache_key(_DATASET, (0, 1, 2), ("linear",), None)
+        img = _array(1600)
+
+        self.assertTrue(cache.add_cache_item(key, img))
+        np.testing.assert_array_equal(cache.get_cache_item(key), img)
+
+    def test_distinct_keys_are_kept_side_by_side(self) -> None:
+        cache = ComputationCache()
+        first_key = cache.get_cache_key(_DATASET, band_index=0, normalized=False)
+        second_key = cache.get_cache_key(_DATASET, band_index=1, normalized=False)
+        normalized_key = cache.get_cache_key(_DATASET, band_index=0, normalized=True)
+        first, second, normalized = _array(80), _array(160), _array(240)
+
+        cache.add_cache_item(first_key, first)
+        cache.add_cache_item(second_key, second)
+        cache.add_cache_item(normalized_key, normalized)
+
+        np.testing.assert_array_equal(cache.get_cache_item(first_key), first)
+        np.testing.assert_array_equal(cache.get_cache_item(second_key), second)
+        np.testing.assert_array_equal(cache.get_cache_item(normalized_key), normalized)
+
+    def test_masked_arrays_round_trip(self) -> None:
+        # get_image_data() masks the data-ignore value before storing, so the
+        # computation cache holds masked arrays as well as plain ones.
+        cache = ComputationCache()
+        key = cache.get_cache_key(_DATASET)
+        masked = np.ma.masked_values(np.array([1.0, -9999.0, 3.0]), -9999.0)
+
+        self.assertTrue(cache.add_cache_item(key, masked))
+
+        cached = cache.get_cache_item(key)
+        self.assertIsInstance(cached, np.ma.MaskedArray)
+        np.testing.assert_array_equal(cached.mask, masked.mask)
+
+
+class TestSizeAccounting(unittest.TestCase):
+    """_size must equal the bytes actually held, including across replacements."""
+
+    def test_size_follows_the_stored_arrays(self) -> None:
+        cache = ComputationCache()
+        first, second = _array(800), _array(1600)
+
+        cache.add_cache_item(cache.get_cache_key(_DATASET, band_index=0), first)
+        self.assertEqual(cache._size, first.nbytes)
+        cache.add_cache_item(cache.get_cache_key(_DATASET, band_index=1), second)
+        self.assertEqual(cache._size, first.nbytes + second.nbytes)
+
+    def test_replacing_a_key_does_not_double_count(self) -> None:
+        cache = ComputationCache()
+        key = cache.get_cache_key(_DATASET, band_index=0)
+        original, replacement = _array(800), _array(2400)
+
+        cache.add_cache_item(key, original)
+        self.assertTrue(cache.add_cache_item(key, replacement))
+
+        self.assertEqual(len(cache._cache), 1)
+        self.assertEqual(cache._size, replacement.nbytes)
+        np.testing.assert_array_equal(cache.get_cache_item(key), replacement)
+
+    def test_remove_cache_item_gives_back_its_bytes(self) -> None:
+        cache = ComputationCache()
+        key = cache.get_cache_key(_DATASET, band_index=0)
+
+        cache.add_cache_item(key, _array(800))
+        cache.remove_cache_item(key)
+
+        self.assertEqual(cache._size, 0)
+        self.assertIsNone(cache.get_cache_item(key))
+
+    def test_clear_keys_from_partial_drops_only_that_dataset(self) -> None:
+        cache = ComputationCache()
+        keep = cache.get_cache_key(_OTHER_DATASET, band_index=0)
+        drop_first = cache.get_cache_key(_DATASET, band_index=0)
+        drop_second = cache.get_cache_key(_DATASET, band_index=1)
+        kept_array = _array(800)
+
+        cache.add_cache_item(keep, kept_array)
+        cache.add_cache_item(drop_first, _array(800))
+        cache.add_cache_item(drop_second, _array(1600))
+
+        cache.clear_keys_from_partial(cache.get_partial_key(_DATASET))
+
+        self.assertIsNone(cache.get_cache_item(drop_first))
+        self.assertIsNone(cache.get_cache_item(drop_second))
+        np.testing.assert_array_equal(cache.get_cache_item(keep), kept_array)
+        self.assertEqual(cache._size, kept_array.nbytes)
+
+    def test_clear_cache_empties_a_populated_cache(self) -> None:
+        cache = ComputationCache()
+        for band in range(3):
+            cache.add_cache_item(cache.get_cache_key(_DATASET, band_index=band), _array(800))
+        self.assertEqual(len(cache._cache), 3)
+
+        cache.clear_cache()
+
+        self.assertEqual(len(cache._cache), 0)
+        self.assertEqual(cache._size, 0)
+
+
+class TestCapacityAndEviction(unittest.TestCase):
+    """Now that entries are stored, capacity is what keeps the caches off the heap."""
+
+    def test_an_entry_larger_than_capacity_is_refused(self) -> None:
+        cache = Cache(capacity=800)
+
+        self.assertFalse(cache.add_cache_item(1, _array(1600)))
+        self.assertEqual(len(cache._cache), 0)
+        self.assertEqual(cache._size, 0)
+
+    def test_eviction_keeps_the_cache_within_capacity(self) -> None:
+        cache = ComputationCache(capacity=2400)
+
+        for band in range(4):
+            cache.add_cache_item(cache.get_cache_key(_DATASET, band_index=band), _array(800))
+            self.assertLessEqual(cache._size, cache._capacity)
+
+        self.assertEqual(cache._size, sum(value.nbytes for value in cache._cache.values()))
+
+    def test_eviction_takes_the_oldest_entry_first(self) -> None:
+        cache = ComputationCache(capacity=2400)
+        keys = [cache.get_cache_key(_DATASET, band_index=band) for band in range(4)]
+
+        for key in keys:
+            cache.add_cache_item(key, _array(800))
+
+        oldest, rest = keys[0], keys[1:]
+        self.assertIsNone(cache.get_cache_item(oldest))
+        for key in rest:
+            self.assertIsNotNone(cache.get_cache_item(key))
+
+    def test_a_replacement_does_not_evict_an_unrelated_entry(self) -> None:
+        # Re-storing a key with a same-sized array must not push the running size
+        # over capacity and cost the cache an entry it should have kept.
+        cache = ComputationCache(capacity=1600)
+        first = cache.get_cache_key(_DATASET, band_index=0)
+        second = cache.get_cache_key(_DATASET, band_index=1)
+        cache.add_cache_item(first, _array(800))
+        cache.add_cache_item(second, _array(800))
+
+        cache.add_cache_item(second, _array(800))
+
+        self.assertIsNotNone(cache.get_cache_item(first))
+        self.assertIsNotNone(cache.get_cache_item(second))
+        self.assertEqual(cache._size, 1600)
+
+
+class TestHistogramCacheUnaffected(unittest.TestCase):
+    """HistogramCache already stored on a miss; it must keep doing so."""
+
+    def test_bins_and_edges_round_trip(self) -> None:
+        cache = HistogramCache()
+        key = cache.get_cache_key(_DATASET, 0, "linear", "none", 0.0, 1.0)
+        bins, edges = _array(800), _array(808)
+
+        cache.add_cache_item(key, (bins, edges))
+
+        cached_bins, cached_edges = cache.get_cache_item(key)
+        np.testing.assert_array_equal(cached_bins, bins)
+        np.testing.assert_array_equal(cached_edges, edges)
+        self.assertEqual(cache._size, bins.nbytes + edges.nbytes)
+
+
+class TestDataCacheTiers(unittest.TestCase):
+    def test_each_tier_is_its_own_cache(self) -> None:
+        data_cache = DataCache()
+
+        self.assertIsInstance(data_cache.get_render_cache(), RenderCache)
+        self.assertIsInstance(data_cache.get_computation_cache(), ComputationCache)
+        self.assertIsInstance(data_cache.get_histogram_cache(), HistogramCache)
+        self.assertIsNot(data_cache.get_render_cache(), data_cache.get_computation_cache())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/wiser/raster/data_cache.py
+++ b/src/wiser/raster/data_cache.py
@@ -46,7 +46,7 @@ class Cache:
         Raises:
             AssertionError: If the cache size does not reduce to zero after clearing.
         """
-        for key in self._cache:
+        for key in list(self._cache):
             self._size -= self._cache[key].nbytes
             del self._cache[key]
         assert np.isclose(self._size, 0.0)
@@ -66,24 +66,35 @@ class Cache:
         """
         Adds a new item to the cache. Evicts existing items if necessary to maintain capacity.
 
+        The item is stored whether or not the key is already present, because callers
+        add an item only after a lookup missed -- a new key must be inserted, not
+        skipped.
+
         Args:
             key (int): The key associated with the value.
             value (Union[np.ndarray, np.ma.masked_array]): The data to be cached.
 
         Returns:
-            bool: True if the item was added to the cache, False if it was not.
+            bool: True if the item was added to the cache, False if it was not
+                (which happens when the value on its own is larger than the capacity).
         """
+        data_size = value.nbytes
+        if data_size > self._capacity:
+            logger.debug(f"Size of data exceeds cache size: {data_size} > {self._capacity}")
+            return False
         if key in self._cache:
-            data_size = value.nbytes
-            if data_size > self._capacity:
-                logger.debug(f"Size of data exceeds cache size: {data_size} > {self._capacity}")
-                return False
-            if self._size + data_size > self._capacity:
-                self._evict()
-            self._cache[key] = value
-            self._size += value.nbytes
-            return True
-        return False
+            # Replacing an entry: give back the old value's bytes before adding the
+            # new value's, otherwise the key is counted twice in the running size.
+            # Deleting and re-inserting also moves the refreshed entry to the back of
+            # the OrderedDict, so FIFO eviction treats it as the newest item.
+            self._size -= self._cache[key].nbytes
+            del self._cache[key]
+        self._cache[key] = value
+        self._size += data_size
+        # Evict once the new item is in and counted, so the loop frees enough room
+        # for it. The item just added is the newest, so the older entries go first.
+        self._evict()
+        return True
 
     def get_cache_key(self, *args):
         """


### PR DESCRIPTION
This PR proposes fixing `Cache.add_cache_item` so that a miss actually stores its entry, which is what the render and computation caches need before they can serve a hit at all (Fixes #772). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/454. You can sign in with your GitHub ID to claim ownership of the project.

## What is broken

`Cache.add_cache_item` guards its insert with `if key in self._cache:` and returns `False` otherwise, so a key that is not already present is never stored. Every caller reaches it only *after* a lookup missed — `get_band_data`, `get_band_data_normalized`, `get_image_data` and `get_image_data_subset` in `src/wiser/raster/dataset.py`, and `RasterView.update_display_image` in `src/wiser/gui/rasterview.py`, all follow `get_cache_item()` → `if arr is None:` → read → `add_cache_item()`. The key is therefore never already there, and the render and computation tiers stay empty for the life of the process. `HistogramCache` overrides `add_cache_item` without the guard, which is why the histogram tier is unaffected.

Reproduced on `main` at `d0b14c4b`, loading one of the repo's own test datasets through `RasterDataLoader` with a `DataCache` attached and calling `get_band_data_normalized(0)` 51 times:

```
[file] test_utils/test_datasets/caltech_4_100_150_nm
[file] first read        : 2360 us
[file] repeat read (avg) : 1228 us over 50 calls
[file] computation cache : 0 entries, 0 bytes
[cube] shape (16, 700, 700) float32
[cube] repeat read (avg) : 177 us over 50 calls
[cube] computation cache : 0 entries, 0 bytes
```

Nothing is held, so every one of those reads goes back to GDAL and re-normalizes — the work `_data_cache` exists to absorb on the rendering hot path.

## The change

`src/wiser/raster/data_cache.py`, all inside the base `Cache`:

- The capacity check moves up front and the insert becomes unconditional, so a miss stores its entry.
- A replacement gives back the old value's `nbytes` before adding the new value's, so `_size` counts an overwritten key once rather than twice. Deleting before re-inserting also moves the refreshed entry to the back of the `OrderedDict`, so FIFO eviction treats it as the newest item rather than the oldest.
- `_evict()` now runs *after* the insert, once `_size` includes the new item, so it frees enough room for the value being added. With the old ordering the loop compared a size that did not yet count the incoming array and could leave the cache above its capacity — which never showed up because nothing was ever stored. These are 10 GB tiers of raster arrays, so that mattered as soon as the insert started working.
- `clear_cache()` needed one more line to survive the fix: it deleted from the `OrderedDict` it was iterating, which was harmless only while the cache was always empty. On a populated cache it raises `RuntimeError: OrderedDict mutated during iteration`, so it now iterates a snapshot of the keys.

`HistogramCache.clear_cache` has the same iterate-and-delete shape and is reachable today, since that tier already stores. I left it out to keep this to the one defect — happy to send it separately if you want it.

The developer docs carried this as a known issue, so `doc/.../developer-content/data-caching.md` swaps that warning for a short description of the store-on-miss behaviour and the size accounting that goes with it.

## Verification

Same measurement on the patched tree, unchanged script:

```
[file] test_utils/test_datasets/caltech_4_100_150_nm
[file] first read        : 1961 us
[file] repeat read (avg) : 1 us over 50 calls
[file] computation cache : 1 entries, 90000 bytes
[cube] shape (16, 700, 700) float32
[cube] repeat read (avg) : 1 us over 50 calls
[cube] computation cache : 1 entries, 1960000 bytes
```

`src/tests/test_data_cache.py` is new and covers the miss/store/hit cycle for both tiers, masked arrays from the data-ignore path, the size arithmetic across replacement, removal and `clear_keys_from_partial`, and FIFO eviction at capacity. Ten of its fifteen cases fail against unmodified `main` and all fifteen pass with the change; the five that pass either way are the controls — an over-capacity value is still refused, and `HistogramCache` still round-trips its `(bins, edges)` tuple.

```
$ cd src/tests && pytest test_data_cache.py -q          # on unmodified main
10 failed, 5 passed in 3.40s
$ cd src/tests && pytest test_data_cache.py -q          # with this change
15 passed in 3.10s
```

The rest of the suite was run the way `dev-CI.yml` runs it — under `xvfb-run -a --server-args="-screen 0 1280x1024x24 -ac -nolisten tcp"`, in the `linux-cached-dev` environment built from `etc/dev-conda-lock.yml` — and is entirely green with this change: 890 passed, 5 skipped, no failures and no errors across all 91 existing files in `src/tests`. `ruff format --check .` reports 300 files already formatted and `ruff check .` is clean, both on `ruff==0.1.15` as CI pins it.

## How this was managed

This work was tracked on a board imported from this repository's issues and pull requests, on the story for this defect: https://eastagiletracker.com/projects/454/stories/400865 — the board itself is at https://eastagiletracker.com/projects/454, holding 605 stories brought over from your issues, pull requests and milestones.

![board](https://raw.githubusercontent.com/eastagiletracker/WISER/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
