### PR TITLE
fix: pick the netCDF wavelength array that matches the band count

### DIFF
--- a/src/tests/test_raster_utils.py
+++ b/src/tests/test_raster_utils.py
@@ -1,7 +1,12 @@
+import os
+import shutil
+import tempfile
 import unittest
 
 import tests.context
 from wiser.raster import utils
+
+import netCDF4 as nc
 
 import numpy as np
 from astropy import units as u
@@ -236,3 +241,78 @@ class TestRasterUtils(unittest.TestCase):
         self.assertAlmostEqual(out[2], 0.50)
         self.assertAlmostEqual(out[3], 1.00)
         self.assertAlmostEqual(out[4], 1.50)
+
+
+class TestNetCDFBandCountSelection(unittest.TestCase):
+    """Selecting the wavelength array that belongs to the variable being opened.
+
+    A netCDF product may carry several wavelength arrays describing different
+    variables.  PACE OCI L2 is the case that motivated this:  a 286-value array
+    for the instrument sits at the root, and the 172-value array describing the
+    hyperspectral ``Rrs`` cube sits in a sub-group.  Taking the first candidate
+    in declaration order returns the instrument array, whose length then fails
+    the caller's band-count check, and the cube loses its spectral axis with no
+    error reported.
+    """
+
+    def _write_two_arrays(self, path):
+        """A file whose first-declared wavelength array is the wrong length."""
+        with nc.Dataset(path, "w") as ds:
+            ds.createDimension("instrument_bands", 5)
+            ds.createDimension("cube_bands", 3)
+
+            instrument = ds.createVariable("wavelength", "f4", ("instrument_bands",))
+            instrument.units = "nm"
+            instrument[:] = [400.0, 500.0, 600.0, 700.0, 800.0]
+            instrument_mask = ds.createVariable("good_wavelengths", "i1", ("instrument_bands",))
+            instrument_mask[:] = [1, 1, 1, 1, 1]
+
+            group = ds.createGroup("sensor_band_parameters")
+            cube = group.createVariable("wavelength_3d", "f4", ("cube_bands",))
+            cube.units = "nm"
+            cube[:] = [450.0, 550.0, 650.0]
+            cube_mask = group.createVariable("good_wavelengths_3d", "i1", ("cube_bands",))
+            cube_mask[:] = [1, 0, 1]
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self.path = os.path.join(self._tmp, "two_arrays.nc")
+        self._write_two_arrays(self.path)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_wavelengths_prefers_the_array_matching_the_band_count(self):
+        with nc.Dataset(self.path) as ds:
+            wavelengths, unit = utils.extract_netcdf_wavelengths(ds, band_count=3)
+
+        self.assertEqual(len(wavelengths), 3)
+        np.testing.assert_allclose(wavelengths, [450.0, 550.0, 650.0])
+        self.assertEqual(unit, u.nanometer)
+
+    def test_wavelengths_without_a_band_count_take_declaration_order(self):
+        # The caller may not know the band count; behaviour is unchanged there.
+        with nc.Dataset(self.path) as ds:
+            wavelengths, _ = utils.extract_netcdf_wavelengths(ds)
+
+        self.assertEqual(len(wavelengths), 5)
+
+    def test_wavelengths_fall_back_when_no_array_matches(self):
+        # 7 matches neither array:  return the declaration-order candidate and
+        # leave the caller's own length check to reject it.
+        with nc.Dataset(self.path) as ds:
+            wavelengths, _ = utils.extract_netcdf_wavelengths(ds, band_count=7)
+
+        self.assertEqual(len(wavelengths), 5)
+
+    def test_bad_bands_prefer_the_mask_matching_the_band_count(self):
+        with nc.Dataset(self.path) as ds:
+            bad_bands = utils.extract_netcdf_bad_bands(ds, band_count=3)
+
+        self.assertEqual(bad_bands, [1, 0, 1])
+
+    def test_bad_bands_without_a_band_count_take_declaration_order(self):
+        with nc.Dataset(self.path) as ds:
+            bad_bands = utils.extract_netcdf_bad_bands(ds, band_count=None)
+
+        self.assertEqual(bad_bands, [1, 1, 1, 1, 1])

--- a/src/wiser/raster/dataset_impl.py
+++ b/src/wiser/raster/dataset_impl.py
@@ -1522,7 +1522,7 @@ class NetCDF_GDALRasterDataImpl(GDALRasterDataImpl):
                 srs = None
 
         # ---- Wavelengths and Units (searches all groups/subgroups at any depth)
-        wavelengths, wl_unit = extract_netcdf_wavelengths(netcdf_dataset)
+        wavelengths, wl_unit = extract_netcdf_wavelengths(netcdf_dataset, band_count=subdataset.RasterCount)
 
         # Validate wavelengths length — drop on mismatch
         if wavelengths is not None and subdataset.RasterCount != len(wavelengths):
@@ -1533,7 +1533,7 @@ class NetCDF_GDALRasterDataImpl(GDALRasterDataImpl):
             wl_unit = u.nanometer
 
         # ---- Good-wavelength mask (bad bands)
-        bad_bands = extract_netcdf_bad_bands(netcdf_dataset)
+        bad_bands = extract_netcdf_bad_bands(netcdf_dataset, band_count=subdataset.RasterCount)
         if bad_bands is not None and subdataset.RasterCount != len(bad_bands):
             bad_bands = None
 

--- a/src/wiser/raster/utils.py
+++ b/src/wiser/raster/utils.py
@@ -438,6 +438,7 @@ def _collect_wavelength_candidates(
 
 def extract_netcdf_wavelengths(
     netcdf_dataset,
+    band_count: Optional[int] = None,
 ) -> Tuple[Optional[np.ndarray], Optional[u.Unit]]:
     """Search a ``netCDF4.Dataset`` for wavelength data at any nesting depth.
 
@@ -449,8 +450,15 @@ def extract_netcdf_wavelengths(
 
     Selection
     ---------
-    1. Return the **first** candidate (in depth-first, declaration order) that
-       has **both** a 1-D numeric data array *and* a recognised unit.
+    0. When *band_count* is given and any candidate has exactly that many
+       values, only those candidates are considered.  A file may carry several
+       wavelength arrays describing different variables -- PACE OCI L2 ships a
+       286-value array for the instrument alongside a 172-value array for the
+       hyperspectral ``Rrs`` cube -- and only the one matching the variable
+       being opened describes its bands.
+    1. Return the **first** remaining candidate (in depth-first, declaration
+       order) that has **both** a 1-D numeric data array *and* a recognised
+       unit.
     2. If no candidate has both, return the first available data array paired
        with the first available unit — either may be ``None``.
 
@@ -463,6 +471,11 @@ def extract_netcdf_wavelengths(
 
     if not candidates:
         return None, None
+
+    if band_count is not None:
+        sized = [(data, unit) for data, unit in candidates if data is not None and len(data) == band_count]
+        if sized:
+            candidates = sized
 
     # Priority 1: first candidate with both data and unit
     for data, unit in candidates:
@@ -523,7 +536,7 @@ def _collect_good_wavelength_candidates(group) -> List[np.ndarray]:
     return candidates
 
 
-def extract_netcdf_bad_bands(netcdf_dataset) -> Optional[List[int]]:
+def extract_netcdf_bad_bands(netcdf_dataset, band_count: Optional[int] = None) -> Optional[List[int]]:
     """Search a ``netCDF4.Dataset`` for a good-wavelength mask at any depth.
 
     All groups and sub-groups are visited recursively.  Variable names are
@@ -534,12 +547,20 @@ def extract_netcdf_bad_bands(netcdf_dataset) -> Optional[List[int]]:
     element whose raw value equals the variable's ``_FillValue`` is treated as
     a bad band (set to ``0``).
 
+    When *band_count* is given and any candidate has exactly that many values,
+    only those candidates are considered, for the same reason as in
+    :func:`extract_netcdf_wavelengths`.
+
     The first matching array is returned as a :class:`numpy.ndarray` of
     ``numpy.bool_``.  Returns ``None`` if no matching variable is found.
     """
     candidates = _collect_good_wavelength_candidates(netcdf_dataset)
     if not candidates:
         return None
+    if band_count is not None:
+        sized = [c for c in candidates if len(c) == band_count]
+        if sized:
+            candidates = sized
     return [int(v) for v in candidates[0]]
 
 


### PR DESCRIPTION
## What does this change do?

When a netCDF file carries more than one wavelength array, WISER now picks the one
whose length matches the band count of the variable being opened, instead of the
first one in declaration order. The same selection is applied to the
`good_wavelengths` bad-band mask.

Fixes #783.

## What type of PR is this? (check all applicable)
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [ ] Hot Fix
- [ ] Build
- [ ] CI
- [ ] [Chore](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message?utm_source=chatgpt.com)
- [ ] Revert

## Why is this change needed?

`extract_netcdf_wavelengths` searches every group and sub-group and returns the
first candidate it finds. That is ambiguous in any product that describes more
than one variable.

PACE OCI L2 AOP is the case that surfaced it. The file holds a 286-value
`wavelength` array for the full instrument and a 172-value `wavelength_3d` array
in `sensor_band_parameters` describing the hyperspectral `Rrs` cube. Opening the
`Rrs` subdataset returns the 286-value array, `dataset_impl.py` then compares its
length against `RasterCount` (172), sees a mismatch, and drops the wavelengths
entirely. The cube opens with no spectral axis, so the spectrum plot has no x
values and every wavelength-based tool is unavailable, with nothing logged to say
why.

The band count is known at the call site, so it can disambiguate.

Full write-up in #783. Related to #139, which reports the broader "netCDF
wavelengths do not load" symptom across formats; this PR addresses one specific
mechanism behind it and does not close that issue.

## How did you implement the change?

`extract_netcdf_wavelengths` and `extract_netcdf_bad_bands` take an optional
`band_count`. When it is given and at least one candidate has exactly that many
values, only those candidates are considered; the existing priority rules then
run over that narrowed set. When nothing matches, or `band_count` is `None`, the
old declaration-order behaviour stands, so no existing caller changes.

`NetCDF_GDALRasterDataImpl` passes `subdataset.RasterCount` to both.

The caller's own length check is left in place. It is now a guard against a file
that genuinely has no correctly sized array, rather than the thing that silently
discarded a good array.

## Added tests?
- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

`TestNetCDFBandCountSelection` in `src/tests/test_raster_utils.py` writes a
temporary netCDF holding a 5-value root array and a 3-value sub-group array,
mirroring the PACE layout, and covers five cases: the matching array is chosen
for both wavelengths and the bad-band mask; declaration order is preserved when
no `band_count` is passed; and a `band_count` matching neither array falls back
to declaration order rather than returning nothing.

## Added to documentation?
- [ ] yes
- [x] no documentation needed

Both docstrings describe the new selection step.

## Checklist
- [x] There is an issue associated with this pull request
- [x] Code compiles/builds without errors
- [x] No new lint/style issues introduced
- [x] Branch is up-to-date with main/master
- [ ] All CI checks passed

## Desktop Screenshots/Recordings

n/a

## [optional] Are there any post-merge tasks we need to perform?

A second netCDF defect is still open and is not addressed here: WISER does not
apply the `scale_factor` / `add_offset` attributes, so PACE `Rrs` reads as raw
`int16` (for example -15036 where the physical value is 0.0199 sr^-1). That fix
touches the value-read path for every format and wants its own issue and PR.
